### PR TITLE
Expand on the "Documentation and examples" section in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,54 @@ Once in the browser, simply click on the [`01_Introduction.ipynb`](examples/01_I
 
 ## Documentation and examples
 
-We designed the library API such that it is easy to use and discover, however there is also [documentation available here](https://dsd-dbs.github.io/py-capellambse/). Additionally, the [practical examples folder](https://github.com/DSD-DBS/py-capellambse/blob/master/examples/) provides a collection of Jupyter notebooks with practical examples (like getting traceability matrices, change assessments, BoMs, etc).
+The library is designed to be easy to use and discover, especially in an
+interactive environment such as JupyterLab. Additionally, [API documentation]
+is automatically generated and published whenever new features and bug fixes
+are added.
+
+[API documentation]: https://dsd-dbs.github.io/py-capellambse/
+
+You are encouraged to explore our test models and demo notebooks on either a
+public myBinder instance or by installing the library locally ([see
+above](#getting-started)).
+
+The `examples` directory contains several hands-on example notebooks that you
+can immediately run and start experimenting with. Below is a short summary of
+each notebook's goal. If you are in the JupyterLab environment, you can click
+the notebook names to directly open them in a new lab tab. On Github, you will
+be shown a statically rendered preview of the notebook.
+
+- [`01 Introduction.ipynb`](examples/01%20Introduction.ipynb) provides a
+  high-level overview of the library features, with some visual examples
+  leveraging Jupyter's and IPython's rich display functionality.
+- [`02 Intro to Physical
+  Architecture.ipynb`](examples/02%20Intro%20to%20Physical%20Architecture%20API.ipynb)
+  explores some more advanced concepts on the example of the Physical
+  Architecture Layer. It also showcases how to use `pandas` dataframes to
+  effectively manage and search through large numbers of model elements.
+- [`03 Data Values.ipynb`](examples/03%20Data%20Values.ipynb) introduces the
+  data value classes from the `information.datavalue` package, which are used
+  in several places throughout a Capella model.
+- [`04 Intro to Jinja
+  templating.ipynb`](examples/04%20Intro%20to%20Jinja%20templating.ipynb)
+  demonstrates how to effectively combine `capellambse` with the powerful
+  [Jinja templating engine](https://palletsprojects.com/p/jinja/).
+- [`05 Introduction to
+  Libraries.ipynb`](examples/05%20Introduction%20to%20Libraries.ipynb) shows
+  how to use Capella Library Projects within capellambse. These allow multiple
+  collaborators to work on different parts of a project, or on derived
+  projects, independently from one another.
+- [`06 Introduction to Requirement access and management with ReqIF
+  extension.ipynb`](examples/06%20Introduction%20to%20Requirement%20access%20and%20management%20with%20ReqIF%20extension.ipynb)
+  introduces the optional ReqIF extension. If this extension is installed and
+  activated in Capella, Requirement objects can be managed right in a model,
+  and linked up with other model elements. Based on this functionality,
+  `capellambse` also provides a basic exporter for `.reqif` and `.reqifz`
+  files.
+
+We are constantly working on improving everything shown here, as well as adding
+even more useful functionality and helpful demos. If you have any new ideas
+that were not mentioned yet, [don't hesitate to contribute](CONTRIBUTING.md)!
 
 ## Dependencies on 3rd party components and re-distributions
 


### PR DESCRIPTION
Rather than just a very short filename in the `examples/` directory, this section now provides a brief summary of each notebook's goals, as well as the features that it showcases.