### PR TITLE
Add RequirementTypesFolder accessor to RequirementsModule

### DIFF
--- a/capellambse/extensions/reqif/elements.py
+++ b/capellambse/extensions/reqif/elements.py
@@ -717,6 +717,15 @@ def init() -> None:
         ),
     )
     c.set_accessor(
+        RequirementsModule,
+        "requirement_types_folders",
+        c.ProxyAccessor(
+            RequirementsTypesFolder,
+            XT_REQ_TYPES_F,
+            aslist=c.ElementList,
+        ),
+    )
+    c.set_accessor(
         crosslayer.BaseArchitectureLayer,
         "all_requirement_types",
         c.ProxyAccessor(


### PR DESCRIPTION
The `RequirementTypesFolder` can't be created underneath a `RequirementsModule`. But it can be moved there via the GUI. In this PR we added an Accessor to the `RequirementsModule` for `RequirementTypesFolder`s.