### PR TITLE
test: Refactor for pytest's `--import-mode=importlib`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,7 @@ enable = [
 
 [tool.pytest.ini_options]
 addopts = """
+  --import-mode=importlib
   --strict-config
   --strict-markers
 """

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,8 +1,0 @@
-# SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
-# SPDX-License-Identifier: Apache-2.0
-
-import pathlib
-import re
-
-TEST_ROOT = pathlib.Path(__file__).parent / "data" / "melodymodel"
-TEST_MODEL = "Melody Model Test.aird"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,15 @@
 
 """Global fixtures for pytest"""
 import io
+import pathlib
 import sys
 
 import pytest
 
 import capellambse
 
-from . import TEST_MODEL, TEST_ROOT
+TEST_ROOT = pathlib.Path(__file__).parent / "data" / "melodymodel"
+TEST_MODEL = "Melody Model Test.aird"
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_model_layers.py
+++ b/tests/test_model_layers.py
@@ -25,7 +25,7 @@ from capellambse.model.layers.ctx import SystemComponentPkg
 from capellambse.model.layers.la import CapabilityRealization
 from capellambse.model.layers.oa import OperationalCapability
 
-from . import TEST_MODEL, TEST_ROOT
+from .conftest import TEST_MODEL, TEST_ROOT
 
 
 def test_model_info_contains_capella_version(model: MelodyModel):

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -13,7 +13,7 @@ import requests_mock
 
 import capellambse
 
-from . import TEST_MODEL, TEST_ROOT
+from .conftest import TEST_MODEL, TEST_ROOT
 
 TEST_MODEL_5_0 = TEST_ROOT / "5_0" / TEST_MODEL
 


### PR DESCRIPTION
In a recent team meeting, we agreed to migrate to this option. Here goes capellambse.