### PR TITLE
ReqIF Attribute Value default __repr__ behaviour

### DIFF
--- a/capellambse/extensions/reqif/elements.py
+++ b/capellambse/extensions/reqif/elements.py
@@ -59,6 +59,7 @@ __all__ = [
 import collections.abc as cabc
 import logging
 import os
+import re
 import typing as t
 
 import markupsafe
@@ -311,13 +312,17 @@ class AbstractRequirementsAttribute(c.GenericElement):
 
     definition = c.AttrProxyAccessor(AttributeDefinition, "definition")
 
+    value: xmltools.AttributeProperty | c.AttrProxyAccessor
+
     def __repr__(self) -> str:
         return self._short_repr_()
 
     def _short_repr_(self) -> str:
+        mytype = type(self).__name__
         if self.definition is not None:
-            return f"<{type(self).__name__} {self.definition.long_name!r} ({self.uuid})>"
-        return super()._short_repr_()
+            return f"<{mytype} {self.definition.long_name!r} ({self.uuid})>"
+        default_name = re.sub(r"([A-Z])", r" \1", mytype).split()
+        return f"<{mytype} [{' '.join(default_name)}] ({self.uuid})>"
 
     def _short_html_(self) -> markupsafe.Markup:
         if self.definition is not None:

--- a/capellambse/extensions/reqif/elements.py
+++ b/capellambse/extensions/reqif/elements.py
@@ -321,8 +321,8 @@ class AbstractRequirementsAttribute(c.GenericElement):
         mytype = type(self).__name__
         if self.definition is not None:
             return f"<{mytype} {self.definition.long_name!r} ({self.uuid})>"
-        default_name = re.sub(r"([A-Z])", r" \1", mytype).split()
-        return f"<{mytype} [{' '.join(default_name)}] ({self.uuid})>"
+        default_name = re.sub(r"(?<!^)([A-Z])", r" \1", mytype)
+        return f"<{mytype} [{default_name}] ({self.uuid})>"
 
     def _short_html_(self) -> markupsafe.Markup:
         if self.definition is not None:

--- a/capellambse/extensions/reqif/elements.py
+++ b/capellambse/extensions/reqif/elements.py
@@ -764,7 +764,12 @@ _attr_type_hints = {
     "date": (DateValueAttribute, XT_REQ_ATTR_DATEVALUE),
     "datevalueattribute": (DateValueAttribute, XT_REQ_ATTR_DATEVALUE),
     "bool": (BooleanValueAttribute, XT_REQ_ATTR_BOOLEANVALUE),
-    "boolvalueattribute": (BooleanValueAttribute, XT_REQ_ATTR_BOOLEANVALUE),
+    "boolean": (BooleanValueAttribute, XT_REQ_ATTR_BOOLEANVALUE),
+    "booleanvalueattribute": (BooleanValueAttribute, XT_REQ_ATTR_BOOLEANVALUE),
     "enum": (EnumerationValueAttribute, XT_REQ_ATTR_ENUMVALUE),
-    "enumvalueattribute": (EnumerationValueAttribute, XT_REQ_ATTR_ENUMVALUE),
+    "enumeration": (EnumerationValueAttribute, XT_REQ_ATTR_ENUMVALUE),
+    "enumerationvalueattribute": (
+        EnumerationValueAttribute,
+        XT_REQ_ATTR_ENUMVALUE,
+    ),
 }

--- a/tests/test_reqif.py
+++ b/tests/test_reqif.py
@@ -440,27 +440,29 @@ class TestReqIFModification:
         assert isinstance(attr, reqif.AbstractRequirementsAttribute)
 
     @pytest.mark.parametrize(
-        "type_hint,value,xml",
+        "type_hint,value,xml,expected_repr_name",
         [
-            pytest.param("Int", 0, None),
-            pytest.param("Int", 1, "1"),
-            pytest.param("Str", "", None),
-            pytest.param("Str", "test", "test"),
-            pytest.param("Float", 0.0, None),
-            pytest.param("Float", 1.0, "1.0"),
-            pytest.param("Date", None, None),
+            pytest.param("Int", 0, None, "[Integer Value Attribute]"),
+            pytest.param("Int", 1, "1", "[Integer Value Attribute]"),
+            pytest.param("Str", "", None, "[String Value Attribute]"),
+            pytest.param("Str", "test", "test", "[String Value Attribute]"),
+            pytest.param("Float", 0.0, None, "[Real Value Attribute]"),
+            pytest.param("Float", 1.0, "1.0", "[Real Value Attribute]"),
+            pytest.param("Date", None, None, "[Date Value Attribute]"),
             pytest.param(
                 "Date",
                 TEST_DATETIME,
                 f"1987-07-27T00:00:00.000000{TEST_TZ_OFFSET}",
+                "[Date Value Attribute]",
             ),
             pytest.param(
                 "Date",
                 datetime.datetime(1987, 7, 27, tzinfo=datetime.timezone.utc),
                 "1987-07-27T00:00:00.000000+0000",
+                "[Date Value Attribute]",
             ),
-            pytest.param("Bool", False, None),
-            pytest.param("Bool", True, "true"),
+            pytest.param("Bool", False, None, "[Boolean Value Attribute]"),
+            pytest.param("Bool", True, "true", "[Boolean Value Attribute]"),
         ],
     )
     def test_create_requirements_attributes_with_non_default_values(
@@ -469,6 +471,7 @@ class TestReqIFModification:
         type_hint: str,
         value: t.Any,
         xml: str | None,
+        expected_repr_name: str,
     ):
         req = model.by_uuid("79291c33-5147-4543-9398-9077d582576d")
 
@@ -482,6 +485,7 @@ class TestReqIFModification:
         assert req.attributes == [value_attr]
         assert value_attr.value == value
         assert value_attr._element.get("value") == xml
+        assert expected_repr_name in repr(value_attr)
 
     def test_create_value_attribute_on_requirements_without_definition(
         self, model: capellambse.MelodyModel

--- a/tests/test_reqif.py
+++ b/tests/test_reqif.py
@@ -636,10 +636,11 @@ class TestRequirementsFiltering:
             "32d66740-e428-4600-be68-8410d9d568cc",
         }
     )
