### PR TITLE
Fix accessing `description` of Diagrams

### DIFF
--- a/capellambse/aird/parser/__init__.py
+++ b/capellambse/aird/parser/__init__.py
@@ -41,6 +41,7 @@ class DiagramDescriptor(t.NamedTuple):
     fragment: pathlib.PurePosixPath
     name: str
     styleclass: str | None
+    descriptor: etree._Element
     uid: str
     viewpoint: str
     target: etree._Element
@@ -128,6 +129,7 @@ def enumerate_diagrams(
                 uid=uid[1:],
                 viewpoint=descriptor[2],
                 target=target,
+                descriptor=descriptor[1],
             )
         except Exception as err:
             C.LOGGER.warning(

--- a/capellambse/model/diagram.py
+++ b/capellambse/model/diagram.py
@@ -369,9 +369,9 @@ class Diagram(AbstractDiagram):
         return self._model is other._model and self._element == other._element
 
     @property
-    def description(self) -> str:
+    def description(self) -> str | None:
         """Return the diagram description."""
-        desc = self._model._loader[self.uuid].get("documentation")
+        desc = self._element.descriptor.get("documentation")
         return desc and helpers.repair_html(desc)
 
     @property

--- a/tests/data/melodymodel/5_0/Melody Model Test.aird
+++ b/tests/data/melodymodel/5_0/Melody Model Test.aird
@@ -8,7 +8,7 @@
     </ownedViews>
     <ownedViews xmi:type="viewpoint:DView" uid="__FJxoKDzEeqf7Mw7EIo_Ew">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']"/>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_7Ft7QKrxEeqOgqWuHJrXFA" name="[MSM] States of Functional Human Being" repPath="#_7FWu4KrxEeqOgqWuHJrXFA" changeId="fba16650-bdda-4b1d-b8a6-ca9d175a51d7">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_7Ft7QKrxEeqOgqWuHJrXFA" documentation="&lt;p>This diagram shows the states that a Functional Human Being can have, as well as how it transitions between them.&lt;/p>&#xA;" name="[MSM] States of Functional Human Being" repPath="#_7FWu4KrxEeqOgqWuHJrXFA" changeId="fba16650-bdda-4b1d-b8a6-ca9d175a51d7">
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Mode%20State%20Machine']"/>
         <target xmi:type="org.polarsys.capella.core.data.capellacommon:Region" href="Melody%20Model%20Test.capella#eeeb98a7-6063-4115-8b4b-40a51cc0df49"/>
       </ownedRepresentationDescriptors>

--- a/tests/data/melodymodel/5_2/Melody Model Test.aird
+++ b/tests/data/melodymodel/5_2/Melody Model Test.aird
@@ -8,7 +8,7 @@
     </ownedViews>
     <ownedViews xmi:type="viewpoint:DView" uid="__FJxoKDzEeqf7Mw7EIo_Ew">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']"/>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_7Ft7QKrxEeqOgqWuHJrXFA" name="[MSM] States of Functional Human Being" repPath="#_7FWu4KrxEeqOgqWuHJrXFA" changeId="fba16650-bdda-4b1d-b8a6-ca9d175a51d7">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_7Ft7QKrxEeqOgqWuHJrXFA" documentation="&lt;p>This diagram shows the states that a Functional Human Being can have, as well as how it transitions between them.&lt;/p>&#xA;" name="[MSM] States of Functional Human Being" repPath="#_7FWu4KrxEeqOgqWuHJrXFA" changeId="fba16650-bdda-4b1d-b8a6-ca9d175a51d7">
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Mode%20State%20Machine']"/>
         <target xmi:type="org.polarsys.capella.core.data.capellacommon:Region" href="Melody%20Model%20Test.capella#eeeb98a7-6063-4115-8b4b-40a51cc0df49"/>
       </ownedRepresentationDescriptors>

--- a/tests/test_model_layers.py
+++ b/tests/test_model_layers.py
@@ -964,7 +964,11 @@ def test_literal_numeric_value_infinity_is_star(
     ["attr", "value"],
     [
         ("name", "[MSM] States of Functional Human Being"),
-        ("description", None),
+        (
+            "description",
+            "<p>This diagram shows the states that a Functional Human Being"
+            " can have, as well as how it transitions between them.</p>\n",
+        ),
         ("filters", {"ModelExtensionFilter"}),
         ("target.uuid", "eeeb98a7-6063-4115-8b4b-40a51cc0df49"),
         ("type", "MSM"),
@@ -982,3 +986,14 @@ def test_diagram_attributes(
     actual = get_attribute_under_test(diagram)
 
     assert actual == value
+
+
+def test_diagram_without_documentation_has_None_description(
+    model: capellambse.MelodyModel,
+) -> None:
+    diagram = model.diagrams.by_uuid("_KK2wcKyJEeqCdMaqCWkrKg")
+    expected = None
+
+    actual = diagram.description
+
+    assert actual == expected


### PR DESCRIPTION
The `description` of `model.Diagram` instances was looked up in the
wrong place.

Fixes #125