### PR TITLE
Detect UUID duplication within models

### DIFF
--- a/capellambse/loader/core.py
+++ b/capellambse/loader/core.py
@@ -52,6 +52,15 @@ ERR_BAD_EXT = "Model file {} has an unsupported extension: {}"
 
 IDTYPES = frozenset({"id", "uid", "xmi:id"})
 IDTYPES_RESOLVED = frozenset(helpers.resolve_namespace(t) for t in IDTYPES)
+IDTYPES_PER_FILETYPE: t.Final[dict[str, frozenset]] = {
+    ".afm": frozenset(),
+    ".aird": frozenset({"uid", helpers.resolve_namespace("xmi:id")}),
+    ".airdfragment": frozenset({"uid", helpers.resolve_namespace("xmi:id")}),
+    ".capella": frozenset({"id"}),
+    ".capellafragment": frozenset({"id"}),
+    ".melodymodeller": frozenset({"id"}),
+    ".melodyfragment": frozenset({"id"}),
+}
 RE_VALID_ID = re.compile(
     r"([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})"
 )
@@ -107,6 +116,15 @@ class MissingResourceLocationError(KeyError):
     """Raised when a model needs an additional resource location."""
 
 
+class CorruptModelError(Exception):
+    """Raised when the model is corrupted and cannot be processed safely.
+
+    In addition to the short description in the exception's arguments,
+    some validators may also produce additional information in the form
+    of CRITICAL log messages just before this exception is raised.
+    """
+
+
 class ResourceLocationManager(dict):
     def __missing__(self, key: str) -> t.NoReturn:
         raise MissingResourceLocationError(key)
@@ -146,17 +164,28 @@ class ModelFile:
     def __getitem__(self, key: str) -> etree._Element:
         return self.__idcache[key]
 
+    def enumerate_uuids(self) -> set[str]:
+        """Enumerate all UUIDs used in this fragment."""
+        return set(self.__idcache)
+
     def idcache_index(self, subtree: etree._Element) -> None:
         """Index the IDs of ``subtree``."""
+        idtypes = IDTYPES_PER_FILETYPE[self.filename.suffix]
         for elm in subtree.iter():
             xtype = helpers.xtype_of(elm)
             if xtype is not None:
                 self.__xtypecache[xtype].append(elm)
 
-            for idtype in IDTYPES_RESOLVED:
+            for idtype in idtypes:
                 elm_id = elm.get(idtype, None)
                 if elm_id is None:
                     continue
+                existing = self.__idcache.get(elm_id)
+                if existing is not None and existing is not elm:
+                    raise CorruptModelError(
+                        f"Duplicate UUID {elm_id!r}"
+                        f" within fragment {self.filename!s}"
+                    )
                 self.__idcache[elm_id] = elm
 
             href = elm.get("href")
@@ -296,9 +325,29 @@ class MelodyLoader:
             pathlib.PurePosixPath("\0", self.entrypoint)
         )
 
+        self.check_duplicate_uuids()
+
     @property
     def filehandler(self) -> filehandler.FileHandler:
         return self.resources["\0"]
