### PR TITLE
Make GenericElement hashable

### DIFF
--- a/capellambse/model/common/element.py
+++ b/capellambse/model/common/element.py
@@ -203,6 +203,9 @@ class GenericElement:
             return NotImplemented
         return self._element is other._element
 
+    def __hash__(self):
+        return hash(self._element)
+
     def __repr__(self) -> str:  # pragma: no cover
         # pylint: disable=unidiomatic-typecheck
         if type(self) is GenericElement:


### PR DESCRIPTION
Having GenericElement as a hashable type (like `object`) allows us to work with sets of elements. We are not limited to using only lists.