### PR TITLE
Minor fixes

### DIFF
--- a/capellambse/extensions/reqif/elements.py
+++ b/capellambse/extensions/reqif/elements.py
@@ -312,12 +312,11 @@ class AbstractRequirementsAttribute(c.GenericElement):
     definition = c.AttrProxyAccessor(AttributeDefinition, "definition")
 
     def __repr__(self) -> str:
-        mytype = self.xtype.rsplit(":", maxsplit=1)[-1]
-        try:
-            name = self.definition.long_name
-        except AttributeError:
-            name = ""
-        return f"<{mytype} [{name}] ({self.uuid})>"
+        return self._short_repr_()
+
+    def _short_repr_(self, _: str = "") -> str:
+        name = self.definition.long_name if self.definition is not None else _
+        return super()._short_repr_(name)
 
     def _short_html_(self) -> markupsafe.Markup:
         if self.definition is not None:

--- a/capellambse/extensions/reqif/elements.py
+++ b/capellambse/extensions/reqif/elements.py
@@ -279,6 +279,9 @@ class ReqIFElement(c.GenericElement):
 
         return f'<{mytype} {"/".join(reversed(path))!r} ({self.uuid})>'
 
+    def _short_repr_(self, name: str = "") -> str:
+        return super()._short_repr_(name or self.name or self.long_name)
+
     def _short_html_(self) -> markupsafe.Markup:
         return markupsafe.Markup(
             self._wrap_short_html(

--- a/capellambse/extensions/reqif/elements.py
+++ b/capellambse/extensions/reqif/elements.py
@@ -279,8 +279,8 @@ class ReqIFElement(c.GenericElement):
 
         return f'<{mytype} {"/".join(reversed(path))!r} ({self.uuid})>'
 
-    def _short_repr_(self, name: str = "") -> str:
-        return super()._short_repr_(name or self.name or self.long_name)
+    def _short_repr_(self) -> str:
+        return f"<{type(self).__name__} {self.long_name!r} ({self.uuid})>"
 
     def _short_html_(self) -> markupsafe.Markup:
         return markupsafe.Markup(
@@ -314,9 +314,10 @@ class AbstractRequirementsAttribute(c.GenericElement):
     def __repr__(self) -> str:
         return self._short_repr_()
 
-    def _short_repr_(self, _: str = "") -> str:
-        name = self.definition.long_name if self.definition is not None else _
-        return super()._short_repr_(name)
+    def _short_repr_(self) -> str:
+        if self.definition is not None:
+            return f"<{type(self).__name__} {self.definition.long_name!r} ({self.uuid})>"
+        return super()._short_repr_()
 
     def _short_html_(self) -> markupsafe.Markup:
         if self.definition is not None:

--- a/capellambse/loader/filehandler/gitfilehandler.py
+++ b/capellambse/loader/filehandler/gitfilehandler.py
@@ -854,6 +854,9 @@ class GitFileHandler(FileHandler):
                 ret_level = logging.DEBUG
 
             if stderr:
-                for line in stderr.decode("utf-8").splitlines():
+                if isinstance(stderr, bytes):
+                    stderr = stderr.decode("utf-8")
+
+                for line in stderr.splitlines():
                     LOGGER.getChild("git").log(err_level, "%s", line)
             LOGGER.log(ret_level, "Exit status: %d", returncode)

--- a/capellambse/model/common/element.py
+++ b/capellambse/model/common/element.py
@@ -271,13 +271,13 @@ class GenericElement:
         attr_text = "\n".join(attrs)
         return f"{header}\n{attr_text}"
 
-    def _short_repr_(self) -> str:
+    def _short_repr_(self, name: str = "") -> str:
         # pylint: disable=unidiomatic-typecheck
         if type(self) is GenericElement:
             mytype = f"Model element ({self.xtype})"
         else:
             mytype = type(self).__name__
-        return f"<{mytype} {self.name!r} ({self.uuid})>"
+        return f"<{mytype} {name or self.name!r} ({self.uuid})>"
 
     def __html__(self) -> markupsafe.Markup:
         fragments: list[str] = []

--- a/capellambse/model/common/element.py
+++ b/capellambse/model/common/element.py
@@ -271,13 +271,13 @@ class GenericElement:
         attr_text = "\n".join(attrs)
         return f"{header}\n{attr_text}"
 
-    def _short_repr_(self, name: str = "") -> str:
+    def _short_repr_(self) -> str:
         # pylint: disable=unidiomatic-typecheck
         if type(self) is GenericElement:
             mytype = f"Model element ({self.xtype})"
         else:
             mytype = type(self).__name__
-        return f"<{mytype} {name or self.name!r} ({self.uuid})>"
+        return f"<{mytype} {self.name!r} ({self.uuid})>"
 
     def __html__(self) -> markupsafe.Markup:
         fragments: list[str] = []


### PR DESCRIPTION
With this PR we are more safe during loader failures and the displayed representation of `reqif.ReqIFElement`s in the Terminal (and possibly Jupyter) is fixed. For the latter we simply had to add a `_short_repr_`. To stay dry we changed the signature of `_short_repr_` on `common.GenericElement` such that it can be reused.