+    reqtype_uuid = "db47fca9-ddb6-4397-8d4b-e397e53d277e"
 
     def test_filtering_by_type_name(self, model: capellambse.MelodyModel):
         requirements = model.search(reqif.XT_REQUIREMENT)
-        rt = model.by_uuid("db47fca9-ddb6-4397-8d4b-e397e53d277e")
+        rt = model.by_uuid(self.reqtype_uuid)
         assert isinstance(rt, reqif.RequirementType)
 
         rtype_reqs = requirements.by_type(rt.long_name)
@@ -649,7 +650,7 @@ class TestRequirementsFiltering:
 
     def test_filtering_by_type_names(self, model: capellambse.MelodyModel):
         requirements = model.search(reqif.XT_REQUIREMENT)
-        rt1 = model.by_uuid("db47fca9-ddb6-4397-8d4b-e397e53d277e")
+        rt1 = model.by_uuid(self.reqtype_uuid)
         rt2 = model.by_uuid("00195554-8fae-4687-86ca-77c93330893d")
         assert isinstance(rt1, reqif.RequirementType)
         assert isinstance(rt2, reqif.RequirementType)
@@ -664,14 +665,14 @@ class TestRequirementsFiltering:
         self, model: capellambse.MelodyModel
     ):
         requirements = model.search(reqif.XT_REQUIREMENT)
-        rt = model.by_uuid("db47fca9-ddb6-4397-8d4b-e397e53d277e")
+        rt = model.by_uuid(self.reqtype_uuid)
 
         uuids = {r.uuid for r in requirements.by_type(rt)}
         assert uuids & self.uuids == self.uuids
 
     def test_filtering_by_types(self, model: capellambse.MelodyModel):
         requirements = model.search(reqif.XT_REQUIREMENT)