+
+    def check_duplicate_uuids(self):
+        seen_ids = set[str]()
+        has_dups = False
+        for fragment, tree in self.trees.items():
+            tree_ids = set(tree.enumerate_uuids())
+            if duplicates := seen_ids & tree_ids:
+                LOGGER.critical(
+                    "Duplicate UUIDs across fragments (found in %s): %r",
+                    fragment,
+                    duplicates,
+                )
+                has_dups = True
+        if has_dups:
+            raise CorruptModelError(
+                "Model has duplicated UUIDs across fragments"
+                " - check the 'resources' for duplicate models"
+            )
 
     def __derive_entrypoint(
         self, entrypoint: str | pathlib.PurePosixPath | None
@@ -346,6 +395,7 @@ class MelodyLoader:
         capellambse.loader.filehandler.gitfilehandler.GitFileHandler.write_transaction :
             Accepted ``**kw`` when using ``git://`` and similar URLs
         """
+        self.check_duplicate_uuids()
         LOGGER.debug("Saving model %r", self.get_model_info().title)
         with self.filehandler.write_transaction(**kw) as unsupported_kws:
             if unsupported_kws:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,20 @@ import capellambse
 from . import TEST_MODEL, TEST_ROOT
 
 
+@pytest.fixture(scope="session")
+def session_shared_model() -> capellambse.MelodyModel:
+    """Load the standard test model.
+
+    Unlike the ``model`` fixture, this fixture is shared across the
+    entire test session. As such, the test functions using this fixture
+    are expected to not modify it.
+
+    This fixture exists as a speed optimization for tests that only read
+    from the model.
+    """
+    return capellambse.MelodyModel(TEST_ROOT / "5_0" / TEST_MODEL)
+
+
 @pytest.fixture
 def model(monkeypatch) -> capellambse.MelodyModel:
     """Return test model"""

--- a/tests/data/melodymodel/5_0/Melody Model Test.capella
+++ b/tests/data/melodymodel/5_0/Melody Model Test.capella
@@ -2293,9 +2293,9 @@ The predator is far away</bodies>
             <ownedFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
                 id="24d3e25a-5399-4374-aa85-8a4fd2b2a815" name="teach Care of Magical Creatures"/>
             <ownedFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
-                id="a7acb298-d14b-4707-a419-fea272434541" name="teach  Potions">
+                id="83ba0220-54f2-48f7-bca1-cd87e39639f2" name="teach  Potions">
               <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
-                  id="3612f112-f0c7-42ec-b0e9-f53afc1ef486" name="FOP 1"/>
+                  id="a88ff724-b8af-4609-8142-550a9aaabc78" name="FOP 1"/>
             </ownedFunctions>
             <ownedFunctionalExchanges xsi:type="org.polarsys.capella.core.data.fa:FunctionalExchange"
                 id="cdc69c5e-ddd8-4e59-8b99-f510400650aa" name="educate" target="#6584a94b-80fb-4ec4-8644-4781bb9509af"

--- a/tests/data/melodymodel/5_2/Melody Model Test.capella
+++ b/tests/data/melodymodel/5_2/Melody Model Test.capella
@@ -2187,9 +2187,9 @@ The predator is far away</bodies>
             <ownedFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
                 id="24d3e25a-5399-4374-aa85-8a4fd2b2a815" name="teach Care of Magical Creatures"/>
             <ownedFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
-                id="a7acb298-d14b-4707-a419-fea272434541" name="teach  Potions">
+                id="83ba0220-54f2-48f7-bca1-cd87e39639f2" name="teach  Potions">
               <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
-                  id="3612f112-f0c7-42ec-b0e9-f53afc1ef486" name="FOP 1"/>
+                  id="a88ff724-b8af-4609-8142-550a9aaabc78" name="FOP 1"/>
             </ownedFunctions>
             <ownedFunctionalExchanges xsi:type="org.polarsys.capella.core.data.fa:FunctionalExchange"
                 id="cdc69c5e-ddd8-4e59-8b99-f510400650aa" name="educate" target="#6584a94b-80fb-4ec4-8644-4781bb9509af"

--- a/tests/data/pvmt/expected-output/apply.melodymodeller
+++ b/tests/data/pvmt/expected-output/apply.melodymodeller
@@ -452,7 +452,7 @@
         <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="279e414d-3b5a-460b-b88c-e8c1ad0e53cb"
             name="Display" abstractType="#37df87be-bc83-4007-84d6-9027946d9fb8"/>
         <ownedPhysicalLinks xsi:type="org.polarsys.capella.core.data.cs:PhysicalLink"
-            id="d32caffc-b9a1-448e-8e96-65a36ba06292" name="DP-1" appliedPropertyValueGroups="#65db4b2e-4e14-47e8-af67-e5fc59fdd01a #5b1390f5-f7ac-4afd-bef0-8567f19f34a3 #01234567-89ab-4def-8123-456789abcdef"
+            id="d32caffc-b9a1-448e-8e96-65a36ba06292" name="DP-1" appliedPropertyValueGroups="#65db4b2e-4e14-47e8-af67-e5fc59fdd01a #5b1390f5-f7ac-4afd-bef0-8567f19f34a3 #00000000-0000-0000-0000-000000000001"
             linkEnds="#d7737b9b-02da-4c7d-af45-d5274c89ffe6 #8c8e9fdd-ace7-4322-9c6d-b6ec2ed2c0b3">
           <ownedPropertyValueGroups xsi:type="org.polarsys.capella.core.data.capellacore:PropertyValueGroup"
               id="65db4b2e-4e14-47e8-af67-e5fc59fdd01a" name="Computer.Cables" appliedPropertyValueGroups="#0fb1fbfb-43a6-4f96-9ec3-2cb83d80c702">
@@ -477,10 +477,10 @@
                 value="1"/>
           </ownedPropertyValueGroups>
           <ownedPropertyValueGroups xsi:type="org.polarsys.capella.core.data.capellacore:PropertyValueGroup"
-              id="01234567-89ab-4def-8123-456789abcdef" name="External Data.Object IDs"
+              id="00000000-0000-0000-0000-000000000001" name="External Data.Object IDs"
               appliedPropertyValueGroups="#00fd06dd-cedc-403a-9742-261510c70b76">
             <ownedPropertyValues xsi:type="org.polarsys.capella.core.data.capellacore:StringPropertyValue"
-                name="Object ID" id="01234567-89ab-4def-8123-456789abcdef" appliedPropertyValues="#4ae427b8-af5d-4d42-b454-a656ddce9b1d"
+                name="Object ID" id="00000000-0000-0000-0000-000000000002" appliedPropertyValues="#4ae427b8-af5d-4d42-b454-a656ddce9b1d"
                 value="CABLE-0001"/>
           </ownedPropertyValueGroups>
         </ownedPhysicalLinks>

--- a/tests/test_model_layers.py
+++ b/tests/test_model_layers.py
@@ -10,6 +10,7 @@ import markupsafe
 import pytest
 
 import capellambse
+import capellambse.model.common as c
 from capellambse.model import MelodyModel, modeltypes
 from capellambse.model.crosslayer.capellacommon import (
     Region,
@@ -527,6 +528,19 @@ def test_model_search_below_filters_elements_by_ancestor(
 
     actual = {i.uuid for i in nested}
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "xtype",
+    {i for map in c.XTYPE_HANDLERS.values() for i in map.values()},
+)
+def test_model_search_does_not_contain_duplicates(
+    model: capellambse.MelodyModel, xtype: type[t.Any]
+) -> None:
+    results = model.search(xtype)
+    uuids = [i.uuid for i in results]
+
+    assert len(uuids) == len(set(uuids))
 
 
 def test_CommunicationMean(model: capellambse.MelodyModel) -> None:

--- a/tests/test_model_layers.py
+++ b/tests/test_model_layers.py
@@ -489,7 +489,7 @@ def test_constraint_without_specification_raises_AttributeError(
     [Class, "org.polarsys.capella.core.data.information:Class", "Class"],
 )
 def test_model_search_finds_elements(
-    model: capellambse.MelodyModel, searchkey
+    session_shared_model: capellambse.MelodyModel, searchkey
 ):
     expected = {
         "0fef2887-04ce-4406-b1a1-a1b35e1ce0f3",
@@ -509,22 +509,24 @@ def test_model_search_finds_elements(
         "d2b4a93c-73ef-4f01-8b59-f86c074ec521",
     }
 
-    found = model.search(searchkey)
+    found = session_shared_model.search(searchkey)
     actual = {i.uuid for i in found}
 
     assert actual == expected
 
 
 def test_model_search_below_filters_elements_by_ancestor(
-    model: capellambse.MelodyModel,
+    session_shared_model: capellambse.MelodyModel,
 ):
-    parent = model.by_uuid("6583b560-6d2f-4190-baa2-94eef179c8ea")
+    parent = session_shared_model.by_uuid(
+        "6583b560-6d2f-4190-baa2-94eef179c8ea"
+    )
     expected = {
         "3bdd4fa2-5646-44a1-9fa6-80c68433ddb7",
         "a58821df-c5b4-4958-9455-0d30755be6b1",
     }
 
-    nested = model.search("LogicalComponent", below=parent)
+    nested = session_shared_model.search("LogicalComponent", below=parent)
 
     actual = {i.uuid for i in nested}
     assert actual == expected
@@ -535,9 +537,9 @@ def test_model_search_below_filters_elements_by_ancestor(
     {i for map in c.XTYPE_HANDLERS.values() for i in map.values()},
 )
 def test_model_search_does_not_contain_duplicates(
-    model: capellambse.MelodyModel, xtype: type[t.Any]
+    session_shared_model: capellambse.MelodyModel, xtype: type[t.Any]
 ) -> None:
-    results = model.search(xtype)
+    results = session_shared_model.search(xtype)
     uuids = [i.uuid for i in results]
 
     assert len(uuids) == len(set(uuids))

--- a/tests/test_pvmt.py
+++ b/tests/test_pvmt.py
@@ -216,7 +216,7 @@ class TestAppliedPropertyValueGroupXML:
         def mock_generate_uuid(*__, **_):
             nonlocal call_count
             call_count += 1
-            return "01234567-89ab-4def-8123-456789abcdef"
+            return f"00000000-0000-0000-0000-{call_count:012x}"
 
         monkeypatch.setattr(
             "capellambse.loader.MelodyLoader.generate_uuid",


### PR DESCRIPTION
It was discovered that our test models somehow had gotten multiple elements that shared the same UUID. While investigating the cause of this, I implemented this simple routine that checks for such duplication while loading and before saving a model. As a side effect of where the code is hooked into, this also adds an additional guard while creating / inserting new elements into the model's XML tree.

The PVMT tests needed to be adjusted, because a mock function would always return the same UUID, which triggered the new before-save check.