### PR TITLE
Draft: Add hierarchical creation

### DIFF
--- a/capellambse/loader/xmltools.py
+++ b/capellambse/loader/xmltools.py
@@ -429,7 +429,7 @@ class EnumAttributeProperty(AttributeProperty):
             return None
         return self.enumcls[rawvalue]
 
-    def __set__(self, obj: t.Any, value: t.Any) -> None:
+    def __set__(self, obj: t.Any, value: str | enum.Enum) -> None:
         assert self.__objclass__ is not None
         if isinstance(value, str):
             try:
@@ -447,7 +447,7 @@ class EnumAttributeProperty(AttributeProperty):
                 )
             )
 
-        return super().__set__(obj, value.value)
+        return super().__set__(obj, value.name)
 
     def __set_name__(self, owner: type[t.Any], name: str) -> None:
         self.__name__ = name

--- a/capellambse/model/common/accessors.py
+++ b/capellambse/model/common/accessors.py
@@ -463,7 +463,8 @@ class DirectProxyAccessor(WritableAccessor[T], PhysicalAccessor[T]):
     ) -> None:
         assert obj._model is elmlist._model
         elmlist._model._loader.idcache_remove(obj._element)
-        elmlist._parent._element.remove(obj._element)
+        obj_parent = obj._element.getparent()
+        obj_parent.remove(obj._element)
 
 
 class DeepProxyAccessor(DirectProxyAccessor[T]):

--- a/capellambse/model/common/element.py
+++ b/capellambse/model/common/element.py
@@ -175,6 +175,11 @@ class GenericElement:
         self._element = element
         return self
 