-        rt1 = model.by_uuid("db47fca9-ddb6-4397-8d4b-e397e53d277e")
+        rt1 = model.by_uuid(self.reqtype_uuid)
         rt2 = model.by_uuid("00195554-8fae-4687-86ca-77c93330893d")
         expected_uuids = self.uuids | {"db4d4c74-b913-4d9a-8905-7d93d3360560"}
 
@@ -680,7 +681,7 @@ class TestRequirementsFiltering:
 
     def test_filtering_by_name_and_type(self, model: capellambse.MelodyModel):
         requirements = model.search(reqif.XT_REQUIREMENT)
-        rt1 = model.by_uuid("db47fca9-ddb6-4397-8d4b-e397e53d277e")
+        rt1 = model.by_uuid(self.reqtype_uuid)
         rt2 = model.by_uuid("00195554-8fae-4687-86ca-77c93330893d")
         assert isinstance(rt1, reqif.RequirementType)
         assert isinstance(rt2, reqif.RequirementType)
@@ -773,7 +774,7 @@ class TestRequirementsFiltering:
     def test_requirement_type_is_hashable(
         self, model: capellambse.MelodyModel
     ):
-        req_type = model.by_uuid("db47fca9-ddb6-4397-8d4b-e397e53d277e")
+        req_type = model.by_uuid(self.reqtype_uuid)
 
         assert isinstance(req_type, reqif.RequirementType)
         assert isinstance(req_type, t.Hashable)

--- a/tests/test_reqif.py
+++ b/tests/test_reqif.py
@@ -498,17 +498,29 @@ class TestReqIFModification:
         assert isinstance(attr, reqif.AbstractRequirementsAttribute)
 
     @pytest.mark.parametrize(
-        "type_hint",
+        "type_hint,expected_type",
         [
-            pytest.param("Integer"),
-            pytest.param("String"),
-            pytest.param("Real"),
-            pytest.param("Date"),
-            pytest.param("Boolean"),
+            pytest.param("Int", "Integer"),
+            pytest.param("Integer", "Integer"),
+            pytest.param("Integervalueattribute", "Integer"),
+            pytest.param("Str", "String"),
+            pytest.param("String", "String"),
+            pytest.param("Stringvalueattribute", "String"),
+            pytest.param("Float", "Real"),
+            pytest.param("Real", "Real"),
+            pytest.param("Realvalueattribute", "Real"),
+            pytest.param("Date", "Date"),
+            pytest.param("Datevalueattribute", "Date"),
+            pytest.param("Bool", "Boolean"),
+            pytest.param("Boolean", "Boolean"),
+            pytest.param("Booleanvalueattribute", "Boolean"),
         ],
     )
     def test_requirements_attribute_value_default_reprs(
-        self, model: capellambse.MelodyModel, type_hint: str
+        self,
+        model: capellambse.MelodyModel,
+        type_hint: str,
+        expected_type: str,
     ):
         req = model.by_uuid("79291c33-5147-4543-9398-9077d582576d")
 
@@ -516,7 +528,7 @@ class TestReqIFModification:
 
         attr = req.attributes.create(type_hint)
 
