### PR TITLE
fix: Diagrams with default Circle styling

### DIFF
--- a/capellambse/svg/style.py
+++ b/capellambse/svg/style.py
@@ -368,7 +368,8 @@ class StyleBuilder:
                 continue
 
             elmtype = tuple(i or "" for i in elmtype_match.groups())
-            self.stylewriters[elmtype[0]](elmtype, styles)
+            if (cls := elmtype[0]) != "Circle":
+                self.stylewriters[cls](elmtype, styles)
 
     def create(self) -> None:
         """Create style builder and all needed components.

--- a/capellambse/svg/style.py
+++ b/capellambse/svg/style.py
@@ -367,9 +367,11 @@ class StyleBuilder:
                 logger.error("Invalid style key: %s", key)
                 continue
 
-            elmtype = tuple(i or "" for i in elmtype_match.groups())
-            if (cls := elmtype[0]) != "Circle":
-                self.stylewriters[cls](elmtype, styles)
+            elmtype, elmclass, pseudoclass = elmtype_match.groups()
+            if elmtype not in self.stylewriters:
+                continue
+            write_styles_real = self.stylewriters[elmtype]
+            write_styles_real(elmclass or "", pseudoclass or "", styles)
 
     def create(self) -> None:
         """Create style builder and all needed components.
@@ -399,10 +401,10 @@ class StyleBuilder:
 
     def _write_styles_box(
         self,
-        selector_parts: tuple[str, ...],
+        elmclass: str,
+        pseudo: str,
         styles: dict[str, aird.CSSdef],
     ) -> None:
-        _, elmclass, pseudo = selector_parts
         selectors = [
             f"g.Box{elmclass}{pseudo} > {tag}" for tag in ("rect", "use")
         ]
@@ -417,10 +419,10 @@ class StyleBuilder:
 
     def _write_styles_edge(
         self,
-        selector_parts: tuple[str, ...],
+        elmclass: str,
+        pseudo: str,
         styles: dict[str, aird.CSSdef],
     ) -> None:
-        _, elmclass, pseudo = selector_parts
         selector = f"g.Edge{elmclass}{pseudo} > path"
         selector_text = f"g.Edge{elmclass}{pseudo} > text"
         self._write_styledict(


### PR DESCRIPTION
Writing Circle styles is provided by the edge style-writer already.
Please get this merged in as fast as possible as [PR #9](https://github.com/DSD-DBS/capellambse-context-diagrams/pull/9) depends on it.