### PR TITLE
Split up the ProxyAccessor

### DIFF
--- a/capellambse/extensions/reqif/elements.py
+++ b/capellambse/extensions/reqif/elements.py
@@ -332,7 +332,7 @@ class AbstractRequirementsAttribute(c.GenericElement):
         return markupsafe.Markup(self._wrap_short_html(f" &quot;{name}&quot;"))
 
 
-class AttributeAccessor(c.ProxyAccessor[AbstractRequirementsAttribute]):
+class AttributeAccessor(c.DirectProxyAccessor[AbstractRequirementsAttribute]):
     def __init__(self) -> None:
         super().__init__(
             c.GenericElement,  # type: ignore[arg-type]
@@ -473,7 +473,7 @@ class EnumDataTypeDefinition(ReqIFElement):
 
     _xmltag = "ownedDefinitionTypes"
 
-    values = c.ProxyAccessor(
+    values = c.DirectProxyAccessor(
         EnumValue, XT_REQ_TYPE_ATTR_ENUM, aslist=c.ElementList
     )
 
@@ -514,7 +514,7 @@ class EnumerationValueAttribute(AbstractRequirementsAttribute):
 @c.attr_equal("long_name")
 class AbstractType(ReqIFElement):
     owner = c.ParentAccessor(c.GenericElement)
-    attribute_definitions = c.ProxyAccessor(
+    attribute_definitions = c.DirectProxyAccessor(
         c.GenericElement,
         (XT_REQ_TYPE_ATTR_DEF, XT_REQ_TYPE_ENUM_DEF),
         aslist=c.MixedElementList,
@@ -572,7 +572,7 @@ class RequirementsFolder(Requirement):
     _xmltag = "ownedRequirements"
 
     folders: c.Accessor
-    requirements = c.ProxyAccessor(
+    requirements = c.DirectProxyAccessor(
         Requirement, XT_REQUIREMENT, aslist=c.ElementList
     )
 
@@ -583,10 +583,10 @@ class RequirementsModule(ReqIFElement):
 
     _xmltag = "ownedExtensions"
 
-    folders = c.ProxyAccessor(
+    folders = c.DirectProxyAccessor(
         RequirementsFolder, XT_FOLDER, aslist=c.ElementList
     )
-    requirements = c.ProxyAccessor(
+    requirements = c.DirectProxyAccessor(
         Requirement, XT_REQUIREMENT, aslist=c.ElementList
     )
     type = c.AttrProxyAccessor(ModuleType, "moduleType")
@@ -668,18 +668,18 @@ class RequirementsIntRelation(AbstractRequirementsRelation):
 class RequirementsTypesFolder(ReqIFElement):
     _xmltag = "ownedExtensions"
 
-    data_type_definitions = c.ProxyAccessor(
+    data_type_definitions = c.DirectProxyAccessor(
         c.GenericElement,
         (XT_REQ_TYPES_DATA_DEF, XT_REQ_TYPE_ENUM),
         aslist=c.MixedElementList,
     )
-    module_types = c.ProxyAccessor(
+    module_types = c.DirectProxyAccessor(
         ModuleType, XT_MODULE_TYPE, aslist=c.ElementList
     )
-    relation_types = c.ProxyAccessor(
+    relation_types = c.DirectProxyAccessor(
         RelationType, XT_RELATION_TYPE, aslist=c.ElementList
     )
-    requirement_types = c.ProxyAccessor(
+    requirement_types = c.DirectProxyAccessor(
         RequirementType, XT_REQ_TYPE, aslist=c.ElementList
     )
 
@@ -688,29 +688,32 @@ def init() -> None:
     c.set_accessor(
         RequirementsFolder,
         "folders",
-        c.ProxyAccessor(RequirementsFolder, XT_FOLDER, aslist=c.ElementList),
+        c.DirectProxyAccessor(
+            RequirementsFolder, XT_FOLDER, aslist=c.ElementList
+        ),
     )
     c.set_accessor(c.GenericElement, "requirements", ElementRelationAccessor())
     c.set_accessor(
         crosslayer.BaseArchitectureLayer,
         "requirement_modules",
-        c.ProxyAccessor(RequirementsModule, XT_MODULE, aslist=c.ElementList),
+        c.DirectProxyAccessor(
+            RequirementsModule, XT_MODULE, aslist=c.ElementList
+        ),
     )
     c.set_accessor(
         crosslayer.BaseArchitectureLayer,
         "all_requirements",
-        c.ProxyAccessor(
+        c.DeepProxyAccessor(
             Requirement,
             XT_REQUIREMENT,
             aslist=c.ElementList,
             rootelem=XT_MODULE,
-            deep=True,
         ),
     )
     c.set_accessor(
         crosslayer.BaseArchitectureLayer,
         "requirement_types_folders",
-        c.ProxyAccessor(
+        c.DirectProxyAccessor(
             RequirementsTypesFolder,
             XT_REQ_TYPES_F,
             aslist=c.ElementList,
@@ -719,7 +722,7 @@ def init() -> None:
     c.set_accessor(
         RequirementsModule,
         "requirement_types_folders",
-        c.ProxyAccessor(
+        c.DirectProxyAccessor(
             RequirementsTypesFolder,
             XT_REQ_TYPES_F,
             aslist=c.ElementList,
@@ -728,34 +731,31 @@ def init() -> None:
     c.set_accessor(
         crosslayer.BaseArchitectureLayer,
         "all_requirement_types",
-        c.ProxyAccessor(
+        c.DeepProxyAccessor(
             RequirementType,
             XT_REQ_TYPE,
             aslist=c.ElementList,
             rootelem=XT_REQ_TYPES_F,
-            deep=True,
         ),
     )
     c.set_accessor(
         crosslayer.BaseArchitectureLayer,
         "all_module_types",
-        c.ProxyAccessor(
+        c.DeepProxyAccessor(
             ModuleType,
             XT_MODULE_TYPE,
             aslist=c.ElementList,
             rootelem=XT_REQ_TYPES_F,
-            deep=True,
         ),
     )
     c.set_accessor(
         crosslayer.BaseArchitectureLayer,
         "all_relation_types",
-        c.ProxyAccessor(
+        c.DeepProxyAccessor(
             RelationType,
             XT_RELATION_TYPE,
             aslist=c.ElementList,
             rootelem=XT_REQ_TYPES_F,
-            deep=True,
         ),
     )
 

--- a/capellambse/model/__init__.py
+++ b/capellambse/model/__init__.py
@@ -39,10 +39,12 @@ class MelodyModel:
     aspects.
     """
 
-    oa = common.ProxyAccessor(oa.OperationalAnalysis, rootelem=XT_SYSENG)
-    sa = common.ProxyAccessor(ctx.SystemAnalysis, rootelem=XT_SYSENG)
-    la = common.ProxyAccessor(la.LogicalArchitecture, rootelem=XT_SYSENG)
-    pa = common.ProxyAccessor(pa.PhysicalArchitecture, rootelem=XT_SYSENG)
+    oa = common.DirectProxyAccessor(oa.OperationalAnalysis, rootelem=XT_SYSENG)
+    sa = common.DirectProxyAccessor(ctx.SystemAnalysis, rootelem=XT_SYSENG)
+    la = common.DirectProxyAccessor(la.LogicalArchitecture, rootelem=XT_SYSENG)
+    pa = common.DirectProxyAccessor(
+        pa.PhysicalArchitecture, rootelem=XT_SYSENG
+    )
     diagrams = diagram.DiagramAccessor(
         None, cacheattr="_MelodyModel__diagram_cache"
     )

--- a/capellambse/model/common/__init__.py
+++ b/capellambse/model/common/__init__.py
@@ -81,7 +81,7 @@ def set_accessor(
 
 def set_self_references(*args: tuple[type[GenericElement], str]) -> None:
     for cls, attr in args:
-        set_accessor(cls, attr, ProxyAccessor(cls, aslist=ElementList))
+        set_accessor(cls, attr, DirectProxyAccessor(cls, aslist=ElementList))
 
 
 def xtype_handler(  # pylint: disable=keyword-arg-before-vararg  # PEP-570

--- a/capellambse/model/crosslayer/__init__.py
+++ b/capellambse/model/crosslayer/__init__.py
@@ -14,27 +14,18 @@ class BaseArchitectureLayer(c.GenericElement):
 
     _xmltag = "ownedArchitectures"
 
-    data_package = c.ProxyAccessor(information.DataPkg)
-    interface_package = c.ProxyAccessor(cs.InterfacePkg)
+    data_package = c.DirectProxyAccessor(information.DataPkg)
+    interface_package = c.DirectProxyAccessor(cs.InterfacePkg)
 
-    all_classes = c.ProxyAccessor(
-        information.Class, deep=True, aslist=c.ElementList
+    all_classes = c.DeepProxyAccessor(information.Class, aslist=c.ElementList)
+    all_collections = c.DeepProxyAccessor(
+        information.Collection, aslist=c.ElementList
     )
-    all_collections = c.ProxyAccessor(
-        information.Collection, deep=True, aslist=c.ElementList
+    all_unions = c.DeepProxyAccessor(information.Union, aslist=c.ElementList)
+    all_enumerations = c.DeepProxyAccessor(
+        information.datatype.Enumeration, aslist=c.ElementList
     )
-    all_unions = c.ProxyAccessor(
-        information.Union, deep=True, aslist=c.ElementList
+    all_complex_values = c.DeepProxyAccessor(
+        information.datavalue.ComplexValue, aslist=c.ElementList
     )
-    all_enumerations = c.ProxyAccessor(
-        information.datatype.Enumeration, deep=True, aslist=c.ElementList
-    )
-    all_complex_values = c.ProxyAccessor(
-        information.datavalue.ComplexValue,
-        deep=True,
-        aslist=c.ElementList,
-        follow_abstract=False,
-    )
-    all_interfaces = c.ProxyAccessor(
-        cs.Interface, deep=True, aslist=c.ElementList
-    )
+    all_interfaces = c.DeepProxyAccessor(cs.Interface, aslist=c.ElementList)

--- a/capellambse/model/crosslayer/capellacommon.py
+++ b/capellambse/model/crosslayer/capellacommon.py
@@ -27,7 +27,7 @@ class AbstractStateMode(c.GenericElement):
 
     _xmltag = "ownedStates"
 
-    regions = c.ProxyAccessor(Region, aslist=c.ElementList)
+    regions = c.DirectProxyAccessor(Region, aslist=c.ElementList)
 
     functions: c.Accessor
 
@@ -83,7 +83,7 @@ class StateMachine(c.GenericElement):
 
     _xmltag = "ownedStateMachines"
 
-    regions = c.ProxyAccessor(Region, aslist=c.ElementList)
+    regions = c.DirectProxyAccessor(Region, aslist=c.ElementList)
 
 
 @c.xtype_handler(None)
@@ -115,7 +115,7 @@ class GenericTrace(c.GenericElement):
 c.set_accessor(
     AbstractStateMode,
     "realized_states",
-    c.ProxyAccessor(
+    c.ReferencingProxyAccessor(
         c.GenericElement,
         XT_ABSTRACT_STATE_REAL,
         follow="targetElement",
@@ -146,14 +146,16 @@ c.set_accessor(
     "states",
     c.RoleTagAccessor(AbstractStateMode._xmltag, aslist=c.ElementList),
 )
-c.set_accessor(Region, "modes", c.ProxyAccessor(Mode, aslist=c.ElementList))
+c.set_accessor(
+    Region, "modes", c.DirectProxyAccessor(Mode, aslist=c.ElementList)
+)
 c.set_accessor(
     Region,
     "transitions",
-    c.ProxyAccessor(StateTransition, aslist=c.ElementList),
+    c.DirectProxyAccessor(StateTransition, aslist=c.ElementList),
 )
 c.set_accessor(
     c.GenericElement,
     "traces",
-    c.ProxyAccessor(GenericTrace, aslist=c.ElementList),
+    c.DirectProxyAccessor(GenericTrace, aslist=c.ElementList),
 )

--- a/capellambse/model/crosslayer/capellacore.py
+++ b/capellambse/model/crosslayer/capellacore.py
@@ -29,5 +29,5 @@ class Generalization(c.GenericElement):
 c.set_accessor(
     c.GenericElement,
     "constraints",
-    c.ProxyAccessor(Constraint, aslist=c.ElementList),
+    c.DirectProxyAccessor(Constraint, aslist=c.ElementList),
 )

--- a/capellambse/model/crosslayer/cs.py
+++ b/capellambse/model/crosslayer/cs.py
@@ -45,11 +45,10 @@ class Interface(c.GenericElement):
 class InterfacePkg(c.GenericElement):
     """A package that can hold interfaces and exchange items."""
 
-    exchange_items = c.ProxyAccessor(
-        information.ExchangeItem,
-        aslist=c.ElementList,
+    exchange_items = c.DirectProxyAccessor(
+        information.ExchangeItem, aslist=c.ElementList
     )
-    interfaces = c.ProxyAccessor(Interface, aslist=c.ElementList)
+    interfaces = c.DirectProxyAccessor(Interface, aslist=c.ElementList)
 
     packages: c.Accessor
 
@@ -70,7 +69,7 @@ class PhysicalLink(PhysicalPort):
     linkEnds = c.AttrProxyAccessor(
         PhysicalPort, "linkEnds", aslist=c.ElementList
     )
-    exchanges = c.ProxyAccessor(
+    exchanges = c.ReferencingProxyAccessor(
         fa.ComponentExchange,
         xtypes=fa.XT_COMP_EX_ALLOC,
         aslist=c.ElementList,
@@ -86,13 +85,13 @@ class PhysicalPath(c.GenericElement):
 
     _xmltag = "ownedPhysicalPath"
 
-    involved_items = c.ProxyAccessor(
+    involved_items = c.ReferencingProxyAccessor(
         c.GenericElement,
         xtypes=XT_PHYS_PATH_INV,
         aslist=c.MixedElementList,
         follow="involved",
     )
-    exchanges = c.ProxyAccessor(
+    exchanges = c.ReferencingProxyAccessor(
         fa.ComponentExchange,
         xtypes=fa.XT_COMP_EX_ALLOC,
         aslist=c.ElementList,
@@ -120,14 +119,14 @@ class Component(c.GenericElement):
     )
 
     owner = c.ParentAccessor(c.GenericElement)
-    state_machines = c.ProxyAccessor(
+    state_machines = c.DirectProxyAccessor(
         capellacommon.StateMachine, aslist=c.ElementList
     )
-    ports = c.ProxyAccessor(fa.ComponentPort, aslist=c.ElementList)
-    physical_ports = c.ProxyAccessor(PhysicalPort, aslist=c.ElementList)
+    ports = c.DirectProxyAccessor(fa.ComponentPort, aslist=c.ElementList)
+    physical_ports = c.DirectProxyAccessor(PhysicalPort, aslist=c.ElementList)
     parts = c.ReferenceSearchingAccessor(Part, "type", aslist=c.ElementList)
-    physical_paths = c.ProxyAccessor(PhysicalPath, aslist=c.ElementList)
-    physical_links = c.ProxyAccessor(PhysicalLink, aslist=c.ElementList)
+    physical_paths = c.DirectProxyAccessor(PhysicalPath, aslist=c.ElementList)
+    physical_links = c.DirectProxyAccessor(PhysicalLink, aslist=c.ElementList)
     exchanges = c.ReferenceSearchingAccessor(
         fa.ComponentExchange,
         "source.owner",
@@ -146,17 +145,13 @@ class ComponentRealization(c.GenericElement):
 c.set_accessor(
     InterfacePkg,
     "packages",
-    c.ProxyAccessor(InterfacePkg, aslist=c.ElementList),
+    c.DirectProxyAccessor(InterfacePkg, aslist=c.ElementList),
 )
 c.set_accessor(
     Part,
     "deployed_parts",
-    c.ProxyAccessor(
-        Part,
-        XT_DEPLOY_LINK,
-        aslist=c.ElementList,
-        follow="deployedElement",
-        follow_abstract=False,
+    c.ReferencingProxyAccessor(
+        Part, XT_DEPLOY_LINK, aslist=c.ElementList, follow="deployedElement"
     ),
 )
 c.set_accessor(

--- a/capellambse/model/crosslayer/fa.py
+++ b/capellambse/model/crosslayer/fa.py
@@ -96,7 +96,7 @@ class FunctionPort(c.GenericElement):
 
     owner = c.ParentAccessor(c.GenericElement)
     exchanges: c.Accessor
-    state_machines = c.ProxyAccessor(
+    state_machines = c.DirectProxyAccessor(
         capellacommon.StateMachine, aslist=c.ElementList
     )
 
@@ -128,8 +128,8 @@ class Function(AbstractFunction):
 
     is_leaf = property(lambda self: not self.functions)
 
-    inputs = c.ProxyAccessor(FunctionInputPort, aslist=c.ElementList)
-    outputs = c.ProxyAccessor(FunctionOutputPort, aslist=c.ElementList)
+    inputs = c.DirectProxyAccessor(FunctionInputPort, aslist=c.ElementList)
+    outputs = c.DirectProxyAccessor(FunctionOutputPort, aslist=c.ElementList)
 
     functions: c.Accessor
     packages: c.Accessor
@@ -179,10 +179,10 @@ class FunctionalChain(c.GenericElement):
 
     _xmltag = "ownedFunctionalChains"
 
-    involved = c.ProxyAccessor(
+    involved = c.ReferencingProxyAccessor(
         c.GenericElement, XT_FCI, aslist=c.MixedElementList, follow="involved"
     )
-    involvements = c.ProxyAccessor(
+    involvements = c.DirectProxyAccessor(
         c.GenericElement, XT_FCI, aslist=c.ElementList
     )
 
@@ -206,7 +206,7 @@ class ComponentExchange(AbstractExchange):
 
     _xmltag = "ownedComponentExchanges"
 
-    allocated_functional_exchanges = c.ProxyAccessor(
+    allocated_functional_exchanges = c.ReferencingProxyAccessor(
         FunctionalExchange,
         XT_COMP_EX_FNC_EX_ALLOC,
         aslist=c.ElementList,

--- a/capellambse/model/crosslayer/information/__init__.py
+++ b/capellambse/model/crosslayer/information/__init__.py
@@ -134,12 +134,10 @@ class Class(c.GenericElement):
     visibility = xmltools.EnumAttributeProperty(
         "_element", "visibility", modeltypes.VisibilityKind, default="UNSET"
     )
-    state_machines = c.ProxyAccessor(
+    state_machines = c.DirectProxyAccessor(
         capellacommon.StateMachine, aslist=c.ElementList
     )
-    owned_properties = c.ProxyAccessor(
-        Property, aslist=c.ElementList, follow_abstract=False
-    )
+    owned_properties = c.DirectProxyAccessor(Property, aslist=c.ElementList)
 
     @property
     def properties(self) -> c.ElementList[Property]:
@@ -180,12 +178,14 @@ class Collection(c.GenericElement):
 class DataPkg(c.GenericElement):
     """A data package that can hold classes."""
 
-    classes = c.ProxyAccessor(Class, aslist=c.ElementList)
-    unions = c.ProxyAccessor(Union, aslist=c.ElementList)
-    collections = c.ProxyAccessor(Collection, aslist=c.ElementList)
-    enumerations = c.ProxyAccessor(datatype.Enumeration, aslist=c.ElementList)
-    complex_values = c.ProxyAccessor(
-        datavalue.ComplexValue, aslist=c.ElementList, follow_abstract=False
+    classes = c.DirectProxyAccessor(Class, aslist=c.ElementList)
+    unions = c.DirectProxyAccessor(Union, aslist=c.ElementList)
+    collections = c.DirectProxyAccessor(Collection, aslist=c.ElementList)
+    enumerations = c.DirectProxyAccessor(
+        datatype.Enumeration, aslist=c.ElementList
+    )
+    complex_values = c.DirectProxyAccessor(
+        datavalue.ComplexValue, aslist=c.ElementList
     )
     packages: c.Accessor
 
@@ -212,11 +212,7 @@ class ExchangeItem(c.GenericElement):
         modeltypes.ExchangeItemType,
         default="UNSET",
     )
-    elements = c.ProxyAccessor(
-        ExchangeItemElement,
-        aslist=c.ElementList,
-        follow_abstract=False,
-    )
+    elements = c.DirectProxyAccessor(ExchangeItemElement, aslist=c.ElementList)
     exchanges = c.CustomAccessor(
         c.GenericElement,
         _search_all_exchanges,
@@ -229,11 +225,8 @@ for cls in [Class, Union, datatype.Enumeration, Collection]:
     c.set_accessor(
         cls,
         "super",
-        c.ProxyAccessor(
-            cls,
-            capellacore.Generalization,
-            follow="super",
-            follow_abstract=False,
+        c.ReferencingProxyAccessor(
+            cls, capellacore.Generalization, follow="super"
         ),
     )
     c.set_accessor(
@@ -248,6 +241,6 @@ c.set_accessor(
     c.ParentAccessor(datatype.Enumeration),
 )
 c.set_accessor(
-    DataPkg, "packages", c.ProxyAccessor(DataPkg, aslist=c.ElementList)
+    DataPkg, "packages", c.DirectProxyAccessor(DataPkg, aslist=c.ElementList)
 )
 c.set_accessor(ExchangeItemElement, "owner", c.ParentAccessor(ExchangeItem))

--- a/capellambse/model/crosslayer/information/datatype.py
+++ b/capellambse/model/crosslayer/information/datatype.py
@@ -13,10 +13,8 @@ class Enumeration(c.GenericElement):
 
     _xmltag = "ownedDataTypes"
 
-    owned_literals = c.ProxyAccessor(
-        datavalue.EnumerationLiteral,
-        aslist=c.ElementList,
-        follow_abstract=False,
+    owned_literals = c.DirectProxyAccessor(
+        datavalue.EnumerationLiteral, aslist=c.ElementList
     )
 
     sub: c.Accessor

--- a/capellambse/model/crosslayer/information/datavalue.py
+++ b/capellambse/model/crosslayer/information/datavalue.py
@@ -50,7 +50,7 @@ class ComplexValue(c.GenericElement):
     _xmltag = "ownedDataValues"
 
     type = c.AttrProxyAccessor(c.GenericElement, "abstractType")
-    value_parts = c.ProxyAccessor(ValuePart, aslist=c.ElementList)
+    value_parts = c.DirectProxyAccessor(ValuePart, aslist=c.ElementList)
 
 
 @c.attr_equal("name")

--- a/capellambse/model/layers/ctx.py
+++ b/capellambse/model/layers/ctx.py
@@ -24,7 +24,7 @@ class SystemFunction(fa.Function):
 
     _xmltag = "ownedFunctions"
 
-    realized_operational_activities = c.ProxyAccessor(
+    realized_operational_activities = c.ReferencingProxyAccessor(
         oa.OperationalActivity,
         fa.FunctionRealization,
         aslist=c.ElementList,
@@ -40,7 +40,7 @@ class SystemFunctionPkg(c.GenericElement):
 
     _xmltag = "ownedFunctionPkg"
 
-    functions = c.ProxyAccessor(SystemFunction, aslist=c.ElementList)
+    functions = c.DirectProxyAccessor(SystemFunction, aslist=c.ElementList)
     packages: c.Accessor
 
 
@@ -50,13 +50,13 @@ class SystemComponent(cs.Component):
 
     _xmltag = "ownedSystemComponents"
 
-    allocated_functions = c.ProxyAccessor(
+    allocated_functions = c.ReferencingProxyAccessor(
         SystemFunction,
         fa.XT_FCALLOC,
         follow="targetElement",
         aslist=c.ElementList,
     )
-    realized_operational_entities = c.ProxyAccessor(
+    realized_operational_entities = c.ReferencingProxyAccessor(
         oa.Entity,
         cs.ComponentRealization,
         aslist=c.ElementList,
@@ -70,8 +70,8 @@ class SystemComponentPkg(c.GenericElement):
 
     _xmltag = "ownedSystemComponentPkg"
 
-    components = c.ProxyAccessor(SystemComponent, aslist=c.ElementList)
-    state_machines = c.ProxyAccessor(
+    components = c.DirectProxyAccessor(SystemComponent, aslist=c.ElementList)
+    state_machines = c.DirectProxyAccessor(
         capellacommon.StateMachine, aslist=c.ElementList
     )
 
@@ -89,38 +89,40 @@ class Capability(c.GenericElement):
 
     _xmltag = "ownedCapabilities"
 
-    extends = c.ProxyAccessor(
+    extends = c.DirectProxyAccessor(
         interaction.AbstractCapabilityExtend, aslist=c.ElementList
     )
-    includes = c.ProxyAccessor(
+    includes = c.DirectProxyAccessor(
         interaction.AbstractCapabilityInclude, aslist=c.ElementList
     )
-    generalizes = c.ProxyAccessor(
+    generalizes = c.DirectProxyAccessor(
         interaction.AbstractCapabilityGeneralization, aslist=c.ElementList
     )
-    owned_chains = c.ProxyAccessor(fa.FunctionalChain, aslist=c.ElementList)
-    involved_functions = c.ProxyAccessor(
+    owned_chains = c.DirectProxyAccessor(
+        fa.FunctionalChain, aslist=c.ElementList
+    )
+    involved_functions = c.ReferencingProxyAccessor(
         SystemFunction,
         interaction.XT_CAP2ACT,
         aslist=c.ElementList,
         follow="involved",
     )
-    involved_chains = c.ProxyAccessor(
+    involved_chains = c.ReferencingProxyAccessor(
         fa.FunctionalChain,
         interaction.XT_CAP2PROC,
         aslist=c.ElementList,
         follow="involved",
     )
-    involved_components = c.ProxyAccessor(
+    involved_components = c.ReferencingProxyAccessor(
         SystemComponent,
         xtypes=CapabilityInvolvement,
         follow="involved",
         aslist=c.MixedElementList,
     )
-    component_involvements = c.ProxyAccessor(
+    component_involvements = c.DirectProxyAccessor(
         CapabilityInvolvement, aslist=c.ElementList
     )
-    realized_capabilities = c.ProxyAccessor(
+    realized_capabilities = c.ReferencingProxyAccessor(
         oa.OperationalCapability,
         interaction.XT_CAP_REAL,
         follow="targetElement",
@@ -131,7 +133,9 @@ class Capability(c.GenericElement):
         capellacore.Constraint, "postCondition"
     )
     precondition = c.AttrProxyAccessor(capellacore.Constraint, "preCondition")
-    scenarios = c.ProxyAccessor(interaction.Scenario, aslist=c.ElementList)
+    scenarios = c.DirectProxyAccessor(
+        interaction.Scenario, aslist=c.ElementList
+    )
     states = c.AttrProxyAccessor(
         capellacommon.State, "availableInStates", aslist=c.ElementList
     )
@@ -165,14 +169,16 @@ class Mission(c.GenericElement):
 
     _xmltag = "ownedMissions"
 
-    involvements = c.ProxyAccessor(MissionInvolvement, aslist=c.ElementList)
-    exploits = c.ProxyAccessor(
+    involvements = c.DirectProxyAccessor(
+        MissionInvolvement, aslist=c.ElementList
+    )
+    exploits = c.ReferencingProxyAccessor(
         Capability,
         xtypes=CapabilityExploitation,
         follow="capability",
         aslist=c.ElementList,
     )
-    exploitations = c.ProxyAccessor(
+    exploitations = c.DirectProxyAccessor(
         CapabilityExploitation, aslist=c.ElementList
     )
 
@@ -183,7 +189,7 @@ class MissionPkg(c.GenericElement):
 
     _xmltag = "ownedMissionPkg"
 
-    missions = c.ProxyAccessor(Mission, aslist=c.ElementList)
+    missions = c.DirectProxyAccessor(Mission, aslist=c.ElementList)
     packages: c.Accessor
 
 
@@ -193,7 +199,7 @@ class CapabilityPkg(c.GenericElement):
 
     _xmltag = "ownedAbstractCapabilityPkg"
 
-    capabilities = c.ProxyAccessor(Capability, aslist=c.ElementList)
+    capabilities = c.DirectProxyAccessor(Capability, aslist=c.ElementList)
 
     packages: c.Accessor
 
@@ -207,54 +213,44 @@ class SystemAnalysis(crosslayer.BaseArchitectureLayer):
         attributes={"is_actor": False},
         rootelem=SystemComponentPkg,
     )
-    root_function = c.ProxyAccessor(SystemFunction, rootelem=SystemFunctionPkg)
+    root_function = c.DirectProxyAccessor(
+        SystemFunction, rootelem=SystemFunctionPkg
+    )
 
-    function_package = c.ProxyAccessor(SystemFunctionPkg)
-    capability_package = c.ProxyAccessor(CapabilityPkg)
-    component_package = c.ProxyAccessor(SystemComponentPkg)
-    mission_package = c.ProxyAccessor(MissionPkg)
+    function_package = c.DirectProxyAccessor(SystemFunctionPkg)
+    capability_package = c.DirectProxyAccessor(CapabilityPkg)
+    component_package = c.DirectProxyAccessor(SystemComponentPkg)
+    mission_package = c.DirectProxyAccessor(MissionPkg)
 
-    all_functions = c.ProxyAccessor(
-        SystemFunction, deep=True, aslist=c.ElementList
-    )
-    all_capabilities = c.ProxyAccessor(
-        Capability, deep=True, aslist=c.ElementList
-    )
-    all_components = c.ProxyAccessor(
-        SystemComponent, deep=True, aslist=c.ElementList
-    )
+    all_functions = c.DeepProxyAccessor(SystemFunction, aslist=c.ElementList)
+    all_capabilities = c.DeepProxyAccessor(Capability, aslist=c.ElementList)
+    all_components = c.DeepProxyAccessor(SystemComponent, aslist=c.ElementList)
     all_actors = property(
         lambda self: self._model.search(SystemComponent).by_is_actor(True)
     )
-    all_missions = c.ProxyAccessor(Mission, deep=True, aslist=c.ElementList)
+    all_missions = c.DeepProxyAccessor(Mission, aslist=c.ElementList)
 
-    actor_exchanges = c.ProxyAccessor(
+    actor_exchanges = c.DirectProxyAccessor(
         fa.ComponentExchange,
         aslist=c.ElementList,
         rootelem=SystemComponentPkg,
     )
-    component_exchanges = c.ProxyAccessor(
+    component_exchanges = c.DeepProxyAccessor(
         fa.ComponentExchange,
         aslist=c.ElementList,
         rootelem=[SystemComponentPkg, SystemComponent],
-        deep=True,
     )
 
-    all_capability_exploitations = c.ProxyAccessor(
-        CapabilityExploitation,
-        aslist=c.ElementList,
-        deep=True,
+    all_capability_exploitations = c.DeepProxyAccessor(
+        CapabilityExploitation, aslist=c.ElementList
     )
-    all_function_exchanges = c.ProxyAccessor(
+    all_function_exchanges = c.DeepProxyAccessor(
         fa.FunctionalExchange,
         aslist=c.ElementList,
         rootelem=[SystemFunctionPkg, SystemFunction],
-        deep=True,
     )
-    all_component_exchanges = c.ProxyAccessor(
-        fa.ComponentExchange,
-        aslist=c.ElementList,
-        deep=True,
+    all_component_exchanges = c.DeepProxyAccessor(
+        fa.ComponentExchange, aslist=c.ElementList
     )
 
     diagrams = diagram.DiagramAccessor(
@@ -274,10 +270,7 @@ c.set_accessor(
 c.set_accessor(
     SystemFunction,
     "packages",
-    c.ProxyAccessor(
-        SystemFunctionPkg,
-        aslist=c.ElementList,
-    ),
+    c.DirectProxyAccessor(SystemFunctionPkg, aslist=c.ElementList),
 )
 c.set_accessor(
     oa.OperationalCapability,

--- a/capellambse/model/layers/la.py
+++ b/capellambse/model/layers/la.py
@@ -23,7 +23,7 @@ class LogicalFunction(fa.Function):
 
     _xmltag = "ownedLogicalFunctions"
 
-    realized_system_functions = c.ProxyAccessor(
+    realized_system_functions = c.ReferencingProxyAccessor(
         ctx.SystemFunction,
         fa.FunctionRealization,
         aslist=c.ElementList,
@@ -48,7 +48,7 @@ class LogicalFunctionPkg(c.GenericElement):
 
     _xmltag = "ownedFunctionPkg"
 
-    functions = c.ProxyAccessor(LogicalFunction, aslist=c.ElementList)
+    functions = c.DirectProxyAccessor(LogicalFunction, aslist=c.ElementList)
 
     packages: c.Accessor
 
@@ -59,13 +59,13 @@ class LogicalComponent(cs.Component):
 
     _xmltag = "ownedLogicalComponents"
 
-    functions = c.ProxyAccessor(
+    functions = c.ReferencingProxyAccessor(
         LogicalFunction,
         fa.XT_FCALLOC,
         aslist=c.ElementList,
         follow="targetElement",
     )
-    realized_components = c.ProxyAccessor(
+    realized_components = c.ReferencingProxyAccessor(
         ctx.SystemComponent,
         cs.ComponentRealization,
         aslist=c.ElementList,
@@ -81,8 +81,8 @@ class LogicalComponentPkg(c.GenericElement):
 
     _xmltag = "ownedLogicalComponentPkg"
 
-    components = c.ProxyAccessor(LogicalComponent, aslist=c.ElementList)
-    state_machines = c.ProxyAccessor(
+    components = c.DirectProxyAccessor(LogicalComponent, aslist=c.ElementList)
+    state_machines = c.DirectProxyAccessor(
         capellacommon.StateMachine, aslist=c.ElementList
     )
 
@@ -95,26 +95,28 @@ class CapabilityRealization(c.GenericElement):
 
     _xmltag = "ownedCapabilityRealizations"
 
-    owned_chains = c.ProxyAccessor(fa.FunctionalChain, aslist=c.ElementList)
-    involved_functions = c.ProxyAccessor(
+    owned_chains = c.DirectProxyAccessor(
+        fa.FunctionalChain, aslist=c.ElementList
+    )
+    involved_functions = c.ReferencingProxyAccessor(
         LogicalFunction,
         interaction.XT_CAP2ACT,
         aslist=c.ElementList,
         follow="involved",
     )
-    involved_chains = c.ProxyAccessor(
+    involved_chains = c.ReferencingProxyAccessor(
         fa.FunctionalChain,
         interaction.XT_CAP2PROC,
         aslist=c.ElementList,
         follow="involved",
     )
-    involved_components = c.ProxyAccessor(
+    involved_components = c.ReferencingProxyAccessor(
         LogicalComponent,
         xtypes=ctx.CapabilityInvolvement,
         follow="involved",
         aslist=c.MixedElementList,
     )
-    realized_capabilities = c.ProxyAccessor(
+    realized_capabilities = c.ReferencingProxyAccessor(
         ctx.Capability,
         interaction.XT_CAP_REAL,
         follow="targetElement",
@@ -125,7 +127,9 @@ class CapabilityRealization(c.GenericElement):
         capellacore.Constraint, "postCondition"
     )
     precondition = c.AttrProxyAccessor(capellacore.Constraint, "preCondition")
-    scenarios = c.ProxyAccessor(interaction.Scenario, aslist=c.ElementList)
+    scenarios = c.DirectProxyAccessor(
+        interaction.Scenario, aslist=c.ElementList
+    )
     states = c.AttrProxyAccessor(
         capellacommon.State, "availableInStates", aslist=c.ElementList
     )
@@ -139,7 +143,9 @@ class CapabilityRealizationPkg(c.GenericElement):
 
     _xmltag = "ownedAbstractCapabilityPkg"
 
-    capabilities = c.ProxyAccessor(CapabilityRealization, aslist=c.ElementList)
+    capabilities = c.DirectProxyAccessor(
+        CapabilityRealization, aslist=c.ElementList
+    )
 
     packages: c.Accessor
 
@@ -153,52 +159,47 @@ class LogicalArchitecture(crosslayer.BaseArchitectureLayer):
         attributes={"is_actor": False},
         rootelem=LogicalComponentPkg,
     )
-    root_function = c.ProxyAccessor(
+    root_function = c.DirectProxyAccessor(
         LogicalFunction, rootelem=LogicalFunctionPkg
     )
 
-    function_package = c.ProxyAccessor(LogicalFunctionPkg)
-    component_package = c.ProxyAccessor(LogicalComponentPkg)
-    capability_package = c.ProxyAccessor(CapabilityRealizationPkg)
+    function_package = c.DirectProxyAccessor(LogicalFunctionPkg)
+    component_package = c.DirectProxyAccessor(LogicalComponentPkg)
+    capability_package = c.DirectProxyAccessor(CapabilityRealizationPkg)
 
-    all_functions = c.ProxyAccessor(
+    all_functions = c.DeepProxyAccessor(
         LogicalFunction,
         aslist=c.ElementList,
         rootelem=LogicalFunctionPkg,
-        deep=True,
     )
-    all_capabilities = c.ProxyAccessor(
-        CapabilityRealization, deep=True, aslist=c.ElementList
+    all_capabilities = c.DeepProxyAccessor(
+        CapabilityRealization, aslist=c.ElementList
     )
-    all_components = c.ProxyAccessor(  # maybe this should exclude .is_actor
-        LogicalComponent, aslist=c.ElementList, deep=True
+    all_components = (  # maybe this should exclude .is_actor
+        c.DeepProxyAccessor(LogicalComponent, aslist=c.ElementList)
     )
     all_actors = property(
         lambda self: self._model.search(LogicalComponent).by_is_actor(True)
     )
 
-    actor_exchanges = c.ProxyAccessor(
+    actor_exchanges = c.DirectProxyAccessor(
         fa.ComponentExchange,
         aslist=c.ElementList,
         rootelem=LogicalComponentPkg,
     )
-    component_exchanges = c.ProxyAccessor(
+    component_exchanges = c.DeepProxyAccessor(
         fa.ComponentExchange,
         aslist=c.ElementList,
         rootelem=[LogicalComponentPkg, LogicalComponent],
-        deep=True,
     )
 
-    all_function_exchanges = c.ProxyAccessor(
+    all_function_exchanges = c.DeepProxyAccessor(
         fa.FunctionalExchange,
         aslist=c.ElementList,
         rootelem=[LogicalFunctionPkg, LogicalFunction],
-        deep=True,
     )
-    all_component_exchanges = c.ProxyAccessor(
-        fa.ComponentExchange,
-        aslist=c.ElementList,
-        deep=True,
+    all_component_exchanges = c.DeepProxyAccessor(
+        fa.ComponentExchange, aslist=c.ElementList
     )
 
     diagrams = diagram.DiagramAccessor(
@@ -239,7 +240,7 @@ c.set_accessor(
 c.set_accessor(
     LogicalFunction,
     "packages",
-    c.ProxyAccessor(
+    c.DirectProxyAccessor(
         LogicalFunctionPkg,
         aslist=c.ElementList,
     ),

--- a/capellambse/model/layers/oa.py
+++ b/capellambse/model/layers/oa.py
@@ -74,43 +74,47 @@ class OperationalCapability(c.GenericElement):
 
     _xmltag = "ownedOperationalCapabilities"
 
-    extends = c.ProxyAccessor(
+    extends = c.DirectProxyAccessor(
         interaction.AbstractCapabilityExtend, aslist=c.ElementList
     )
-    includes = c.ProxyAccessor(
+    includes = c.DirectProxyAccessor(
         interaction.AbstractCapabilityInclude, aslist=c.ElementList
     )
-    generalizes = c.ProxyAccessor(
+    generalizes = c.DirectProxyAccessor(
         interaction.AbstractCapabilityGeneralization, aslist=c.ElementList
     )
-    involved_activities = c.ProxyAccessor(
+    involved_activities = c.ReferencingProxyAccessor(
         OperationalActivity,
         interaction.XT_CAP2ACT,
         aslist=c.ElementList,
         follow="involved",
     )
-    involved_entities = c.ProxyAccessor(
+    involved_entities = c.ReferencingProxyAccessor(
         c.GenericElement,
         XT_EOCI,
         follow="involved",
         aslist=c.MixedElementList,
     )
-    entity_involvements = c.ProxyAccessor(
+    entity_involvements = c.DirectProxyAccessor(
         EntityOperationalCapabilityInvolvement, aslist=c.ElementList
     )
-    involved_processes = c.ProxyAccessor(
+    involved_processes = c.ReferencingProxyAccessor(
         OperationalProcess,
         interaction.XT_CAP2PROC,
         aslist=c.ElementList,
         follow="involved",
     )
-    owned_processes = c.ProxyAccessor(OperationalProcess, aslist=c.ElementList)
+    owned_processes = c.DirectProxyAccessor(
+        OperationalProcess, aslist=c.ElementList
+    )
 
     postcondition = c.AttrProxyAccessor(
         capellacore.Constraint, "postCondition"
     )
     precondition = c.AttrProxyAccessor(capellacore.Constraint, "preCondition")
-    scenarios = c.ProxyAccessor(interaction.Scenario, aslist=c.ElementList)
+    scenarios = c.DirectProxyAccessor(
+        interaction.Scenario, aslist=c.ElementList
+    )
     states = c.AttrProxyAccessor(
         capellacommon.State, "availableInStates", aslist=c.ElementList
     )
@@ -124,7 +128,9 @@ class OperationalCapabilityPkg(c.GenericElement):
 
     _xmltag = "ownedAbstractCapabilityPkg"
 
-    capabilities = c.ProxyAccessor(OperationalCapability, aslist=c.ElementList)
+    capabilities = c.DirectProxyAccessor(
+        OperationalCapability, aslist=c.ElementList
+    )
 
     packages: c.Accessor
 
@@ -132,7 +138,7 @@ class OperationalCapabilityPkg(c.GenericElement):
 class AbstractEntity(cs.Component):
     """Common code for Entities."""
 
-    activities = c.ProxyAccessor(
+    activities = c.ReferencingProxyAccessor(
         OperationalActivity,
         fa.XT_FCALLOC,
         aslist=c.ElementList,
@@ -169,7 +175,9 @@ class OperationalActivityPkg(c.GenericElement):
 
     _xmltag = "ownedFunctionPkg"
 
-    activities = c.ProxyAccessor(OperationalActivity, aslist=c.ElementList)
+    activities = c.DirectProxyAccessor(
+        OperationalActivity, aslist=c.ElementList
+    )
 
     packages: c.Accessor
 
@@ -180,7 +188,7 @@ class CommunicationMean(fa.AbstractExchange):
 
     _xmltag = "ownedComponentExchanges"
 
-    allocated_interactions = c.ProxyAccessor(
+    allocated_interactions = c.ReferencingProxyAccessor(
         fa.FunctionalExchange,
         fa.XT_COMP_EX_FNC_EX_ALLOC,
         aslist=c.ElementList,
@@ -201,8 +209,8 @@ class EntityPkg(c.GenericElement):
 
     _xmltag = "ownedEntityPkg"
 
-    entities = c.ProxyAccessor(Entity, aslist=c.ElementList)
-    state_machines = c.ProxyAccessor(
+    entities = c.DirectProxyAccessor(Entity, aslist=c.ElementList)
+    state_machines = c.DirectProxyAccessor(
         capellacommon.StateMachine, aslist=c.ElementList
     )
 
@@ -213,49 +221,43 @@ class EntityPkg(c.GenericElement):
 class OperationalAnalysis(crosslayer.BaseArchitectureLayer):
     """Provides access to the OperationalAnalysis layer of the model."""
 
-    root_entity = c.ProxyAccessor(Entity, rootelem=EntityPkg)
-    root_activity = c.ProxyAccessor(
+    root_entity = c.DirectProxyAccessor(Entity, rootelem=EntityPkg)
+    root_activity = c.DirectProxyAccessor(
         OperationalActivity, rootelem=OperationalActivityPkg
     )
 
-    activity_package = c.ProxyAccessor(OperationalActivityPkg)
-    capability_package = c.ProxyAccessor(OperationalCapabilityPkg)
-    entity_package = c.ProxyAccessor(EntityPkg)
+    activity_package = c.DirectProxyAccessor(OperationalActivityPkg)
+    capability_package = c.DirectProxyAccessor(OperationalCapabilityPkg)
+    entity_package = c.DirectProxyAccessor(EntityPkg)
 
-    all_activities = c.ProxyAccessor(
+    all_activities = c.DeepProxyAccessor(
         OperationalActivity,
         aslist=c.ElementList,
-        deep=True,
     )
-    all_processes = c.ProxyAccessor(
+    all_processes = c.DeepProxyAccessor(
         OperationalProcess,
         aslist=c.ElementList,
-        deep=True,
     )
-    all_capabilities = c.ProxyAccessor(
+    all_capabilities = c.DeepProxyAccessor(
         OperationalCapability,
         aslist=c.ElementList,
-        deep=True,
     )
     all_actors = property(
         lambda self: self._model.search(Entity).by_is_actor(True)
     )
-    all_entities = c.ProxyAccessor(
+    all_entities = c.DeepProxyAccessor(
         Entity,
         aslist=c.ElementList,
-        deep=True,
     )
 
-    all_activity_exchanges = c.ProxyAccessor(
+    all_activity_exchanges = c.DeepProxyAccessor(
         fa.FunctionalExchange,
         aslist=c.ElementList,
         rootelem=[OperationalActivityPkg, OperationalActivity],
-        deep=True,
     )
-    all_entity_exchanges = c.ProxyAccessor(
+    all_entity_exchanges = c.DeepProxyAccessor(
         CommunicationMean,
         aslist=c.ElementList,
-        deep=True,
     )
 
     diagrams = diagram.DiagramAccessor(
@@ -266,10 +268,7 @@ class OperationalAnalysis(crosslayer.BaseArchitectureLayer):
 c.set_accessor(
     OperationalActivity,
     "packages",
-    c.ProxyAccessor(
-        OperationalActivityPkg,
-        aslist=c.ElementList,
-    ),
+    c.DirectProxyAccessor(OperationalActivityPkg, aslist=c.ElementList),
 )
 c.set_accessor(
     Entity,

--- a/capellambse/model/layers/pa.py
+++ b/capellambse/model/layers/pa.py
@@ -34,7 +34,7 @@ class PhysicalFunction(fa.Function):
         operator.attrgetter("_model.pa.all_components"),
         matchtransform=operator.attrgetter("functions"),
     )
-    realized_logical_functions = c.ProxyAccessor(
+    realized_logical_functions = c.ReferencingProxyAccessor(
         la.LogicalFunction,
         fa.FunctionRealization,
         aslist=c.ElementList,
@@ -48,7 +48,7 @@ class PhysicalFunctionPkg(c.GenericElement):
 
     _xmltag = "ownedFunctionPkg"
 
-    components = c.ProxyAccessor(PhysicalFunction, aslist=c.ElementList)
+    components = c.DirectProxyAccessor(PhysicalFunction, aslist=c.ElementList)
 
     packages: c.Accessor
 
@@ -66,13 +66,13 @@ class PhysicalComponent(cs.Component):
         "_element", "kind", modeltypes.Kind, default=modeltypes.Kind.UNSET
     )
 
-    functions = c.ProxyAccessor(
+    functions = c.ReferencingProxyAccessor(
         PhysicalFunction,
         fa.XT_FCALLOC,
         aslist=c.ElementList,
         follow="targetElement",
     )
-    realized_logical_components = c.ProxyAccessor(
+    realized_logical_components = c.ReferencingProxyAccessor(
         la.LogicalComponent,
         cs.ComponentRealization,
         aslist=c.ElementList,
@@ -104,8 +104,8 @@ class PhysicalComponentPkg(c.GenericElement):
 
     _xmltag = "ownedPhysicalComponentPkg"
 
-    components = c.ProxyAccessor(PhysicalComponent, aslist=c.ElementList)
-    state_machines = c.ProxyAccessor(
+    components = c.DirectProxyAccessor(PhysicalComponent, aslist=c.ElementList)
+    state_machines = c.DirectProxyAccessor(
         capellacommon.StateMachine, aslist=c.ElementList
     )
 
@@ -121,57 +121,52 @@ class PhysicalArchitecture(crosslayer.BaseArchitectureLayer):
         attributes={"is_actor": False},
         rootelem=PhysicalComponentPkg,
     )
-    root_function = c.ProxyAccessor(
+    root_function = c.DirectProxyAccessor(
         PhysicalComponent, rootelem=PhysicalFunctionPkg
     )
 
-    function_package = c.ProxyAccessor(PhysicalFunctionPkg)
-    component_package = c.ProxyAccessor(PhysicalComponentPkg)
-    capability_package = c.ProxyAccessor(la.CapabilityRealizationPkg)
+    function_package = c.DirectProxyAccessor(PhysicalFunctionPkg)
+    component_package = c.DirectProxyAccessor(PhysicalComponentPkg)
+    capability_package = c.DirectProxyAccessor(la.CapabilityRealizationPkg)
 
-    all_functions = c.ProxyAccessor(
+    all_functions = c.DeepProxyAccessor(
         PhysicalFunction,
         aslist=c.ElementList,
         rootelem=PhysicalFunctionPkg,
-        deep=True,
     )
-    all_capabilities = c.ProxyAccessor(
-        la.CapabilityRealization, deep=True, aslist=c.ElementList
+    all_capabilities = c.DeepProxyAccessor(
+        la.CapabilityRealization, aslist=c.ElementList
     )
-    all_components = c.ProxyAccessor(
-        PhysicalComponent, aslist=c.ElementList, deep=True
+    all_components = c.DeepProxyAccessor(
+        PhysicalComponent, aslist=c.ElementList
     )
     all_actors = property(
         lambda self: self._model.search(PhysicalComponent).by_is_actor(True)
     )
 
-    all_function_exchanges = c.ProxyAccessor(
+    all_function_exchanges = c.DeepProxyAccessor(
         fa.FunctionalExchange,
         aslist=c.ElementList,
         rootelem=[PhysicalFunctionPkg, PhysicalFunction],
-        deep=True,
     )
-    all_physical_paths = c.ProxyAccessor(
+    all_physical_paths = c.DeepProxyAccessor(
         cs.PhysicalPath,
         aslist=c.ElementList,
         rootelem=PhysicalComponentPkg,
-        deep=True,
     )
-    all_component_exchanges = c.ProxyAccessor(
+    all_component_exchanges = c.DeepProxyAccessor(
         fa.ComponentExchange,
         aslist=c.ElementList,
         rootelem=PhysicalComponentPkg,
-        deep=True,
     )
 
-    all_physical_exchanges = c.ProxyAccessor(
+    all_physical_exchanges = c.DeepProxyAccessor(
         fa.FunctionalExchange,
         aslist=c.ElementList,
         rootelem=[PhysicalFunctionPkg, PhysicalFunction],
-        deep=True,
     )
-    all_physical_links = c.ProxyAccessor(
-        cs.PhysicalLink, aslist=c.ElementList, deep=True
+    all_physical_links = c.DeepProxyAccessor(
+        cs.PhysicalLink, aslist=c.ElementList
     )
 
     diagrams = diagram.DiagramAccessor(
@@ -212,10 +207,7 @@ c.set_accessor(
 c.set_accessor(
     PhysicalFunction,
     "packages",
-    c.ProxyAccessor(
-        PhysicalFunctionPkg,
-        aslist=c.ElementList,
-    ),
+    c.DirectProxyAccessor(PhysicalFunctionPkg, aslist=c.ElementList),
 )
 c.set_self_references(
     (PhysicalComponent, "owned_components"),

--- a/tests/test_xlayer_cs.py
+++ b/tests/test_xlayer_cs.py
@@ -6,9 +6,9 @@ from capellambse import MelodyModel
 
 def test_physical_path_has_ordered_list_of_involved_items(model: MelodyModel):
     path = model.pa.all_physical_paths.by_name("card1 - card2 connection")
-    cmp_0 = model.pa.all_components.by_name("Compute Card 1")
+    cmp_0_part = model.search("Part").by_name("Compute Card 1")
     link_1 = model.pa.all_physical_links.by_name("Eth Cable 2")
-    assert cmp_0 == path.involved_items[0]
+    assert cmp_0_part == path.involved_items[0]
     assert link_1 == path.involved_items[1]
 
 


### PR DESCRIPTION
The `ProxyAccessor` has been split up into multiple different classes,
each taking over a part of the former `ProxyAccessor`'s
responsibilities:

- The `DirectProxyAccessor`, which handles the most common simple cases
- The `ReferencingProxyAccessor`, which handles the case where the child
  elements in the tree are only references onto the actual elements, and
  not the elements themselves (this takes away the `follow=` argument)
- The `DeepProxyAccessor`, which searches through an entire subtree
  (this takes away the `deep=` argument)

This split simplifies the logic around the various `__get__` methods of
these accessors. It also allows to implement the different strategies
for the related `__set__` methods in a cleaner way in a future commit.

Be aware that the default value for `follow_abstract=` to
`ProxyAccessor` has been changed from `True` to `False`, along with a
slight, but significant, semantic change. Previously it would *try* to
follow an `abstractType` reference if it was `True`, and would fall back
to yielding the element itself if `abstractType` was not set. This has
been changed: It is now an error if `follow_abstract` is `True`, but
`abstractType` is not set in the XML.

All references to the `ProxyAccessor` have been updated.

Co-authored-by: Martin Lehmann <martin.lehmann@deutschebahn.com>