### PR TITLE
Release capellambse

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -53,8 +53,9 @@ jobs:
       - name: Build packages
         run: |-
           echo "Building '$GITHUB_REF'"
-          python -m pip install -U pip versioneer
-          python setup.py sdist bdist_wheel
+          python -m pip install -U pip build twine
+          python -m build
+          python -m twine check dist/*
       - name: Publish to PyPI (release only)
-        if: github.event.ref_type == 'tag' && matrix.python-version == '3.8'
-        run: poetry publish -u __token__ -p ${{ secrets.PYPI_TOKEN }}
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: python -m twine upload -u __token__ -p ${{ secrets.PYPI_TOKEN }} --non-interactive dist/*

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -58,6 +58,8 @@ jobs:
       - name: Build packages
         run: |-
           python -m build
+      - name: Verify packages
+        run: |-
           python -m twine check dist/*
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -31,18 +31,18 @@ jobs:
           restore-keys: |
             ${{runner.os}}-pip-
             ${{runner.os}}-
-      - name: Upgrade pip
+      - name: Upgrade Pip
         run: |-
           python -m pip install -U pip
       - name: Install test dependencies
         run: |-
-          python -m pip install pytest pytest-cov '.[test]'
+          python -m pip install '.[test]'
       - name: Run unit tests
         run: |-
           python -m pytest --cov-report=term --cov=capellambse --rootdir=.
 
   publish:
-    name: Publish artifacts to PyPI
+    name: Publish artifacts
     runs-on: ubuntu-latest
     needs: test
     steps:
@@ -59,6 +59,11 @@ jobs:
         run: |-
           python -m build
           python -m twine check dist/*
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Artifacts
+          path: 'dist/*'
       - name: Publish to PyPI (release only)
         if: startsWith(github.ref, 'refs/tags/v')
         run: python -m twine upload -u __token__ -p ${{ secrets.PYPI_TOKEN }} --non-interactive dist/*

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["*"]
     pull_request: [master]
-    tags: ["v*"]
+    tags: ["v*.*.*"]
 
 jobs:
   test:

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -33,7 +33,7 @@ jobs:
             ${{runner.os}}-
       - name: Upgrade pip
         run: |-
-          python -m pip install -U pip versioneer
+          python -m pip install -U pip
       - name: Install test dependencies
         run: |-
           python -m pip install pytest pytest-cov '.[test]'
@@ -50,10 +50,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.8"
+      - name: Install dependencies
+        run: |-
+          python -m pip install -U pip
+          python -m pip install build twine
       - name: Build packages
         run: |-
-          echo "Building '$GITHUB_REF'"
-          python -m pip install -U pip build twine
           python -m build
           python -m twine check dist/*
       - name: Publish to PyPI (release only)

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -42,6 +42,7 @@ jobs:
           python -m pytest --cov-report=term --cov=capellambse --rootdir=.
 
   publish:
+    name: Publish artifacts to PyPI
     runs-on: ubuntu-latest
     needs: test
     steps:

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -7,24 +7,6 @@ on:
     tags: ["v*"]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.8"
-      - name: Upgrade pip
-        run: |-
-          python -m pip install -U pip
-      - name: Build wheel package
-        run: |-
-          python -m pip wheel --no-deps .
-      - uses: actions/upload-artifact@v2
-        with:
-          name: Wheel package
-          path: '*.whl'
   test:
     name: Test with Python ${{matrix.python_version}} on ${{matrix.os}}
     runs-on: ${{matrix.os}}
@@ -51,10 +33,28 @@ jobs:
             ${{runner.os}}-
       - name: Upgrade pip
         run: |-
-          python -m pip install -U pip
+          python -m pip install -U pip versioneer
       - name: Install test dependencies
         run: |-
           python -m pip install pytest pytest-cov '.[test]'
       - name: Run unit tests
         run: |-
           python -m pytest --cov-report=term --cov=capellambse --rootdir=.
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Build packages
+        run: |-
+          echo "Building '$GITHUB_REF'"
+          python -m pip install -U pip versioneer
+          python setup.py sdist bdist_wheel
+      - name: Publish to PyPI (release only)
+        if: github.event.ref_type == 'tag' && matrix.python-version == '3.8'
+        run: poetry publish -u __token__ -p ${{ secrets.PYPI_TOKEN }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ test =
     mypy
     pylint
     pytest
+    pytest-cov
     types-docutils
     types-requests
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ classifiers =
 license = Apache
 description = Provides access to Capella MBSE projects in Python
 long_description = file: README.md
-long_description_content_type = text/x-markdown
+long_description_content_type = text/markdown
 keywords = arcadia, capella, mbse, model-based systems engineering
 platforms = any
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,8 @@ classifiers =
     Topic :: Software Development :: Libraries :: Python Modules
 license = Apache
 description = Provides access to Capella MBSE projects in Python
-long_description = file: README.rst
-long_description_content_type = text/x-rst
+long_description = file: README.md
+long_description_content_type = text/x-markdown
 keywords = arcadia, capella, mbse, model-based systems engineering
 platforms = any
 


### PR DESCRIPTION
Releases are published on PyPI: https://pypi.org/project/capellambse/

Releases are created with any tag that starts with `v`. E.g. `v0.1.0`, `v0.0.1a1`.

See https://github.com/DSD-DBS/py-capellambse/actions/runs/1435034047 for a successful build.

For a real release all tests should pass. I disabled the windows build for testing purposes.

NB. Do not depend on version 0.0.1a1: will be removed at some point.