+    def delete(self) -> None:
+        assert isinstance(self.parent._element, etree._Element)
+        self._model._loader.idcache_remove(self._element)
+        self.parent._element.remove(self._element)
+
     def __init__(
         self,
         model: capellambse.MelodyModel,

--- a/capellambse/model/common/element.py
+++ b/capellambse/model/common/element.py
@@ -209,9 +209,9 @@ class GenericElement:
         self._element: etree._Element = etree.Element(self._xmltag)
         parent.append(self._element)
         try:
-            for key, val in kw.items():
+            for key, value in kw.items():
                 if key == "xtype":
-                    self._element.set(helpers.ATT_XT, val)
+                    self._element.set(helpers.ATT_XT, value)
                 elif not isinstance(
                     getattr(type(self), key),
                     (accessors.Accessor, xmltools.AttributeProperty),
@@ -219,42 +219,44 @@ class GenericElement:
                     raise TypeError(
                         f"Cannot set {key!r} on {type(self).__name__}"
                     )
-                elif isinstance(val, cabc.Mapping):
+                elif isinstance(value, cabc.Mapping):
                     raise NotImplementedError
-                elif isinstance(val, cabc.Iterable) and not isinstance(
-                    val, str
+                elif isinstance(value, cabc.Iterable) and not isinstance(
+                    value, str
                 ):
-                    val = list(val)
-                    if all((isinstance(v, GenericElement) for v in val)):
-                        setattr(self, key, val)
-                    else:
-                        target = getattr(self, key)
-                        for v in val:
-                            if isinstance(v, cabc.Mapping):
-                                type_hints = v.get("type_hints", [])
-                                if type_hints:
-                                    del v[  # type:ignore[attr-defined]
-                                        "type_hints"
-                                    ]
-
-                                if isinstance(
-                                    type_hints, cabc.Iterable
-                                ) and not isinstance(type_hints, str):
-                                    for hint in type_hints:
-                                        assert isinstance(hint, str)
-                                else:
-                                    assert isinstance(type_hints, str)
-                                    type_hints = [type_hints]
-
-                                target.create(*type_hints, **v)
-                            else:
-                                target.create_singleattr(v)
+                    self._create_from_iterable(key, value)
                 else:
-                    setattr(self, key, val)
+                    setattr(self, key, value)
             self._model._loader.idcache_index(self._element)
         except BaseException:
             parent.remove(self._element)
             raise
+
+    def _create_from_iterable(self, key: str, value: t.Any) -> None:
+        value = list(value)
+        if all((isinstance(v, GenericElement) for v in value)):
+            return setattr(self, key, value)
+
+        target = getattr(self, key)
+        for v in value:
+            if isinstance(v, cabc.Mapping):
+                type_hints = v.get("type_hints", [])
+                if type_hints:
+                    del v["type_hints"]  # type:ignore[attr-defined]
+
+                if isinstance(type_hints, cabc.Iterable) and not isinstance(
+                    type_hints, str
+                ):
+                    for hint in type_hints:
+                        assert isinstance(hint, str)
+                else:
+                    assert isinstance(type_hints, str)
+                    type_hints = [type_hints]
+
+                target.create(*type_hints, **v)
+            else:
+                target.create_singleattr(v)
+        return None
 
     def __getattr__(self, attr: str) -> t.Any:
         raise AttributeError(f"{attr} isn't defined on {type(self).__name__}")

--- a/capellambse/model/crosslayer/information/__init__.py
+++ b/capellambse/model/crosslayer/information/__init__.py
@@ -144,7 +144,7 @@ class Class(c.GenericElement):
         """Return all owned and inherited properties."""
         return (
             self.owned_properties + self.super.properties
-            if self.super is not None
+            if isinstance(self.super, Class)
             else self.owned_properties
         )
 

--- a/capellambse/model/layers/pa.py
+++ b/capellambse/model/layers/pa.py
@@ -48,7 +48,7 @@ class PhysicalFunctionPkg(c.GenericElement):
 
     _xmltag = "ownedFunctionPkg"
 
-    components = c.DirectProxyAccessor(PhysicalFunction, aslist=c.ElementList)
+    functions = c.DirectProxyAccessor(PhysicalFunction, aslist=c.ElementList)
 
     packages: c.Accessor
 
@@ -122,7 +122,7 @@ class PhysicalArchitecture(crosslayer.BaseArchitectureLayer):
         rootelem=PhysicalComponentPkg,
     )
     root_function = c.DirectProxyAccessor(
-        PhysicalComponent, rootelem=PhysicalFunctionPkg
+        PhysicalFunction, rootelem=PhysicalFunctionPkg
     )
 
     function_package = c.DirectProxyAccessor(PhysicalFunctionPkg)

--- a/tests/test_model_creation_deletion.py
+++ b/tests/test_model_creation_deletion.py
@@ -132,3 +132,40 @@ def test_delete_elements_from_lookups(model: capellambse.MelodyModel):
     del model.la.all_functions[0]
 
     assert not model.la.all_functions
+
+
+def test_create_architecture_layer_from_mapping(
+    model: capellambse.MelodyModel,
+):
+    del model.pa
+    model.pa = {
+        "name": "New Physical Arch",
+        "component_package": {
+            "name": "Components",
+            "components": [
+                {
+                    "name": "Root Component",
+                    "nature": modeltypes.Nature.NODE,
+                }
+            ],
+            "packages": [
+                {
+                    "name": "SubComponents",
+                    "components": [{"name": "SubComponent"}],
+                }
+            ],
+        },
+        "function_package": {
+            "name": "PhysicalFunctionPkg",
+            "functions": [{"name": "Function"}],
+        },
+    }
+
+    assert model.pa.name == "New Physical Arch"
+    assert model.pa.owner == model
+    assert model.pa.root_component.name == "Root Component"
+    assert model.pa.root_component.nature == modeltypes.Nature.NODE
+    assert model.pa.all_components[1].name == "SubComponent"
+    assert model.pa.all_components[1].owner.name == "SubComponents"
+    assert model.pa.all_functions[0].name == "Function"
+    assert model.pa.function_package.name == "PhysicalFunctionPkg"

--- a/tests/test_model_creation_deletion.py
+++ b/tests/test_model_creation_deletion.py
@@ -78,3 +78,11 @@ def test_delete_all_deletes_matching_objects(model: capellambse.MelodyModel):
     comps.delete_all(name="Delete Me")
     assert len(comps) == 1
     assert comps[0].name == "Keep Me"
+
+
+def test_delete_elements_from_lookups(model: capellambse.MelodyModel):
+    assert model.la.all_functions[0] == model.la.root_function
+
+    del model.la.all_functions[0]
+
+    assert not model.la.all_functions


### PR DESCRIPTION
Added a testcase for creation of the PhysicalArchitecture layer. During the creation the whole structure information is passed as a dictionary and should be created in one go.

@vik378 mentioned the idea that at first the dict is checked against a minimum viable scheme/skeleton of the ModelElement on which the initial create call is requested.

In a later stage there might be generic name (or requried attribute) generation added.