### PR TITLE
Fix creating model objects with explicit default values (#108)

### DIFF
--- a/capellambse/loader/xmltools.py
+++ b/capellambse/loader/xmltools.py
@@ -110,16 +110,13 @@ class AttributeProperty:
 
     def __set__(self, obj, value) -> None:
         xml_element = getattr(obj, self.xmlattr)
-        attribute_exists = xml_element.get(self.attribute) is not None
-        if not self.writable and attribute_exists:
+        if not self.writable and xml_element.get(self.attribute) is not None:
             raise TypeError(
                 f"Cannot set attribute {self.__name__!r} on {type(obj).__name__!r} objects"
             )
 
         if value == self.default:
-            if attribute_exists:
-                self.__delete__(obj)
-            return
+            return self.__delete__(obj)
 
         stringified = str(value)
 
@@ -149,9 +146,7 @@ class AttributeProperty:
         try:
             del xml_element.attrib[self.attribute]
         except KeyError:
-            raise AttributeError(
-                f"{obj!r} does not have {self.__name__} set"
-            ) from None
+            pass
 
     def __set_name__(self, owner: type[t.Any], name: str) -> None:
         self.__name__ = name
@@ -252,7 +247,7 @@ class BooleanAttributeProperty(AttributeProperty):
     def __set__(self, obj, value) -> None:
         if value:
             super().__set__(obj, "true")
-        elif getattr(obj, self.xmlattr).get(self.attribute) is not None:
+        else:
             self.__delete__(obj)
 
 
@@ -307,8 +302,7 @@ class DatetimeAttributeProperty(AttributeProperty):
 
     def __set__(self, obj, value) -> None:
         if value is None:
-            if getattr(obj, self.xmlattr).get(self.attribute):
-                self.__delete__(obj)
+            self.__delete__(obj)
         elif isinstance(value, datetime.datetime):
             if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
                 value = value.astimezone()

--- a/capellambse/loader/xmltools.py
+++ b/capellambse/loader/xmltools.py
@@ -310,6 +310,8 @@ class DatetimeAttributeProperty(AttributeProperty):
             if getattr(obj, self.xmlattr).get(self.attribute):
                 self.__delete__(obj)
         elif isinstance(value, datetime.datetime):
+            if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+                value = value.astimezone()
             super().__set__(obj, value.strftime(self.format))
         else:
             raise TypeError(f"Expected datetime, not {type(value).__name__}")

--- a/capellambse/model/common/accessors.py
+++ b/capellambse/model/common/accessors.py
@@ -440,7 +440,7 @@ class ProxyAccessor(WritableAccessor[T], PhysicalAccessor[T]):
         if "uuid" in kw:
             want_id = kw.pop("uuid")
         with elmlist._model._loader.new_uuid(parent, want=want_id) as obj_id:
-            obj = elmclass(elmlist._model, parent, **kw, uuid=obj_id)
+            obj = elmclass(elmlist._model, parent, uuid=obj_id, **kw)
         return obj  # type: ignore[return-value]
 
     def insert(

--- a/tests/test_reqif.py
+++ b/tests/test_reqif.py
@@ -433,7 +433,7 @@ class TestReqIFModification:
         definition = model.by_uuid("682bd51d-5451-4930-a97e-8bfca6c3a127")
         attr = req.attributes.create(type_hint, definition=definition)
 
-        assert tuple(req.attributes) == (attr,)
+        assert req.attributes == [attr]
         assert attr.definition == definition
         assert attr.value == default_value
         assert attr._element.get("value") is None
@@ -479,7 +479,7 @@ class TestReqIFModification:
         if isinstance(value, datetime.datetime):
             value = value.astimezone()
 
-        assert tuple(req.attributes) == (value_attr,)
+        assert req.attributes == [value_attr]
         assert value_attr.value == value
         assert value_attr._element.get("value") == xml
 
@@ -488,8 +488,8 @@ class TestReqIFModification:
     ):
         req = model.by_uuid("79291c33-5147-4543-9398-9077d582576d")
         assert isinstance(req, reqif.Requirement)
-
         assert not req.attributes
+
         attr = req.attributes.create("Int")
 
         assert len(req.attributes) == 1

--- a/tests/test_reqif.py
+++ b/tests/test_reqif.py
@@ -8,13 +8,11 @@ import datetime
 import operator
 import textwrap
 import typing as t
-from xmlrpc.client import boolean
 
 import pytest
 
 import capellambse
 from capellambse.extensions import reqif
-from capellambse.loader.core import RE_VALID_ID
 
 long_req_text = textwrap.dedent(
     """\

--- a/tests/test_reqif.py
+++ b/tests/test_reqif.py
@@ -8,6 +8,7 @@ import datetime
 import operator
 import textwrap
 import typing as t
+from xmlrpc.client import boolean
 
 import pytest
 
@@ -482,6 +483,25 @@ class TestReqIFModification:
         assert attr.definition is None
         assert isinstance(attr, reqif.AbstractRequirementsAttribute)
 
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param(True, id="Boolean Attribute set to True"),
+            pytest.param(False, id="Boolean Attribute set to False"),
+        ],
+    )
+    def test_create_bool_attr(
+        self, model: capellambse.MelodyModel, value: boolean
+    ):
+        req = model.by_uuid("79291c33-5147-4543-9398-9077d582576d")
+        assert isinstance(req, reqif.Requirement)
+
+        assert not req.attributes
+        attr = req.attributes.create("Bool", value=value)
+        assert len(req.attributes) == 1
+        assert req.attributes[0] == attr
+        assert isinstance(attr, reqif.AbstractRequirementsAttribute)
+
     def test_create_enum_value_attribute_on_requirements(
         self, model: capellambse.MelodyModel
     ):
@@ -510,6 +530,7 @@ class TestReqIFModification:
         "value",
         [
             pytest.param(True, id="Boolean Attribute"),
+            pytest.param(False, id="Boolean Attribute"),
             pytest.param(1, id="Integer Attribute"),
             pytest.param(
                 datetime.datetime(


### PR DESCRIPTION
This PR fixes the bug described in #108 but for the creation of all AttributeValues, not BooleanAttributeValue exclusively. In doing so it was revealed that handing over timezone unaware `datetime` objects doesn't lead to the supported format for writing to the xml. An extra test parameter was added where in this case the local timezone was added as tzinfo.