### PR TITLE
Add traces attribute to GenericElement

### DIFF
--- a/capellambse/model/crosslayer/capellacommon.py
+++ b/capellambse/model/crosslayer/capellacommon.py
@@ -100,6 +100,18 @@ class StateTransition(c.GenericElement):
     guard = c.AttrProxyAccessor(capellacore.Constraint, "guard")
 
 
+@c.xtype_handler(None)
+class GenericTrace(c.GenericElement):
+    """A trace between two elements."""
+
+    source = c.AttrProxyAccessor(c.GenericElement, attr="sourceElement")
+    target = c.AttrProxyAccessor(c.GenericElement, attr="targetElement")
+
+    @property
+    def name(self) -> str:  # type: ignore
+        return f"[{self.__class__.__name__}] to {self.target.name} ({self.target.uuid})"
+
+
 c.set_accessor(
     AbstractStateMode,
     "realized_states",
@@ -139,4 +151,9 @@ c.set_accessor(
     Region,
     "transitions",
     c.ProxyAccessor(StateTransition, aslist=c.ElementList),
+)
+c.set_accessor(
+    c.GenericElement,
+    "traces",
+    c.ProxyAccessor(GenericTrace, aslist=c.ElementList),
 )

--- a/tests/data/melodymodel/5_2/Melody Model Test.capella
+++ b/tests/data/melodymodel/5_2/Melody Model Test.capella
@@ -1379,6 +1379,20 @@ The predator is far away</bodies>
                   sourceElement="#0fef2887-04ce-4406-b1a1-a1b35e1ce0f3"/>
             </ownedClasses>
           </ownedDataPkgs>
+          <ownedDataPkgs xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+              id="80b36e27-cf57-44e6-862b-37f52b77bcc8" name="TestTrace">
+            <ownedClasses xsi:type="org.polarsys.capella.core.data.information:Class"
+                id="ed272baf-43f2-4fa1-ad50-49c00563258b" name="Class Trace"/>
+            <ownedClasses xsi:type="org.polarsys.capella.core.data.information:Class"
+                id="ad876857-33d3-4f2e-9fe2-71545a78352d" name="Class 2">
+              <ownedTraces xsi:type="org.polarsys.capella.core.data.capellacommon:GenericTrace"
+                  id="9f84f273-1af4-49c2-a9f1-143e94ab816b" targetElement="#ed272baf-43f2-4fa1-ad50-49c00563258b"
+                  sourceElement="#ad876857-33d3-4f2e-9fe2-71545a78352d"/>
+              <ownedTraces xsi:type="org.polarsys.capella.core.data.capellacommon:GenericTrace"
+                  id="0880af85-4f96-4a77-b588-2e7a0385629d" targetElement="#01788b49-ccef-4a37-93d2-119287f8dd53"
+                  sourceElement="#ad876857-33d3-4f2e-9fe2-71545a78352d"/>
+            </ownedClasses>
+          </ownedDataPkgs>
           <ownedClasses xsi:type="org.polarsys.capella.core.data.information:Class"
               id="959b5222-7717-4ee9-bd3a-f8a209899464" name="1st Specialization of SuperClass"
               summary="" description="&lt;p>This is a test description for a class.&lt;/p>&#xA;"

--- a/tests/data/melodymodel/5_2/Melody Model Test.capella
+++ b/tests/data/melodymodel/5_2/Melody Model Test.capella
@@ -1382,9 +1382,9 @@ The predator is far away</bodies>
           <ownedDataPkgs xsi:type="org.polarsys.capella.core.data.information:DataPkg"
               id="80b36e27-cf57-44e6-862b-37f52b77bcc8" name="TestTrace">
             <ownedClasses xsi:type="org.polarsys.capella.core.data.information:Class"
-                id="ed272baf-43f2-4fa1-ad50-49c00563258b" name="Class Trace"/>
+                id="ed272baf-43f2-4fa1-ad50-49c00563258b" name="Class TraceTarget"/>
             <ownedClasses xsi:type="org.polarsys.capella.core.data.information:Class"
-                id="ad876857-33d3-4f2e-9fe2-71545a78352d" name="Class 2">
+                id="ad876857-33d3-4f2e-9fe2-71545a78352d" name="Class TraceSource">
               <ownedTraces xsi:type="org.polarsys.capella.core.data.capellacommon:GenericTrace"
                   id="9f84f273-1af4-49c2-a9f1-143e94ab816b" targetElement="#ed272baf-43f2-4fa1-ad50-49c00563258b"
                   sourceElement="#ad876857-33d3-4f2e-9fe2-71545a78352d"/>

--- a/tests/test_model_layers.py
+++ b/tests/test_model_layers.py
@@ -551,7 +551,7 @@ def test_GenericElement_has_GenericTraces(
 
     assert trace in cls.traces
     assert trace.name == expected
-    
+
 
 @pytest.mark.parametrize(
     "chain_uuid,fnc_uuid,target_uuid",

--- a/tests/test_model_layers.py
+++ b/tests/test_model_layers.py
@@ -530,6 +530,31 @@ def test_FunctionalChainInvolvementLink_attributes(
     assert link.name == f"[FunctionalChainInvolvementLink] to {expected_end}"
 
 
+@pytest.mark.parametrize(
+    "trace_uuid,target_uuid",
+    [
+        pytest.param(
+            "9f84f273-1af4-49c2-a9f1-143e94ab816b",
+            "ed272baf-43f2-4fa1-ad50-49c00563258b",
+        ),
+        pytest.param(
+            "0880af85-4f96-4a77-b588-2e7a0385629d",
+            "01788b49-ccef-4a37-93d2-119287f8dd53",
+        ),
+    ],
+)
+def test_Class_has_GenericTraces(
+    model_5_2: capellambse.MelodyModel, trace_uuid: str, target_uuid: str
+) -> None:
+    cls = model_5_2.by_uuid("ad876857-33d3-4f2e-9fe2-71545a78352d")
+    trace = model_5_2.by_uuid(trace_uuid)
+    target = model_5_2.by_uuid(target_uuid)
+    expected_end = f"{target.name} ({target.uuid})"
+
+    assert trace in cls.traces
+    assert trace.name == f"[GenericTrace] to {expected_end}"
+
+
 class TestArchitectureLayers:
     @pytest.mark.parametrize(
         "layer,definitions",

--- a/tests/test_model_layers.py
+++ b/tests/test_model_layers.py
@@ -531,28 +531,26 @@ def test_FunctionalChainInvolvementLink_attributes(
 
 
 @pytest.mark.parametrize(
-    "trace_uuid,target_uuid",
+    "trace_uuid,expected",
     [
         pytest.param(
             "9f84f273-1af4-49c2-a9f1-143e94ab816b",
-            "ed272baf-43f2-4fa1-ad50-49c00563258b",
+            "[GenericTrace] to Class TraceTarget (ed272baf-43f2-4fa1-ad50-49c00563258b)",
         ),
         pytest.param(
             "0880af85-4f96-4a77-b588-2e7a0385629d",
-            "01788b49-ccef-4a37-93d2-119287f8dd53",
+            "[GenericTrace] to Hunt (01788b49-ccef-4a37-93d2-119287f8dd53)",
         ),
     ],
 )
-def test_Class_has_GenericTraces(
-    model_5_2: capellambse.MelodyModel, trace_uuid: str, target_uuid: str
+def test_GenericElement_has_GenericTraces(
+    model_5_2: capellambse.MelodyModel, trace_uuid: str, expected: str
 ) -> None:
     cls = model_5_2.by_uuid("ad876857-33d3-4f2e-9fe2-71545a78352d")
     trace = model_5_2.by_uuid(trace_uuid)
-    target = model_5_2.by_uuid(target_uuid)
-    expected_end = f"{target.name} ({target.uuid})"
 
     assert trace in cls.traces
-    assert trace.name == f"[GenericTrace] to {expected_end}"
+    assert trace.name == expected
 
 
 class TestArchitectureLayers:


### PR DESCRIPTION
This PR adds a new ModelObject called `GenericTrace` that can be added via the Wizards > Trace Manager option exposed when right clicking a ModelObject in the Project Explorer. 
![image](https://user-images.githubusercontent.com/50786483/172643314-0b2daa3b-0ad0-4be1-a99e-9f02d878c068.png)

As this is a very generic thing, an Acessor is set on the `GenericElement` and reveals a `.traces` attribute. We currently do not distinguish between incoming and outgoing traceability links.

@Wuestengecko I want to point out that the name property of this class is in a similar fashion like the recently added `FunctionalChainInvolvementLink` & `FunctionalChainInvolvementFunction`. Does it make sense to generalize this, to get drier or do you feel that this adds unnecessary complexity? I can think about a flexible function that gets a parameter `attr: str` and builds a name just like this.