### PR TITLE
Fix side by side badges in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,10 @@ Python-Capellambse
 ==================
 
 .. image:: https://github.com/DSD-DBS/py-capellambse/actions/workflows/build-test-publish.yml/badge.svg
+  :target: https://github.com/DSD-DBS/py-capellambse/actions/workflows/build-test-publish.yml/badge.svg
 
 .. image:: https://github.com/DSD-DBS/py-capellambse/actions/workflows/lint.yml/badge.svg
+  :target: https://github.com/DSD-DBS/py-capellambse/actions/workflows/lint.yml/badge.svg
 
 *A Python 3 headless implementation of the Capella modeling tool*
 


### PR DESCRIPTION
The status badges in the README are displayed in new lines... this can be fixed by adding `:target:`s as described in [this issue](https://github.com/badges/shields/issues/1491).