### PR TITLE
refactor: Use SPDX license header in source files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,13 @@ repos:
     hooks:
     - id: mypy
       additional_dependencies: [types-docutils==0.17.0, types-requests==2.25.11, sphinx]
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.1.13
+    hooks:
+      - id: insert-license
+        files: '.+/.+\.py$'
+        args:
+          - --license-filepath
+          - license_header.txt
+          - --comment-style
+          - '#'

--- a/capellambse/__init__.py
+++ b/capellambse/__init__.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """The Python capellambse package."""
 import platformdirs
 

--- a/capellambse/_namespaces.py
+++ b/capellambse/_namespaces.py
@@ -1,16 +1,5 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
 

--- a/capellambse/aird/__init__.py
+++ b/capellambse/aird/__init__.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """The AIRD parser and various other diagramming related tools.
 
 This module is used to enumerate, access and export the diagrams from

--- a/capellambse/aird/capstyle.py
+++ b/capellambse/aird/capstyle.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """The color palette and default style definitions used by Capella."""
 from __future__ import annotations
 

--- a/capellambse/aird/diagram.py
+++ b/capellambse/aird/diagram.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Classes that represent different aspects of a diagram."""
 from __future__ import annotations
 

--- a/capellambse/aird/json_enc.py
+++ b/capellambse/aird/json_enc.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """This module handles converting diagrams to the intermediary JSON format."""
 from __future__ import annotations
 

--- a/capellambse/aird/parser/__init__.py
+++ b/capellambse/aird/parser/__init__.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Functions for parsing and interacting with diagrams in a Capella model."""
 from __future__ import annotations
 

--- a/capellambse/aird/parser/_box_factories.py
+++ b/capellambse/aird/parser/_box_factories.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Factory functions for different types of Boxes."""
 from __future__ import annotations
 

--- a/capellambse/aird/parser/_common.py
+++ b/capellambse/aird/parser/_common.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Common constants and helpers used by all parser submodules."""
 from __future__ import annotations
 

--- a/capellambse/aird/parser/_edge_factories.py
+++ b/capellambse/aird/parser/_edge_factories.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Factory functions for Edges inside a diagram."""
 from __future__ import annotations
 

--- a/capellambse/aird/parser/_filters/__init__.py
+++ b/capellambse/aird/parser/_filters/__init__.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Functions implementing various filters that Capella supports."""
 from __future__ import annotations
 

--- a/capellambse/aird/parser/_filters/composite.py
+++ b/capellambse/aird/parser/_filters/composite.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Composite filter implementations."""
 from __future__ import annotations
 

--- a/capellambse/aird/parser/_filters/global.py
+++ b/capellambse/aird/parser/_filters/global.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Global filter implementations."""
 from __future__ import annotations
 

--- a/capellambse/aird/parser/_semantic.py
+++ b/capellambse/aird/parser/_semantic.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Parser entry point for semantic elements.
 
 Semantic elements have a ``<target>`` which references the represented

--- a/capellambse/aird/parser/_styling.py
+++ b/capellambse/aird/parser/_styling.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Functions that handle element styling."""
 from __future__ import annotations
 

--- a/capellambse/aird/parser/_visual.py
+++ b/capellambse/aird/parser/_visual.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Parser entry point for visual elements.
 
 Visual elements, contrary to semantic ones, do not exist in the melody

--- a/capellambse/aird/vector2d.py
+++ b/capellambse/aird/vector2d.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Two dimensional vector calculation utility."""
 # pylint: disable=unsubscriptable-object, not-an-iterable  # false-positives
 from __future__ import annotations

--- a/capellambse/extensions/__init__.py
+++ b/capellambse/extensions/__init__.py
@@ -1,13 +1,2 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0

--- a/capellambse/extensions/pvmt.py
+++ b/capellambse/extensions/pvmt.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Property Value Management extension for CapellaMBSE."""
 from __future__ import annotations
 

--- a/capellambse/extensions/reqif/__init__.py
+++ b/capellambse/extensions/reqif/__init__.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tools for handling ReqIF Requirements.
 
 .. diagram:: [CDB] Requirements ORM

