### PR TITLE
Shallow cloning functionality for the `git://` file handler

### DIFF
--- a/capellambse/loader/filehandler/gitfilehandler.py
+++ b/capellambse/loader/filehandler/gitfilehandler.py
@@ -650,7 +650,7 @@ class GitFileHandler(FileHandler):
         if not (self.cache_dir / "config").exists():
             self.cache_dir.mkdir(parents=True, exist_ok=True)
             LOGGER.debug("Creating a new git repo in %s", self.cache_dir)
-            self._git("init", "--bare")
+            self._git("-c", "init.defaultBranch=master", "init", "--bare")
             self._git("remote", "add", "--mirror=fetch", "origin", self.path)
             update_cache = True
 


### PR DESCRIPTION
This PR implements the capability for the `git://` file handler to create and update shallow clones in its cache directory. This significantly reduces the network bandwidth and disk space needed for updating and maintaining the cache.

It also introduces the new file handler specific keyword argument `shallow=`, which controls this behavior. If it is set to `True` (the default), clones and fetches will be shallow, and existing full clones will be converted to shallow clones as they are accessed. If it is `False`, clones and fetches will fetch the full history. Existing shallow clones will however not be "unshallowed".

Note that actually unlinking unused objects is subject to git's garbage collection. To benefit from the disk space savings immediately, consider either wiping the cache or updating all locally cached models (by loading them once) and running `git gc` manually.

- [x] When creating a new cache, the relevant ref is downloaded and made available as symbolic ref.
- [x] When updating a cache, the local copy of the ref is updated to the current state on the remote.
- [x] When pushing to a branch, the remote is updated with the committed changes.