-        assert f"[{type_hint} Value Attribute]" in repr(attr)
+        assert f"[{expected_type} Value Attribute]" in repr(attr)
 
     def test_create_enum_value_attribute_on_requirements(
         self, model: capellambse.MelodyModel

--- a/tests/test_reqif.py
+++ b/tests/test_reqif.py
@@ -756,6 +756,20 @@ class TestRequirementsFiltering:
 
         assert [i.uuid for i in filtered_related] == target_uuids
 
+    def test_attributes_filtering_by_definition_long_name(
+        self, model: capellambse.MelodyModel
+    ):
+        req = model.by_uuid("85d41db2-9e17-438b-95cf-49342452ddf3")
+        ex_definition = model.by_uuid("c316ab07-c5c3-4866-a896-92e34733055c")
+        def_name = ex_definition.long_name
+
+        attributes = req.attributes.by_definition.long_name(def_name)
+        attr = req.attributes.by_definition.long_name(def_name, single=True)
+
+        assert def_name in req.attributes.by_definition.long_name
+        assert [attr.definition for attr in attributes] == [ex_definition]
+        assert attr.definition == ex_definition
+
     def test_RelationsLists_slicing(self, model: capellambse.MelodyModel):
         req = model.by_uuid("3c2d312c-37c9-41b5-8c32-67578fa52dc3")
         assert isinstance(req, reqif.Requirement)

--- a/tests/test_reqif.py
+++ b/tests/test_reqif.py
@@ -440,29 +440,27 @@ class TestReqIFModification:
         assert isinstance(attr, reqif.AbstractRequirementsAttribute)
 
     @pytest.mark.parametrize(
-        "type_hint,value,xml,expected_repr_name",
+        "type_hint,value,xml",
         [
-            pytest.param("Int", 0, None, "[Integer Value Attribute]"),
-            pytest.param("Int", 1, "1", "[Integer Value Attribute]"),
-            pytest.param("Str", "", None, "[String Value Attribute]"),
-            pytest.param("Str", "test", "test", "[String Value Attribute]"),
-            pytest.param("Float", 0.0, None, "[Real Value Attribute]"),
-            pytest.param("Float", 1.0, "1.0", "[Real Value Attribute]"),
-            pytest.param("Date", None, None, "[Date Value Attribute]"),
+            pytest.param("Int", 0, None),
+            pytest.param("Int", 1, "1"),
+            pytest.param("Str", "", None),
+            pytest.param("Str", "test", "test"),
+            pytest.param("Float", 0.0, None),
+            pytest.param("Float", 1.0, "1.0"),
+            pytest.param("Date", None, None),
             pytest.param(
                 "Date",
                 TEST_DATETIME,
                 f"1987-07-27T00:00:00.000000{TEST_TZ_OFFSET}",
-                "[Date Value Attribute]",
             ),
             pytest.param(
                 "Date",
                 datetime.datetime(1987, 7, 27, tzinfo=datetime.timezone.utc),
                 "1987-07-27T00:00:00.000000+0000",
-                "[Date Value Attribute]",
             ),
-            pytest.param("Bool", False, None, "[Boolean Value Attribute]"),
-            pytest.param("Bool", True, "true", "[Boolean Value Attribute]"),
+            pytest.param("Bool", False, None),
+            pytest.param("Bool", True, "true"),
         ],
     )
     def test_create_requirements_attributes_with_non_default_values(
@@ -471,7 +469,6 @@ class TestReqIFModification:
         type_hint: str,
         value: t.Any,
         xml: str | None,
-        expected_repr_name: str,
     ):
         req = model.by_uuid("79291c33-5147-4543-9398-9077d582576d")
 
@@ -485,7 +482,6 @@ class TestReqIFModification:
         assert req.attributes == [value_attr]
         assert value_attr.value == value
         assert value_attr._element.get("value") == xml
-        assert expected_repr_name in repr(value_attr)
 
     def test_create_value_attribute_on_requirements_without_definition(
         self, model: capellambse.MelodyModel
@@ -500,6 +496,27 @@ class TestReqIFModification:
         assert req.attributes[0] == attr
         assert attr.definition is None
         assert isinstance(attr, reqif.AbstractRequirementsAttribute)
+
+    @pytest.mark.parametrize(
+        "type_hint",
+        [
+            pytest.param("Integer"),
+            pytest.param("String"),
+            pytest.param("Real"),
+            pytest.param("Date"),
+            pytest.param("Boolean"),
+        ],
+    )
+    def test_requirements_attribute_value_default_reprs(
+        self, model: capellambse.MelodyModel, type_hint: str
+    ):
+        req = model.by_uuid("79291c33-5147-4543-9398-9077d582576d")
+
+        assert isinstance(req, reqif.Requirement)
+
+        attr = req.attributes.create(type_hint)
+
+        assert f"[{type_hint} Value Attribute]" in repr(attr)
 
     def test_create_enum_value_attribute_on_requirements(
         self, model: capellambse.MelodyModel


### PR DESCRIPTION
When there is no definition reference given, Capella displays AttributeValue elements with `[TYPE Value Attribute]` where the `TYPE` is exchanged with one of (Integer, String, Boolean,...). This commit implements this behavior and adds lines to `test_create_requirements_attributes`.