### PR TITLE
fix(aird): Fix rendering issues with "custom" `<sourceAnchors>`

### DIFF
--- a/capellambse/aird/parser/_edge_factories.py
+++ b/capellambse/aird/parser/_edge_factories.py
@@ -115,6 +115,8 @@ def extract_bendpoints(
             ).attrib["id"]
         except (StopIteration, KeyError):
             sourceanchor = "(0.5, 0.5)"
+        if sourceanchor.endswith(" custom"):
+            sourceanchor = sourceanchor[: -len(" custom")]
         sourceanchor = helpers.ssvparse(
             sourceanchor, float, parens="()", num=2
         )


### PR DESCRIPTION
Some `<sourceAnchor>` elements have a `custom` marker appended to their coordinates. This commit fixes an exception that was thrown as a result of `capellambse` not expecting that marker.