### PR TITLE
Remove broken and/or redundant logic from the `ModelInfo` object

### DIFF
--- a/capellambse/loader/modelinfo.py
+++ b/capellambse/loader/modelinfo.py
@@ -24,33 +24,3 @@ class ModelInfo:
     revision: str | None = None
     rev_hash: str | None = None
     capella_version: str | None = None
-
-    def __post_init__(self) -> None:
-        self.set_project_url()
-        self.version_url = self.derive_version_url()
-
-    def derive_version_url(self) -> str | None:
-        if self.url and self.rev_hash:
-            return "/".join(
-                (
-                    self.url,
-                    "-",
-                    "commit",
-                    self.rev_hash,
-                )
-            )
-        return None
-
-    def set_project_url(self) -> None:
-        """Set self.url to repository URL if the url is an HTTPS URL.
-        Otherweise set it to None.
-        """
-        if self.url:
-            if self.url.endswith(".git"):
-                self.url = self.url[: -len(".git")]
-
-            if not self.url.startswith("https://"):
-                self.url = None
-
-    def as_dict(self) -> dict[str, str | None]:
-        return dataclasses.asdict(self)

--- a/tests/test_model_layers.py
+++ b/tests/test_model_layers.py
@@ -26,11 +26,6 @@ def test_model_info_contains_capella_version(model: MelodyModel):
     assert hasattr(model.info, "capella_version")
 
 
-def test_model_info_dict_has_capella_version(model: MelodyModel):
-    model_info = model.info.as_dict()
-    assert model_info.get("capella_version") == "5.0.0"
-
-
 def test_loading_version_5_succeeds():
     MelodyModel(TEST_ROOT / "5_0" / "MelodyModelTest.aird")
 


### PR DESCRIPTION
The properties of the `ModelInfo` objects (available e.g. as `MelodyModel.info`) are broken:

* `derive_version_url()` assumes that `url` points to a project on a Gitlab instance. We cannot simply make that assumption, and it breaks in several supported cases:
  - Remote repos stored anywhere that's not a Gitlab instance will result in incorrect URLs.
  - Local `file://` repositories or ones accessed over `ssh://` would result in a path that does not exist (however, see the next point as well).
* `url` is set to `None` when it's not an `https://` URL. This also breaks several different use cases:
  - It prevents the `LocalFileHandler` from storing the `path` in that field, as it will never be an `https://` URL.
  - Other URLs (e.g. `git+ssh://`, `git+file://`) are not saved.
* `as_dict()` is simply a call to `dataclasses.asdict(self)`. This looks very redundant to me, and I don't see a use case for that method to begin with (considering that `dataclass` does not provide that by default, and instead refers to the module-level function).

Historic (non-published) blame brings up two relevant commits, `fed7d084628f0216b607f1760185cc8bc2d83e35` by @MoritzWeber0 (introducing the first two issues) and `09b8dc46360f24eb531d93516259edaa8d0a8121` by @ewuerger (introducing the third). Neither commit provides any explanation on why the methods were introduced in the first place (only that they were, but well, that's a start I guess), nor why they have their specific logic.

Therefore, with this PR I propose to remove the relevant methods altogether. If a future `FileHandler` subclass finds itself in a position where it can – without unreasonable assumptions – provide similar additional information, it should make a subclass of `ModelInfo` and return that instead of adding its specific logic onto a very generic class.