### PR TITLE
Improve information

### DIFF
--- a/capellambse/model/crosslayer/__init__.py
+++ b/capellambse/model/crosslayer/__init__.py
@@ -37,11 +37,10 @@ class BaseArchitectureLayer(c.GenericElement):
         information.Union, deep=True, aslist=c.ElementList
     )
     all_enumerations = c.ProxyAccessor(
-        information.Enumeration, deep=True, aslist=c.ElementList
+        information.datatype.Enumeration, deep=True, aslist=c.ElementList
     )
     all_complex_values = c.ProxyAccessor(
-        information.ComplexValue,
-        "org.polarsys.capella.core.data.information.datavalue:ComplexValue",
+        information.datavalue.ComplexValue,
         deep=True,
         aslist=c.ElementList,
         follow_abstract=False,

--- a/capellambse/model/crosslayer/information/datatype.py
+++ b/capellambse/model/crosslayer/information/datatype.py
@@ -1,0 +1,42 @@
+# Copyright 2021 DB Netz AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from ... import common as c
+from . import datavalue
+
+
+@c.xtype_handler(None)
+class Enumeration(c.GenericElement):
+    """An Enumeration."""
+
+    _xmltag = "ownedDataTypes"
+
+    owned_literals = c.ProxyAccessor(
+        datavalue.EnumerationLiteral,
+        aslist=c.ElementList,
+        follow_abstract=False,
+    )
+
+    sub: c.Accessor
+    super: c.Accessor[Enumeration]
+
+    @property
+    def literals(self) -> c.ElementList[datavalue.EnumerationLiteral]:
+        """Return all owned and inherited literals."""
+        return (
+            self.owned_literals + self.super.literals
+            if isinstance(self.super, Enumeration)
+            else self.owned_literals
+        )

--- a/capellambse/model/crosslayer/information/datavalue.py
+++ b/capellambse/model/crosslayer/information/datavalue.py
@@ -1,0 +1,87 @@
+# Copyright 2021 DB Netz AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from capellambse.loader import xmltools
+
+from ... import common as c
+
+
+class LiteralValue(c.GenericElement):
+    is_abstract = xmltools.BooleanAttributeProperty(
+        "_element",
+        "abstract",
+        __doc__="Boolean flag, indicates if property is abstract",
+    )
+    value = xmltools.AttributeProperty(
+        "_element", "value", optional=True, returntype=str
+    )
+    type = c.AttrProxyAccessor(c.GenericElement, "abstractType")
+
+
+@c.xtype_handler(None)
+class LiteralNumericValue(LiteralValue):
+    value = xmltools.AttributeProperty(
+        "_element", "value", optional=True, returntype=float
+    )
+    unit = c.AttrProxyAccessor(c.GenericElement, "unit")
+
+
+@c.xtype_handler(None)
+class LiteralStringValue(LiteralValue):
+    """A Literal String Value"""
+
+
+@c.xtype_handler(None)
+class ValuePart(c.GenericElement):
+    """A Value Part of a Complex Value."""
+
+    _xmltag = "ownedParts"
+
+    referenced_property = c.AttrProxyAccessor(
+        c.GenericElement, "referencedProperty"
+    )
+    value = c.RoleTagAccessor("ownedValue")
+
+
+@c.xtype_handler(None)
+class ComplexValue(c.GenericElement):
+    """A Complex Value."""
+
+    _xmltag = "ownedDataValues"
+
+    type = c.AttrProxyAccessor(c.GenericElement, "abstractType")
+    value_parts = c.ProxyAccessor(ValuePart, aslist=c.ElementList)
+
+
+@c.xtype_handler(None)
+class EnumerationLiteral(c.GenericElement):
+    """An EnumerationLiteral (proxy link)."""
+
+    _xmltag = "ownedLiterals"
+
+    name = xmltools.AttributeProperty("_element", "name", returntype=str)
+
+    owner: c.Accessor
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, str):
+            return self.name == other
+        return super().__eq__(other)
+
+
+@c.xtype_handler(None)
+class EnumerationReference(c.GenericElement):
+    name = xmltools.AttributeProperty("_element", "name", returntype=str)
+    type = c.AttrProxyAccessor(c.GenericElement, "abstractType")
+    value = c.AttrProxyAccessor(c.GenericElement, "referencedValue")

--- a/capellambse/model/layers/oa.py
+++ b/capellambse/model/layers/oa.py
@@ -19,11 +19,16 @@ from __future__ import annotations
 
 import operator
 
-from capellambse.model.crosslayer import information
-
 from .. import common as c
 from .. import crosslayer, diagram
-from ..crosslayer import capellacommon, capellacore, cs, fa, interaction
+from ..crosslayer import (
+    capellacommon,
+    capellacore,
+    cs,
+    fa,
+    information,
+    interaction,
+)
 
 XT_ARCH = "org.polarsys.capella.core.data.oa:OperationalAnalysis"
 


### PR DESCRIPTION
I'm late to the party but I got some cake:

After seeing the progress of our information.py in the crosslayer module I felt the urge to improve its structure and style consistency compared to the other layer implementations where I took part in. So we(@Wuestengecko and I) added functionality to the https://github.com/DSD-DBS/py-capellambse/blob/e45a071649a6f9feba4765c35c5575aca8fa15a1/capellambse/model/common/__init__.py#L51-L59 function such that it is able to resolve nested package structure. Therefore the xtype strings are not needed anymore iff there are class definitions in the right module in line with the xtype-string from capella. For e.g.: `"org.polarsys.capella.core.data.{module}.{submodule}.{subsubmodule}.{...}.{clsname}" is getting resolved.

Additionally the metamodel was updated and now looks like:
![image](https://user-images.githubusercontent.com/50786483/149785058-22b4a89b-4bca-43e5-a8b7-43ac1acf7fa3.png)