--- a/capellambse/extensions/reqif/elements.py
+++ b/capellambse/extensions/reqif/elements.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 __all__ = [

--- a/capellambse/extensions/reqif/exporter.py
+++ b/capellambse/extensions/reqif/exporter.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Implementation of a ReqIF 1.1 and 1.2 exporter"""
 from __future__ import annotations
 

--- a/capellambse/helpers.py
+++ b/capellambse/helpers.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Miscellaneous utility functions used throughout the modules."""
 from __future__ import annotations
 

--- a/capellambse/loader/__init__.py
+++ b/capellambse/loader/__init__.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """The MelodyLoader loads and provides access to a Capella model.
 
 It is using LXML internally to efficiently parse and navigate through

--- a/capellambse/loader/core.py
+++ b/capellambse/loader/core.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Helps loading Capella models (including fragmented variants)."""
 from __future__ import annotations
 

--- a/capellambse/loader/exs.py
+++ b/capellambse/loader/exs.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """An Eclipse-like XML serializer.
 
 The libxml2 XML serializer produces very different output from the one

--- a/capellambse/loader/filehandler/__init__.py
+++ b/capellambse/loader/filehandler/__init__.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import abc

--- a/capellambse/loader/filehandler/git_askpass.py
+++ b/capellambse/loader/filehandler/git_askpass.py
@@ -1,17 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
 
 import os
 import sys

--- a/capellambse/loader/filehandler/gitfilehandler.py
+++ b/capellambse/loader/filehandler/gitfilehandler.py
@@ -1,16 +1,5 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
 
 # pylint: disable=abstract-method, useless-suppression
 # For some reason, pylint in Github CI didn't get the memo that these aren't

--- a/capellambse/loader/filehandler/http.py
+++ b/capellambse/loader/filehandler/http.py
@@ -1,16 +1,5 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
 
 # pylint: disable=abstract-method, useless-suppression
 # For some reason, pylint in Github CI didn't get the memo that these aren't

--- a/capellambse/loader/filehandler/localfilehandler.py
+++ b/capellambse/loader/filehandler/localfilehandler.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import contextlib

--- a/capellambse/loader/modelinfo.py
+++ b/capellambse/loader/modelinfo.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import dataclasses

--- a/capellambse/loader/xmltools.py
+++ b/capellambse/loader/xmltools.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Useful helpers for making object-oriented XML proxy classes."""
 from __future__ import annotations
 

--- a/capellambse/model/__init__.py
+++ b/capellambse/model/__init__.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Implements a high-level interface to Capella projects."""
 from __future__ import annotations
 

--- a/capellambse/model/common/__init__.py
+++ b/capellambse/model/common/__init__.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Common classes used by all MelodyModel functions.
 
 .. diagram:: [CDB] Common Types ORM

--- a/capellambse/model/common/accessors.py
+++ b/capellambse/model/common/accessors.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import warnings

--- a/capellambse/model/common/element.py
+++ b/capellambse/model/common/element.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 __all__ = [

--- a/capellambse/model/crosslayer/__init__.py
+++ b/capellambse/model/crosslayer/__init__.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Utility classes that are used across all layers.
 
 .. diagram:: [CDB] BaseLayer

--- a/capellambse/model/crosslayer/capellacommon.py
+++ b/capellambse/model/crosslayer/capellacommon.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Classes handling Mode/State-Machines and related content."""
 from .. import common as c
 from . import capellacore

--- a/capellambse/model/crosslayer/capellacore.py
+++ b/capellambse/model/crosslayer/capellacore.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 from .. import common as c
 
 

--- a/capellambse/model/crosslayer/cs.py
+++ b/capellambse/model/crosslayer/cs.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Implementation of objects and relations for Functional Analysis
 
 Composite Structure objects inheritance tree (taxonomy):

--- a/capellambse/model/crosslayer/fa.py
+++ b/capellambse/model/crosslayer/fa.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Implementation of objects and relations for Functional Analysis
 
 Functional Analysis objects inheritance tree (taxonomy):

--- a/capellambse/model/crosslayer/information/__init__.py
+++ b/capellambse/model/crosslayer/information/__init__.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Implementation of objects and relations for Information capture and data modelling
 
 Information objects inheritance tree (taxonomy):

--- a/capellambse/model/crosslayer/information/datatype.py
+++ b/capellambse/model/crosslayer/information/datatype.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from ... import common as c

--- a/capellambse/model/crosslayer/information/datavalue.py
+++ b/capellambse/model/crosslayer/information/datavalue.py
@@ -1,16 +1,5 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
 
 from capellambse.loader import xmltools
 

--- a/capellambse/model/crosslayer/interaction.py
+++ b/capellambse/model/crosslayer/interaction.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 from .. import common as c
 
 XT_CAP2PROC = "org.polarsys.capella.core.data.interaction:FunctionalChainAbstractCapabilityInvolvement"

--- a/capellambse/model/diagram.py
+++ b/capellambse/model/diagram.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Classes that allow access to diagrams in the model."""
 from __future__ import annotations
 

--- a/capellambse/model/layers/__init__.py
+++ b/capellambse/model/layers/__init__.py
@@ -1,13 +1,2 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0

--- a/capellambse/model/layers/ctx.py
+++ b/capellambse/model/layers/ctx.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tools for the System Analysis layer.
 
 This is normally the place to declare data used in the model for e.g.

--- a/capellambse/model/layers/la.py
+++ b/capellambse/model/layers/la.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tools for the Logical Architecture layer.
 
 .. diagram:: [CDB] LA ORM

--- a/capellambse/model/layers/oa.py
+++ b/capellambse/model/layers/oa.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tools for the Operational Analysis layer.
 
 .. diagram:: [CDB] OA ORM

--- a/capellambse/model/layers/pa.py
+++ b/capellambse/model/layers/pa.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tools for the Physical Architecture layer.
 
 .. diagram:: [CDB] Physical Architecture [Ontology]

--- a/capellambse/model/modeltypes.py
+++ b/capellambse/model/modeltypes.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Enumeration types used by the MelodyModel."""
 import enum as _enum
 import typing as t

--- a/capellambse/pvmt/__init__.py
+++ b/capellambse/pvmt/__init__.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Provides easy access to the Polarsys Capella PVMT extension.
 
 The public API of this submodule uses raw LXML elements.  For a more

--- a/capellambse/pvmt/core.py
+++ b/capellambse/pvmt/core.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Core functionality shared by all PVMT submodules."""
 
 from capellambse.loader.xmltools import AttributeProperty

--- a/capellambse/pvmt/exceptions.py
+++ b/capellambse/pvmt/exceptions.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Exceptions that may be raised by the PVMT module."""
 
 

--- a/capellambse/pvmt/model.py
+++ b/capellambse/pvmt/model.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Provides easy access to the Polarsys Capella PVMT extensions."""
 
 from __future__ import annotations

--- a/capellambse/pvmt/types.py
+++ b/capellambse/pvmt/types.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Classes that represent different property value types."""
 
 from __future__ import annotations

--- a/capellambse/pvmt/validation.py
+++ b/capellambse/pvmt/validation.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Validation functions for PVMT."""
 
 import logging

--- a/capellambse/sphinx.py
+++ b/capellambse/sphinx.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Sphinx extension for python-capella-mbse.
 
 This extension is be used to display diagrams in Sphinx-generated

--- a/capellambse/svg/__init__.py
+++ b/capellambse/svg/__init__.py
@@ -1,15 +1,5 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Export diagrams to ``.svg`` files."""
 from .generate import SVGDiagram

--- a/capellambse/svg/decorations.py
+++ b/capellambse/svg/decorations.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """The decoration factories for svg elements."""
 from __future__ import annotations
 

--- a/capellambse/svg/drawing.py
+++ b/capellambse/svg/drawing.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Custom extensions to the svgwrite ``Drawing`` object."""
 from __future__ import annotations
 

--- a/capellambse/svg/generate.py
+++ b/capellambse/svg/generate.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import collections.abc as cabc

--- a/capellambse/svg/helpers.py
+++ b/capellambse/svg/helpers.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import collections.abc as cabc

--- a/capellambse/svg/style.py
+++ b/capellambse/svg/style.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Stylesheet generator for SVG diagrams."""
 from __future__ import annotations
 

--- a/capellambse/svg/symbols.py
+++ b/capellambse/svg/symbols.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import typing as t

--- a/docs/source/_ext/jinja_in_rst.py
+++ b/docs/source/_ext/jinja_in_rst.py
@@ -1,16 +1,7 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+
 def rstjinja(app, docname, source):
     """Render our pages as a jinja template for fancy templating goodness."""
     # Make sure we're outputting HTML

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 
 logger = logging.getLogger(__name__)

--- a/license_header.txt
+++ b/license_header.txt
@@ -1,0 +1,2 @@
+Copyright DB Netz AG and the capellambse contributors
+SPDX-License-Identifier: Apache-2.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 import pathlib
 import re
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Global fixtures for pytest"""
 import io
 import sys

--- a/tests/test_aird_filters.py
+++ b/tests/test_aird_filters.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for aird-filters applied after rendering a diagram"""
 import capellambse
 

--- a/tests/test_aird_parser.py
+++ b/tests/test_aird_parser.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import pathlib
 import sys

--- a/tests/test_aird_vector2d.py
+++ b/tests/test_aird_vector2d.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import itertools

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 import pathlib
 
 import pytest

--- a/tests/test_model_creation_deletion.py
+++ b/tests/test_model_creation_deletion.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for creating and deleting model elements"""
 # pylint: disable=missing-function-docstring
 # pylint: disable=protected-access

--- a/tests/test_model_layers.py
+++ b/tests/test_model_layers.py
@@ -1,16 +1,5 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
 
 import typing as t
 

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import pathlib

--- a/tests/test_pvmt.py
+++ b/tests/test_pvmt.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 import pathlib
 import shutil
 import tempfile

--- a/tests/test_reqif.py
+++ b/tests/test_reqif.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # pylint: disable=no-self-use
 from __future__ import annotations
 

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -1,16 +1,6 @@
-# Copyright 2021 DB Netz AG
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import collections.abc as cabc

--- a/tests/test_xlayer_common.py
+++ b/tests/test_xlayer_common.py
@@ -1,3 +1,6 @@
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 import capellambse
 
 

--- a/tests/test_xlayer_cs.py
+++ b/tests/test_xlayer_cs.py
@@ -1,3 +1,6 @@
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 from capellambse import MelodyModel
 
 

--- a/tests/test_xlayer_fa.py
+++ b/tests/test_xlayer_fa.py
@@ -1,3 +1,6 @@
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # pylint: disable=no-self-use
 import typing as t
 

--- a/tests/test_xlayer_information.py
+++ b/tests/test_xlayer_information.py
@@ -1,3 +1,6 @@
+# Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # pylint: disable=no-self-use
 import typing as t
 


### PR DESCRIPTION
This two-line license header is much less overhead compared to the
example provided with the full Apache-2.0 license, while providing
roughly the same information (considering that the full license is
provided in the repo root as well).

Additionally, a new pre-commit hook was added that automates insertion
of these headers.

Fixes #80.