### PR TITLE
YAML-based declarative modelling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,4 +8,6 @@
 
 *.{sh,py} text eol=lf
 
+*.rst conflict-marker-size=40
+
 .git_archival.txt  export-subst

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,7 @@ repos:
         additional_dependencies:
           - sphinx
           - types-docutils==0.17.0
+          - types-pyyaml==6.0.11
           - types-requests==2.25.11
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.13

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
       - id: check-vcs-permalinks
       - id: check-xml
       - id: check-yaml
+        exclude: '^tests/data/decl/[^/]+\.ya?ml$'
       - id: debug-statements
       - id: destroyed-symlinks
       - id: end-of-file-fixer

--- a/capellambse/decl.py
+++ b/capellambse/decl.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Support for YAML-based declarative modelling.
+
+A YAML-based approach to describing how to create and modify
+``capellambse`` compatible models.
+"""
+from __future__ import annotations
+
+__all__ = [
+    "Promise",
+    "UUIDReference",
+    "YDMDumper",
+    "YDMLoader",
+    "dump",
+    "load",
+]
+
+import collections.abc as cabc
+import contextlib
+import dataclasses
+import os
+import typing as t
+
+import yaml
+
+from capellambse import helpers
+
+FileOrPath = t.Union[t.IO[str], str, os.PathLike[t.Any]]
+
+
+def dump(instructions: cabc.Sequence[cabc.Mapping[str, t.Any]]) -> str:
+    """Dump an instruction stream to YAML."""
+    return yaml.dump(instructions, Dumper=YDMDumper)
+
+
+def load(file: FileOrPath) -> list[dict[str, t.Any]]:
+    """Load an instruction stream from a YAML file.
+
+    Parameters
+    ----------
+    file
+        An open file-like object, or a path or PathLike pointing to such
+        a file. Files are expected to use UTF-8 encoding.
+    """
+    if hasattr(file, "read"):
+        file = t.cast(t.IO[str], file)
+        ctx: t.ContextManager[t.IO[str]] = contextlib.nullcontext(file)
+    else:
+        assert not isinstance(file, t.IO)
+        ctx = open(file, encoding="utf-8")
+
+    with ctx as opened_file:
+        return yaml.load(opened_file, Loader=YDMLoader)
+
+
+@dataclasses.dataclass(frozen=True)
+class Promise:
+    """References a model object that will be created later."""
+
+    identifier: str
+
+
+@dataclasses.dataclass(frozen=True)
+class UUIDReference:
+    """References a model object by its UUID."""
+
+    uuid: helpers.UUIDString
+
+    def __post_init__(self) -> None:
+        if not helpers.is_uuid_string(self.uuid):
+            raise ValueError(f"Malformed `!uuid`: {self.uuid!r}")
+
+
+class YDMDumper(yaml.SafeDumper):
+    """A YAML dumper with extensions for declarative modelling."""
+
+    def represent_promise(self, data: t.Any) -> yaml.Node:
+        assert isinstance(data, Promise)
+        return self.represent_scalar("!promise", data.identifier)
+
+    def represent_uuidref(self, data: t.Any) -> yaml.Node:
+        assert isinstance(data, UUIDReference)
+        return self.represent_scalar("!uuid", data.uuid)
+
+
+YDMDumper.add_representer(Promise, YDMDumper.represent_promise)
+YDMDumper.add_representer(UUIDReference, YDMDumper.represent_uuidref)
+
+
+class YDMLoader(yaml.SafeLoader):
+    """A YAML loader with extensions for declarative modelling."""
+
+    def construct_promise(self, node: yaml.Node) -> Promise:
+        if not isinstance(node, yaml.ScalarNode):
+            raise TypeError("!promise only accepts scalar nodes")
+        data = self.construct_scalar(node)
+        if not isinstance(data, str):
+            raise TypeError("!promise only accepts string scalars")
+        return Promise(data)
+
+    def construct_uuidref(self, node: yaml.Node) -> UUIDReference:
+        if not isinstance(node, yaml.ScalarNode):
+            raise TypeError("!uuid only accepts scalar nodes")
+        data = self.construct_scalar(node)
+        if not helpers.is_uuid_string(data):
+            raise ValueError(f"Not a well-formed UUID string: {data}")
+        return UUIDReference(data)
+
+
+YDMLoader.add_constructor("!promise", YDMLoader.construct_promise)
+YDMLoader.add_constructor("!uuid", YDMLoader.construct_uuidref)

--- a/capellambse/decl.py
+++ b/capellambse/decl.py
@@ -276,9 +276,12 @@ def _create_complex_object(
 
     complex_attrs = dict[str, t.Any]()
     simple_attrs = dict[str, t.Any]()
+    type_hint = tuple[str, ...]()
     try:
         for k, v in obj_desc.items():
-            if isinstance(v, cabc.Iterable) and not isinstance(v, str):
+            if k == "_type":
+                type_hint = (v,)
+            elif isinstance(v, cabc.Iterable) and not isinstance(v, str):
                 complex_attrs[k] = v
             else:
                 simple_attrs[k] = _resolve(promises, parent, v)
@@ -286,7 +289,7 @@ def _create_complex_object(
         yield (p.args[0], {"parent": parent, "create": {attr: [obj_desc]}})
         return
     assert isinstance(target, common.ElementListCouplingMixin)
-    obj = target.create(**simple_attrs)
+    obj = target.create(*type_hint, **simple_attrs)
     if promise is not None:
         if isinstance(promise, str):
             promise = Promise(promise)

--- a/capellambse/decl.py
+++ b/capellambse/decl.py
@@ -229,7 +229,7 @@ def _create_complex_objects(
     promises: dict[Promise, capellambse.ModelObject],
     parent: capellambse.ModelObject,
     attr: str,
-    objs: cabc.Iterable[dict[str, t.Any] | Promise],
+    objs: cabc.Iterable[dict[str, t.Any] | Promise | str],
 ) -> cabc.Generator[_OperatorResult, t.Any, None]:
     try:
         target = getattr(parent, attr)
@@ -256,6 +256,8 @@ def _create_complex_objects(
                 yield p.args[0], {"parent": parent, "create": {attr: [child]}}
             else:
                 target.append(obj)
+        elif isinstance(child, str):
+            target.create_singleattr(child)
         else:
             yield from _create_complex_object(
                 promises, parent, attr, target, child

--- a/capellambse/decl.py
+++ b/capellambse/decl.py
@@ -24,6 +24,7 @@ import collections.abc as cabc
 import contextlib
 import dataclasses
 import os
+import sys
 import typing as t
 
 import yaml
@@ -377,3 +378,27 @@ class YDMLoader(yaml.SafeLoader):
 
 YDMLoader.add_constructor("!promise", YDMLoader.construct_promise)
 YDMLoader.add_constructor("!uuid", YDMLoader.construct_uuidref)
+
+
+try:
+    import click
+except ImportError:
+
+    def _main() -> None:
+        """Display a dependency error."""
+        print("Error: Please install 'click' and retry", file=sys.stderr)
+        raise SystemExit(1)
+
+else:
+
+    @click.command()
+    @click.option("-m", "--model", type=capellambse.ModelCLI(), required=True)
+    @click.argument("file", type=click.File("r"))
+    def _main(model: capellambse.MelodyModel, file: t.IO[str]) -> None:
+        """Apply a declarative modelling YAML file to a model."""
+        apply(model, file)
+        model.save()
+
+
+if __name__ == "__main__":
+    _main()

--- a/capellambse/decl.py
+++ b/capellambse/decl.py
@@ -5,6 +5,9 @@
 
 A YAML-based approach to describing how to create and modify
 ``capellambse`` compatible models.
+
+For an in-depth explanation, please refer to the :ref:`full
+documentation about declarative modelling <declarative-modelling>`.
 """
 from __future__ import annotations
 
@@ -76,6 +79,10 @@ def apply(model: capellambse.MelodyModel, file: FileOrPath) -> None:
     file
         An open file-like object to read YAML instructions from, or a
         path to such a file. Files will be read with UTF-8 encoding.
+
+        The full format of these files is documented in the
+        :ref:`section about declarative modelling
+        <declarative-modelling>`.
 
     Notes
     -----

--- a/capellambse/model/common/accessors.py
+++ b/capellambse/model/common/accessors.py
@@ -390,6 +390,33 @@ class DirectProxyAccessor(WritableAccessor[T], PhysicalAccessor[T]):
         ]
         return self._make_list(obj, elems)
 
+    def __set__(
+        self, obj: element.ModelObject, value: str | T | cabc.Iterable[str | T]
+    ) -> None:
+        if self.aslist:
+            if isinstance(value, str) or not isinstance(value, cabc.Iterable):
+                raise TypeError("Can only set list attribute to an iterable")
+            list = self.__get__(obj)
+            list[:] = []
+            for v in value:
+                if isinstance(v, str):
+                    list.create_singleattr(v)
+                else:
+                    list.create(**v)
+        else:
+            if isinstance(value, cabc.Iterable) and not isinstance(value, str):
+                raise TypeError("Cannot set non-list attribute to an iterable")
+            raise NotImplementedError(
+                "Moving model objects is not supported yet"
+            )
+
+    def __delete__(self, obj: element.ModelObject) -> None:
+        if self.aslist is not None:
+            list = self.__get__(obj)
+            list[:] = []
+        else:
+            raise TypeError(f"Cannot delete {self._qualname}")
+
     def _resolve(
         self, obj: element.ModelObject, elem: etree._Element
     ) -> etree._Element:

--- a/capellambse/model/common/element.py
+++ b/capellambse/model/common/element.py
@@ -214,33 +214,6 @@ class GenericElement:
                     raise TypeError(
                         f"Cannot set {key!r} on {type(self).__name__}"
                     )
-                elif isinstance(val, cabc.Mapping):
-                    raise NotImplementedError(
-                        "Multicreation of elements is not yet supported"
-                    )
-                elif isinstance(val, cabc.Iterable) and not isinstance(
-                    val, str
-                ):
-                    val = list(val)
-                    if all(isinstance(v, GenericElement) for v in val):
-                        setattr(self, key, val)
-                    else:
-                        target = getattr(self, key)
-                        for v in val:
-                            if isinstance(v, cabc.Mapping):
-                                v = dict(v)
-                                type_hints: t.Any = []
-                                if "_type" in v:
-                                    type_hints = v.pop("_type")
-
-                                if not isinstance(
-                                    type_hints, cabc.Iterable
-                                ) or isinstance(type_hints, str):
-                                    type_hints = [type_hints]
-
-                                target.create(*type_hints, **v)
-                            else:
-                                target.create_singleattr(v)
                 else:
                     setattr(self, key, val)
             self._model._loader.idcache_index(self._element)

--- a/capellambse/model/crosslayer/cs.py
+++ b/capellambse/model/crosslayer/cs.py
@@ -118,7 +118,11 @@ class Component(c.GenericElement):
     parts = c.ReferenceSearchingAccessor(Part, "type", aslist=c.ElementList)
     physical_paths = c.DirectProxyAccessor(PhysicalPath, aslist=c.ElementList)
     physical_links = c.DirectProxyAccessor(PhysicalLink, aslist=c.ElementList)
-    exchanges = c.ReferenceSearchingAccessor(
+    exchanges = c.DirectProxyAccessor(
+        fa.ComponentExchange, aslist=c.ElementList
+    )
+
+    related_exchanges = c.ReferenceSearchingAccessor(
         fa.ComponentExchange,
         "source.owner",
         "target.owner",

--- a/capellambse/model/crosslayer/fa.py
+++ b/capellambse/model/crosslayer/fa.py
@@ -125,8 +125,10 @@ class Function(AbstractFunction):
     inputs = c.DirectProxyAccessor(FunctionInputPort, aslist=c.ElementList)
     outputs = c.DirectProxyAccessor(FunctionOutputPort, aslist=c.ElementList)
 
+    exchanges: c.Accessor["FunctionalExchange"]
     functions: c.Accessor
     packages: c.Accessor
+    related_exchanges: c.Accessor["FunctionalExchange"]
 
 
 @c.xtype_handler(None)
@@ -294,6 +296,11 @@ c.set_accessor(
 c.set_accessor(
     Function,
     "exchanges",
+    c.DirectProxyAccessor(FunctionalExchange, aslist=c.ElementList),
+)
+c.set_accessor(
+    Function,
+    "related_exchanges",
     c.ReferenceSearchingAccessor(
         FunctionalExchange,
         "source.owner",

--- a/capellambse/model/layers/la.py
+++ b/capellambse/model/layers/la.py
@@ -85,6 +85,9 @@ class LogicalComponentPkg(c.GenericElement):
     state_machines = c.DirectProxyAccessor(
         capellacommon.StateMachine, aslist=c.ElementList
     )
+    exchanges = c.DirectProxyAccessor(
+        fa.ComponentExchange, aslist=c.ElementList
+    )
 
     packages: c.Accessor
 

--- a/capellambse/model/layers/oa.py
+++ b/capellambse/model/layers/oa.py
@@ -215,6 +215,7 @@ class EntityPkg(c.GenericElement):
     )
 
     packages: c.Accessor
+    exchanges = c.DirectProxyAccessor(CommunicationMean, aslist=c.ElementList)
 
 
 @c.xtype_handler(None)
@@ -273,6 +274,11 @@ c.set_accessor(
 c.set_accessor(
     Entity,
     "exchanges",
+    c.DirectProxyAccessor(CommunicationMean, aslist=c.ElementList),
+)
+c.set_accessor(
+    Entity,
+    "related_exchanges",
     c.ReferenceSearchingAccessor(
         CommunicationMean, "source", "target", aslist=c.ElementList
     ),

--- a/capellambse/model/layers/pa.py
+++ b/capellambse/model/layers/pa.py
@@ -105,6 +105,9 @@ class PhysicalComponentPkg(c.GenericElement):
     _xmltag = "ownedPhysicalComponentPkg"
 
     components = c.DirectProxyAccessor(PhysicalComponent, aslist=c.ElementList)
+    exchanges = c.DirectProxyAccessor(
+        fa.ComponentExchange, aslist=c.ElementList
+    )
     state_machines = c.DirectProxyAccessor(
         capellacommon.StateMachine, aslist=c.ElementList
     )

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,9 +44,9 @@ tutorial section.
    start/prerequisites
    start/installation
    start/intro-to-api
+   start/declarative
    start/how-to-explore-capella-mm
    start/developing-docs
-   start/declarative
 
 .. toctree::
    :caption: Tutorials

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,6 +29,10 @@ using Polarsys' Capella_ with Python. Common usage for this API:
 Additionally and as a core idea it provides an interface for the underlying
 database of the Capella model.
 
+Since v0.5, it also supports a simple, but powerful :ref:`declarative modelling
+language <declarative-modelling>`, which is based on the API for the semantic
+model.
+
 If you want a quickstart at how to use this package, head right into the
 tutorial section.
 
@@ -42,6 +46,7 @@ tutorial section.
    start/intro-to-api
    start/how-to-explore-capella-mm
    start/developing-docs
+   start/declarative
 
 .. toctree::
    :caption: Tutorials

--- a/docs/source/start/declarative.rst
+++ b/docs/source/start/declarative.rst
@@ -8,7 +8,7 @@
 Declarative modelling
 *********************
 
-capellambse supports declarative modelling with the ``capellambse.decl``
+capellambse supports declarative modelling with the :py:mod:`capellambse.decl`
 module. This requires the optional dependency ``capellambse[decl]`` to be
 installed.
 
@@ -31,6 +31,9 @@ couple of functions, and functional exchanges between them:
    :lineno-start: 1
    :linenos:
 
+CLI usage
+---------
+
 If the additional optional dependency ``capellambse[decl,cli]`` is installed,
 this file can be applied from the command line. Assuming it is saved as
 ``coffee-machine.yml``, it can then be applied to a locally stored Capella
@@ -42,6 +45,9 @@ model like this:
 
 Refer to the :py:func:`capellambse.cli_helpers.loadcli` documentation to find
 out the supported argument format for ``--model``.
+
+API usage
+---------
 
 Declarative YAML can also be applied programmatically, by calling the
 :py:func:`capellambse.decl.apply` function. It takes a (loaded) CapellaMBSE
@@ -64,8 +70,11 @@ Format description
 
 The expected YAML follows a simple format, where a parent object (i.e. an
 object that already exists in the model) is selected, and one or more of three
-different operations is applied to it: ``create``-ing new child objects,
-``modify``-ing the object itself, or ``delete``-ing one or more children.
+different operations is applied to it:
+
+- ``create``-ing new child objects,
+- ``modify``-ing the object itself, or
+- ``delete``-ing one or more children.
 
 Parents can be selected by their universally unique ID (UUID), using the
 ``!uuid`` YAML tag. The following query selects the root logical function in
@@ -78,10 +87,12 @@ our test model:
 Creating objects
 ----------------
 
-``LogicalFunction`` objects have several different attributes which can be
-modified from a declarative YAML file. For example, it is possible to create
-new sub-``functions``. This snippet creates a function with the name "brew
-coffee" directly below the root function:
+:py:class:`~capellambse.model.layers.la.LogicalFunction` objects have several
+different attributes which can be modified from a declarative YAML file. For
+example, it is possible to create new
+sub-:py:attr:`~capellambse.model.layers.la.LogicalFunction.functions`. This
+snippet creates a function with the name "brew coffee" directly below the root
+function:
 
 .. code-block:: yaml
    :emphasize-lines: 2
@@ -149,8 +160,9 @@ After selecting a parent, it is also possible to directly change its properties
 without introducing new objects into the model. This happens by specifying the
 attributes in the ``modify:`` key.
 
-The following example would change the ``name`` of the root Logical Component
-to "Coffee Machine" (notice how we use a different UUID than before):
+The following example would change the ``name`` of the root
+:py:class:`~capellambse.model.layers.la.LogicalComponent` to "Coffee Machine"
+(notice how we use a different UUID than before):
 
 .. code-block:: yaml
    :emphasize-lines: 2
@@ -161,8 +173,8 @@ to "Coffee Machine" (notice how we use a different UUID than before):
 
 This is not limited to string attributes; it is just as well possible to change
 e.g. numeric properties. This example changes the ``min_card`` property of an
-exchange item element to ``0`` and the ``max_card`` to infinity, effectively
-removing both limitations:
+:py:class:`~capellambse.model.crosslayer.information.ExchangeItemElement` to
+``0`` and the ``max_card`` to infinity, effectively removing both limitations:
 
 .. code-block:: yaml
    :emphasize-lines: 3-

--- a/docs/source/start/declarative.rst
+++ b/docs/source/start/declarative.rst
@@ -1,0 +1,204 @@
+..
+   SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
+   SPDX-License-Identifier: Apache-2.0
+
+.. _declarative-modelling:
+
+*********************
+Declarative modelling
+*********************
+
+capellambse supports declarative modelling with the ``capellambse.decl``
+module. This requires the optional dependency ``capellambse[decl]`` to be
+installed.
+
+The YAML-based declarative modelling engine combines a few simple concepts into
+a powerful, but easy to use file format. These files can then be applied to any
+model supported by py-capellambse.
+
+.. versionadded:: 0.5.0
+   Introduced the declarative modelling module.
+
+Example
+=======
+
+Here is an example YAML file that declares a simple coffee machine with a
+couple of functions, and functional exchanges between them:
+
+.. literalinclude:: ../../../tests/data/decl/coffee-machine.yml
+   :language: yaml
+   :lines: 4-
+   :lineno-start: 1
+   :linenos:
+
+If the additional optional dependency ``capellambse[decl,cli]`` is installed,
+this file can be applied from the command line. Assuming it is saved as
+``coffee-machine.yml``, it can then be applied to a locally stored Capella
+model like this:
+
+.. code-block:: sh
+
+   python -m capellambse.decl --model path/to/model.aird coffee-machine.yml
+
+Refer to the :py:func:`capellambse.cli_helpers.loadcli` documentation to find
+out the supported argument format for ``--model``.
+
+Declarative YAML can also be applied programmatically, by calling the
+:py:func:`capellambse.decl.apply` function. It takes a (loaded) CapellaMBSE
+model, and either a path to a file or a file-like object. To pass in a string
+containing YAML, wrap it in ``io.StringIO``:
+
+.. code-block:: python
+   :emphasize-lines: 5
+
+   import io, capellambse.decl
+   my_model = capellambse.MelodyModel(...)
+   my_yaml = "..."
+
+   capellambse.decl.apply(my_model, io.StringIO(my_yaml))
+
+   my_model.save()
+
+Format description
+==================
+
+The expected YAML follows a simple format, where a parent object (i.e. an
+object that already exists in the model) is selected, and one or more of three
+different operations is applied to it: ``create``-ing new child objects,
+``modify``-ing the object itself, or ``delete``-ing one or more children.
+
+Parents can be selected by their universally unique ID (UUID), using the
+``!uuid`` YAML tag. The following query selects the root logical function in
+our test model:
+
+.. code-block:: yaml
+
+   - parent: !uuid f28ec0f8-f3b3-43a0-8af7-79f194b29a2d
+
+Creating objects
+----------------
+
+``LogicalFunction`` objects have several different attributes which can be
+modified from a declarative YAML file. For example, it is possible to create
+new sub-``functions``. This snippet creates a function with the name "brew
+coffee" directly below the root function:
+
+.. code-block:: yaml
+   :emphasize-lines: 2
+
+   - parent: !uuid f28ec0f8-f3b3-43a0-8af7-79f194b29a2d
+     create:
+       functions:
+         - name: brew coffee
+
+Functions can be nested arbitrarily deeply, and can also receive any other
+supported attributes at the same time. The "brew coffee" function for example
+could further receive nested child functions, each providing an output port:
+
+.. code-block:: yaml
+   :emphasize-lines: 4-5
+
+   - parent: !uuid f28ec0f8-f3b3-43a0-8af7-79f194b29a2d
+     create:
+       functions:
+         - name: brew coffee
+           functions:
+             - name: grind beans
+               outputs:
+                 - name: Ground Beans port
+             - name: heat water
+               outputs:
+                 - name: Hot Water port
+
+While objects that already exist in the base model can be referenced with
+``!uuid``, this is not possible for objects declared by the YAML file, as they
+will have a random UUID assigned to ensure uniqueness. For this reason, a
+promise mechanic exists, which allows to "tag" any declared object with a
+``promise_id``, and later reference that object with the ``!promise`` YAML tag.
+These promise IDs are user defined strings. The only requirement is that two
+objects cannot receive the same ID, however they can be referenced any number
+of times. This example snippet demonstrates how to declare two logical
+functions, which communicate through a functional exchange:
+
+.. code-block:: yaml
+   :emphasize-lines: 7,11,14-15
+
+   - parent: !uuid f28ec0f8-f3b3-43a0-8af7-79f194b29a2d
+     create:
+       functions:
+         - name: brew coffee
+           inputs:
+             - name: Steam port
+               promise_id: steam-input
+         - name: produce steam
+           outputs:
+             - name: Steam port
+               promise_id: steam-output
+       exchanges:
+         - name: Steam
+           source: !promise steam-output
+           target: !promise steam-input
+
+The ``!promise`` tag (and the ``!uuid`` tag as well) can be used anywhere where
+a model object is expected.
+
+Modifying objects
+-----------------
+
+After selecting a parent, it is also possible to directly change its properties
+without introducing new objects into the model. This happens by specifying the
+attributes in the ``modify:`` key.
+
+The following example would change the ``name`` of the root Logical Component
+to "Coffee Machine" (notice how we use a different UUID than before):
+
+.. code-block:: yaml
+   :emphasize-lines: 2
+
+   - parent: !uuid 0d2edb8f-fa34-4e73-89ec-fb9a63001440
+     modify:
+       name: Coffee Machine
+
+This is not limited to string attributes; it is just as well possible to change
+e.g. numeric properties. This example changes the ``min_card`` property of an
+exchange item element to ``0`` and the ``max_card`` to infinity, effectively
+removing both limitations:
+
+.. code-block:: yaml
+   :emphasize-lines: 3-
+
+   - parent: !uuid 81b87fcc-03cf-434b-ad5b-ef18266c5a3e
+     modify:
+       min_card: 0
+       max_card: .inf
+
+Deleting objects
+----------------
+
+Finally, with declarative modelling files, it is possible to delete objects
+from the model. Depending on where the delete operation occurs, either the
+target object is deleted entirely, or only the link to it is destroyed.
+
+Currently, objects to be deleted can only be selected by their UUID.
+
+For example, this snippet deletes the logical function named "produce Great
+Wizards" from the model:
+
+.. code-block:: yaml
+   :emphasize-lines: 3
+
+   - parent: !uuid f28ec0f8-f3b3-43a0-8af7-79f194b29a2d
+     delete:
+       functions:
+         - !uuid 0e71a0d3-0a18-4671-bba0-71b5f88f95dd
+
+In contrast, this snippet only removes its allocation to the "Hogwarts" root
+component, but the function still exists afterwards:
+
+.. code-block:: yaml
+   :emphasize-lines: 3
+
+   - parent: !uuid 0d2edb8f-fa34-4e73-89ec-fb9a63001440
+     delete:
+       allocated_functions:
+         - !uuid 0e71a0d3-0a18-4671-bba0-71b5f88f95dd

--- a/examples/10 Declarative Modeling.ipynb
+++ b/examples/10 Declarative Modeling.ipynb
@@ -1,0 +1,227 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors\n",
+    "SPDX-License-Identifier: Apache-2.0\n",
+    "\n",
+    "\n",
+    "# Declarative Modeling Example\n",
+    "\n",
+    "Declarative approach to modeling means that one could define or update a model using a fragment of structured text. A number of fragments could be \"played\" against a model in a sequence to build it up.\n",
+    "\n",
+    "Enabling declarative modeling for Capella models enables a range of complex automations around modeling process that are explainable / transparent to human auditors.\n",
+    "\n",
+    "This notebook will demonstrate a basic application of this approach to modeling on a coffee machine example. Please note that we will not model any specific modeling process but rather a \"free-form\" demo."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# System Analysis of a Coffee Machine\n",
+    "\n",
+    "Lets do a quick system analysis of a coffee machine. Lets assume that our meta-solution is an automated coffee machine for a household use. We may look into variant management scenario in a separate example.\n",
+    "\n",
+    "## 0. Initialize\n",
+    "\n",
+    "But before we can model something lets first initialize the model. We will use an empty Capella 5.2 model as a starting point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Cannot load PVMT extension: ValueError: Provided model does not have a PropertyValuePkg\n",
+      "Property values are not available in this model\n"
+     ]
+    }
+   ],
+   "source": [
+    "import capellambse\n",
+    "import io\n",
+    "from capellambse import decl, helpers\n",
+    "\n",
+    "model = capellambse.MelodyModel(\n",
+    "    \"../tests/data/decl/empty_project_52/empty_project_52.aird\",\n",
+    "    jupyter_untrusted=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "to visualize the modeling results we'll use context-diagrams extension, you may get one by uncommenting and running the command below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#!pip install capellambse_context_diagrams"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "lets verify that the model is empty at SA layer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "At SA layer the model has 0, out of which 0 are allocated to Root Component\n"
+     ]
+    }
+   ],
+   "source": [
+    "functions_allocated = model.sa.root_component.allocated_functions\n",
+    "functions_available = model.sa.root_function.functions\n",
+    "print(f\"At SA layer the model has {len(functions_available)}, out of which {len(functions_allocated)} are allocated to Root Component\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also for this to work we'll need \"coordinates\" of some key elements in the model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "root_function = model.sa.root_function\n",
+    "root_component = model.sa.root_component\n",
+    "structure = model.sa.component_package"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Context\n",
+    "\n",
+    "Lets start by renaming the root component from **System** to **Coffee Machine**, creating a human actor **User** and a component exchange between those two.\n",
+    "\n",
+    "We can achieve this by applying the following YAML patch to an empty Capella model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_update = f\"\"\"\n",
+    "- parent: !uuid {root_component.uuid}\n",
+    "  modify:\n",
+    "    name: Coffee Machine\n",
+    "- parent: !uuid {root_component.uuid}\n",
+    "  create:\n",
+    "    ports:\n",
+    "      - name: usr\n",
+    "        direction: INOUT\n",
+    "        promise_id: usr-port-promise\n",
+    "    exchanges:\n",
+    "      - name: user interactions\n",
+    "        source: !promise usr-port-promise\n",
+    "        target: !promise cm-port-promise\n",
+    "- parent: !uuid {structure.uuid}\n",
+    "  create:\n",
+    "    components:\n",
+    "      - name: User\n",
+    "        is_actor: true\n",
+    "        is_human: true\n",
+    "        ports:\n",
+    "          - name: cm\n",
+    "            direction: INOUT\n",
+    "            promise_id: cm-port-promise\n",
+    "\"\"\"\n",
+    "# the below line applies the model_update to the model\n",
+    "decl.apply(model, io.StringIO(model_update))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and now we can verify the changes by visualizing the context of our system under analysis:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYQAAABICAIAAAB5ghX/AAAABmJLR0QA/wD/AP+gvaeTAAAQi0lEQVR4nO3de1xMef8A8M+cM81UpEmUbCW3UOkmWy5JyJ1c16qsYl2zqce2HtJj3fa3YWMfpK1+kUexyF1EpLUUSx4qCmvZDUk1CVMzzuX542SMmmpkyrE+79e8en3ne875fj9T02c+5zIzApZlASGE3jfifQeAEEIAmIwQQjyByQghxAuYjBBCvIDJCCHEC5iMEEK8gMkIIcQLmIwQQryAyQghxAvC+hePGhXdPHGgpnPs2Nz3HQJCDWsgGQHAxsP4VP6ABY/FlxP0YWg4GeFb1xBCzaDhZITZCCHUDLAyQgjxAlZGCCFewMoIIcQLWBkhhHgBKyOEEC9gZYQQ4gWsjBBCvICVEUKIF/CNsgghXtBgNw0rI4Q+JgUFBUm7dtM0PWniBEdHx2abFysjhNBrqamp0wJmllRBBSNaEPz19u3bm21qbVZGN69dfVpW+lbTW3Ts/IlVx7faBCHUdKKioiZ8MUco1AEAC6vO0TFb/P39m2dqDQ5gaywz5ajXwCFvtUnG0UM+C4K1GANC6F2USp9ymQgABAKBgGi+nSdtVkYGrQx7OjjXtfTc2dOZF85x7UlTfDt17goAF65exmNSWmHfUlDXIoFgHgDg95h/hASCOp8VnNrPCpdezrnZF+2cXQHgTn5uT5vuTRVcLdpJe2kH9x3fnXjnZt7B5N3pp09ynXduF9zIu34j73rBzTwAuHA+Y9OG77nbH3fvqG4ur6xc989/DO1uOdy240RX+z1xW+uaKHlb7HgXW/+hA2q0G8HVtKXPQFfl3VUL59q3FNy5kavh5vKqqr7tJbX7XYx1GxfPu2Pr9r5CQu/d2z4r1q2NMNIl9v7/pn3xm+mKJ5GRkc0WqnYqoz9z8/z9Zw/rPwgAknbEeg4eCgD+PuPv37sLAGKxeFvigb/+vK92cJaF0Omf6+rr77+U28KglbTkyb5tMXVNujtmS8T23V1te7LsG+3GYIF6+fKPWwVWXbsp5PKLZ8+YWVhy8Wi0Nfv6p6ptqb/g/z76cOno6GyI/CEpKQkAfHx8mnNq7VRGJEmKRWLuVnsnkyBId49BFpYd1G57Oy/nyvlflm+ObWHQCgCM2rSdFRoGAGmHkie69hzvYhPiM6G8tAQA1i9ddP/326uD521euUy1DQCXMs5MG9Rnch+HgGED7ubf4EZW26lqzNQvjiTtAICM40f6DRmm3FX+etrkyX0cxve2XRU0h6FprjMrPW3qAJfxvW0/6+dUeO8u17ll9b/G9eoxrlePvOzLXE/AsAFQXTcZRq1ZHjp9is/AT5VLGwwJoY+Wdiqjth077U05mHcps3ev3t2626hdZ+Jnvs4urjnXr/a0d3JwclH237x2tXMPWz39lqoTPX5Q+N0/AnemXzSz6PDD0kWRy75ZERW/aM0P504c+y5uZ3tLKwBQtkuLi9cvXRRzOM2wtfH1S5nhcwN2pl8se6Kms0ZIQ7wnzR03NDB89ZGkHbMXh/968jhXGf1z/WZjE1OWZVctnJOyd9eoKX4lj4vCZk2LPnSqi41dVaWMK3KfVzzt0sNuftjKYz/vjFr9r83JKcrfGMvCi2cVrgOHzFu64teTKdxSTUJqIsbG1omJl5tnLsQfxsbWmq+sUCgKCwu5dnFxMQDcvXsXACiKatu2rZGRUVNEqEo7Z9OePy1XyGQCYMvLpaWlJV7DRgHA8FHeJU8ePy56ZGFpBQCGhhJzC8tHjx6YW1jq6qocWFGX7a5dvODiPtDMogMAfPblvFmjB9cze/aFc2VPipfM9OXuvnj+rK7OGvRbtuzh4Jx2KPnhn/dsnXsr+9MO7juRvBsAyp4UtzRoNWqK39XMX536unexsQMAXT19AJBXVYl1db3GTwYA577usWtX1xhcV0/fua87AHSxseMqKU1CaiKtW1snJWEy+ui0bv0WyUgqlcbExHDtGzduAEBRURF318fHhx/JSIPKiJbJQhZ8zbWjNq3jGsu+/T8AyEg/5eHpBQDxsVs2b1zLLdqedGCw1wiu3c3e6febebLnz/VbtHw9J8sKQFA9tepPrvFmm2XZbnYOm/elqMastrP2Qxsz9YvFAZ9PXxiqnOX6payD/4mPSznboqXBfzZHFt67CyyAajyvttURiblOgiBpiqoRlVBHh+sRCAhuqUYhNY2ysls+PsubaTLEGwsXbtB8ZVNT0++//55rv5djRtrZTSsuepR+OpWmKSEp/PP+H8p+iqLu/3E3p3U2ABQXF6kdvKuNvaNbvxVfzQqL3GpgKJGWPNkXHz3WL2DdkpDHDx+YmH2yPyHO1WOwMgzVY8xc28nNfXXw3GsXM+0/7cMwTP61bBsnF7WdtWf/1GPIrG/CR0ycyrLVWa5CKm1nbqnfwoB6SZ05csC6pwPLglOfARGLF1Yf7a6qYliGEBCgchibhTeiApXD28qlmoTUREpLb/n6vt1cGRkZWVlZXNvAwCAgIEBPT091hezs7OPHj6v2ODs7jxgx4h1DRVrk53ercRvK5fLmPwmrnd0075nzqqoqM/YmTho/efqMOa9HFwq9J3zGtQ0N1ZwI56zdvmfTiqWT3OwEAoGBoWTq3CDT9uaLI/69YNJIYFmLTl3Cf4ypZ3ZjE9PInfvXLw2pkskomvIcNc7GyUVtZ+1tCYLwmx+i2uPm6XU4aXvwVG9dff2O3Xoop1gdvWPpLF/q5Uuhjs7a7XtM2rXX/PdTT5xvO0izOXHiRPLhlC7d7UiSKH74167dP2ecTSdUzk5kZWXt/nlvnwEDaYp5SdMFN3Lv3b+PyejvISEhobS0NCAgoMErlbRIUH/+GzUqenWipl/ieCDm37NVMlENRw8nnzpxlGvPCQyxsbUHgK3xMZNmf6VxtKhOzkb1/SkFggb+0LUtWbIk/68n4z73F4t0RDrCVaHzvwqcOyMgQLlCVFTU+awroeGrKxWKKrli/+6dVeWPYmPqe9lonHHjYg8enKV2Ecuye/ZcnTKlzkttG6HGmPXMzn/1/93rWnrlypWffvrJ2tpaIpF8+eWXTRngG7T5dhBpaem5jDN1LTU0NJo0ZRrXLi0p4dakKUqLAXzktP4iRhCEkCSFJKkjFE4NmPd1aOjMGTNUVxCJxH09h9g7u1IUTTOMFqdmGJYgqh/O2rXe9ay2Z0+2hslIdcz6V1Mds57ZPwhv+6xgGGbZsmUJCQlt2rQZO3bs0KFDLS0tmyi2GrT5dpAxAXPllZVvNf1wZze8RFArrpSp/z2G+0UfO9bILygnCYFQSHI3R5dP5ZWVcUczxbqvjxzlXL6wIWJVbNIhiqYZhgYWpFJZaOjBuDgfALh/vywyMv3HHyfK5dS6dacfPnwKAI6On8ye3Q8Arl17sGPHJbmc0tcXLVgwwNLSSKGgfX0Txo7tWVgo9fS0dnOz4mb55ptDBw/O4pZ6e/csLCx//PjZ/PnuXbu23bHjN4WCDgs7oq8vCgsb1uCY6em3Hjx4StOMjY1ZYKA7l5v++9/CbdsuKhSUUEiGhQ09fvym6pjc7ABw/vzdxMTLDMOam0uCgjxatdJVG5LaB/u+NOK4T1xc3JgxY0xMTAAgMjIyMDDw8OHDzbOzps3KqI2pmRZHQ+8dISC5ykhIkmKRqJXE6Fm5VNzudTKy6+W2aWXos4oKgVDIMHU+8bOz/xIKiaiozwDg+XM5AJSXV8bFZX733WgDA938/McbNqRv2DABAGQyRc+eZtOm9VY7jkymcHIy9/Pr/dtvf+7c+duKFSO/+KL30aM5a9aM0XDM7t1NJRI9loXNmzMyMm57elpLpbL168+sWTO6Q4fWcjnFsqA6plJJyYuoqHMbNkwwMTGIi7sQH58VHDxQbUi1H+wHpKysLDk5OSWl+oSvtbW1p6dnbGzs7Nmzm2F2/HA1VCdCWRmRpJAkK2UvxG+eUGNoBgBohgWKphmmrldPKyvjmJgLMTEXnJzMnZzMASAv71F5eeXatae5FSorX3INHR3SwcG8rnjEYqGtrRkAWFm1LiqqqLFUkzF//fX3X365AwDl5ZX6+iJPT8jLK7K1NevQoTU3PgDQtJr9zZs3i+zt25uYGADAyJG2S5ceqSuk2g/2A5KQkPDtt9+SJKnsCQ4O9vX19ff3F4lETT27Nisj9DejPGYkFJLPnz1lGMbA8I0r3wpystubWwp1dKoUCoZhSACSJBim+uWLoqr/q83MWm3ZMvnq1cKzZ2/v23c1IsKbZaFTJ+MVK0bWmFEkIuvZIRAKq8/lCQSC2imjwTHz8x+fPJkfEeGtp6dz4MD1V+mM1WQXhGUBQM16tUOq/WAbHp03QkJCavQQBLFr167mmb3h96Zx1/Lg7QO9vQMBQQhe7aYJz546IRaLpg1xVL39sCxo+pwgiqYpimYYBgAMDHTlcorbPbly5S9uoJKSFyRJ9OvXaf78/r//XsKyYGdnVlBQnJ//GABYlr19+0njQiRJgiAILus1OObz53ITEwM9PR2aZjIzq99daGfXPi/vUWFhOQAoFLRcTqmOqWRj0y4392Fp6QsASE3Nd3Sss+Sp/WCRhrAyQnUiCILbTaMoxa6EmH1793p4eCiXRkVFnUw/79i7T5VCQdE0zbA6wAoEMGOGW3j4sfbtDdu0qb6k/t690m3bsrgTyXPn9hcIQCLRW7ZsWEzMebmcomm2Tx+rrl3bNi7I0aNtg4L2GRnprVkzpv4xnZzM09IKVq48IRYLLSyqSzyJRG/RokHr1p2maYYkiSVLvNq1a6U6JrdamzYt5szpv3x5CsuyZmaGQUEeNeN4pfaD5ZuSkpJ27dpRr05k5+bmDh8+XPmutPeo4euMViQ08lwM4oPl0xt5Nm3JkqUpqWl2Dk4kSd66mdujW5dt8fGqK0RFRW3ctMXBpQ9F0zRF/3GnwLWXfVxsrJYCR01Fi8mIpmnVA0zvCL/EEak3fPgwicSQa/f/1HHmzJk1VnBzc5sulSrvujp0c3bW5sWHqJnJZDJfX987d+4AwODBgzdu3AgAZ86cCQsLk8lkhoaG0dHRNjY2VVVVpqamQUFB+fn5fn5+3t5aOyiGX+KI1PPw8FDdKavN2dkZs8/fSWpqqkgkysnJAQCpVAoAxcXFixYtSktLMzY2zszMDAgIuHjxIgBUVFR4eHisWrVKuwFgZYTQx6X2FYxcj729fUhISEhIiJeXl5eXFwCcO3euuLjY17f6Q2+ePav+0BuxWDx4cH2f6tM4WBkh9HGRSCQEQZSXl0skEgAoKSnhrrfu3Lnz9evXT506lZiYGBERkZGRwbKsg4OD8hpIJV1d3aa4JluDU/t4+5BvCNVAkuTAgQO3bt0KADRNx8bGcnVQYWGhUCicOHHili1bsrOzWZZ1d3e/dOlSZmYmADAMc/ly034+H1ZGCH104uLiAgMDu3TpAgCDBg0KDw8HgJycnMWLF3MXJWzatEkgEJiamu7fvz8kJEQmk1EUNW7cOBeXJvzQm4ZP7YfH46n9D9iqGY1/oyxCzQkrI4QQL+DZNIQQLzScjFbPjG6GOBBCH7m3/jRShBBqCtr5RlmEEHpHmIwQQryAyQghxAuYjBBCvIDJCCHEC5iMEEK8gMkIIcQLmIwQQryAyQghxAuYjBBCvIDJCCHEC5iMEEK8gMkIIcQLmIwQQryAyQghxAuYjBBCvPA/ucKbfW/xBg8AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Diagram 'Context of Coffee Machine'>"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "root_component.context_diagram"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please note: the changes we made are not yet stored - if you like those to be saved you may use `model.save()` method. This will save the model back to where it was loaded from, for example by writing back into local files, or by creating a Git commit and pushing it back to the remote.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.6 ('.venv': venv)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "f5c9192943a88c565de58e6fd7c534c9de794a35889e45ad6809ab92c821a96c"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/10 Declarative Modeling.ipynb.license
+++ b/examples/10 Declarative Modeling.ipynb.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
+SPDX-License-Identifier: Apache-2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,12 @@ test = [
   "cssutils",
   "pytest",
   "pytest-cov",
+  "pyyaml>=6.0",
   "requests-mock",
+]
+
+decl = [
+  "pyyaml>=6.0",
 ]
 
 httpfiles = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,10 @@ test = [
   "requests-mock",
 ]
 
+cli = [
+  "click",
+]
+
 decl = [
   "pyyaml>=6.0",
 ]

--- a/tests/data/decl/coffee-machine.yml
+++ b/tests/data/decl/coffee-machine.yml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+- parent: !uuid 0d2edb8f-fa34-4e73-89ec-fb9a63001440  # root logical component
+  create:
+    components:
+      - name: Coffee Machine
+        allocated_functions:
+          - !promise brew coffee
+- parent: !uuid f28ec0f8-f3b3-43a0-8af7-79f194b29a2d  # root logical function
+  create:
+    functions:
+      - name: brew coffee
+        promise_id: brew coffee
+        inputs:
+          - name: Portafilter port
+          - name: Steam port
+            promise_id: steam input
+        outputs:
+          - name: Fluid port
+          - name: Waste port
+            promise_id: waste output
+      - name: produce steam
+        inputs:
+          - name: Water port
+          - name: Power port
+          - name: User command
+        outputs:
+          - name: Steam port
+            promise_id: steam output
+      - name: collect process waste
+        inputs:
+          - name: Waste port
+            promise_id: waste input
+    exchanges:
+      - name: Steam
+        source: !promise steam output
+        target: !promise steam input
+      - name: Waste
+        source: !promise waste output
+        target: !promise waste input

--- a/tests/data/decl/empty_project_52/.project
+++ b/tests/data/decl/empty_project_52/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>empty_project_52</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+		<nature>org.polarsys.capella.project.nature</nature>
+	</natures>
+</projectDescription>

--- a/tests/data/decl/empty_project_52/.project.license
+++ b/tests/data/decl/empty_project_52/.project.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
+SPDX-License-Identifier: Apache-2.0

--- a/tests/data/decl/empty_project_52/empty_project_52.afm
+++ b/tests/data/decl/empty_project_52/empty_project_52.afm
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_1cWXMEhgEe2YzOKfCD79vw">
+  <viewpointReferences id="_1cwm4EhgEe2YzOKfCD79vw" vpId="org.polarsys.capella.core.viewpoint" version="5.2.0"/>
+</metadata:Metadata>

--- a/tests/data/decl/empty_project_52/empty_project_52.afm.license
+++ b/tests/data/decl/empty_project_52/empty_project_52.afm.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
+SPDX-License-Identifier: Apache-2.0

--- a/tests/data/decl/empty_project_52/empty_project_52.aird
+++ b/tests/data/decl/empty_project_52/empty_project_52.aird
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<viewpoint:DAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description" uid="_1cXlUEhgEe2YzOKfCD79vw" selectedViews="_1diC8EhgEe2YzOKfCD79vw _1gR08EhgEe2YzOKfCD79vw _1pbw8EhgEe2YzOKfCD79vw _1qVI0EhgEe2YzOKfCD79vw _1rN5oEhgEe2YzOKfCD79vw _1ripwEhgEe2YzOKfCD79vw _1zH4cEhgEe2YzOKfCD79vw _10tM0EhgEe2YzOKfCD79vw" version="14.6.0.202110251100">
+  <semanticResources>empty_project_52.afm</semanticResources>
+  <semanticResources>empty_project_52.capella</semanticResources>
+  <ownedViews xmi:type="viewpoint:DView" uid="_1diC8EhgEe2YzOKfCD79vw">
+    <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']"/>
+  </ownedViews>
+  <ownedViews xmi:type="viewpoint:DView" uid="_1gR08EhgEe2YzOKfCD79vw">
+    <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']"/>
+  </ownedViews>
+  <ownedViews xmi:type="viewpoint:DView" uid="_1pbw8EhgEe2YzOKfCD79vw">
+    <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']"/>
+  </ownedViews>
+  <ownedViews xmi:type="viewpoint:DView" uid="_1qVI0EhgEe2YzOKfCD79vw">
+    <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']"/>
+  </ownedViews>
+  <ownedViews xmi:type="viewpoint:DView" uid="_1rN5oEhgEe2YzOKfCD79vw">
+    <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/EPBS.odesign#//@ownedViewpoints[name='EPBS%20architecture']"/>
+  </ownedViews>
+  <ownedViews xmi:type="viewpoint:DView" uid="_1ripwEhgEe2YzOKfCD79vw">
+    <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/com.thalesgroup.mde.capella.diagramstyler/descriptions/diagramstyler.odesign#//@ownedViewpoints[name='Diagram%20Styler']"/>
+  </ownedViews>
+  <ownedViews xmi:type="viewpoint:DView" uid="_1zH4cEhgEe2YzOKfCD79vw">
+    <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/context.odesign#//@ownedViewpoints[name='System%20Analysis']"/>
+  </ownedViews>
+  <ownedViews xmi:type="viewpoint:DView" uid="_10tM0EhgEe2YzOKfCD79vw">
+    <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']"/>
+  </ownedViews>
+</viewpoint:DAnalysis>

--- a/tests/data/decl/empty_project_52/empty_project_52.aird.license
+++ b/tests/data/decl/empty_project_52/empty_project_52.aird.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
+SPDX-License-Identifier: Apache-2.0

--- a/tests/data/decl/empty_project_52/empty_project_52.capella
+++ b/tests/data/decl/empty_project_52/empty_project_52.capella
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--Capella_Version_5.2.0-->
+<org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/5.0.0"
+    xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/5.0.0"
+    xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/5.0.0"
+    xmlns:org.polarsys.capella.core.data.capellamodeller="http://www.polarsys.org/capella/core/modeller/5.0.0"
+    xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/5.0.0"
+    xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/5.0.0"
+    xmlns:org.polarsys.capella.core.data.epbs="http://www.polarsys.org/capella/core/epbs/5.0.0"
+    xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/5.0.0"
+    xmlns:org.polarsys.capella.core.data.information="http://www.polarsys.org/capella/core/information/5.0.0"
+    xmlns:org.polarsys.capella.core.data.information.datatype="http://www.polarsys.org/capella/core/information/datatype/5.0.0"
+    xmlns:org.polarsys.capella.core.data.information.datavalue="http://www.polarsys.org/capella/core/information/datavalue/5.0.0"
+    xmlns:org.polarsys.capella.core.data.la="http://www.polarsys.org/capella/core/la/5.0.0"
+    xmlns:org.polarsys.capella.core.data.oa="http://www.polarsys.org/capella/core/oa/5.0.0"
+    xmlns:org.polarsys.capella.core.data.pa="http://www.polarsys.org/capella/core/pa/5.0.0"
+    id="e6c61fb4-8832-4a82-bba1-41f0530f98df"
+    name="empty_project_52">
+  <ownedExtensions xsi:type="libraries:ModelInformation" id="073f2a16-15b4-4edf-9b5b-0a2723b96fac"/>
+  <ownedEnumerationPropertyTypes xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyType"
+      id="8721979f-15d1-49b1-8106-0579e30f6db5" name="ProgressStatus">
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="f93b3999-246d-43da-a02c-f76131f6c834" name="DRAFT"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="7390c4a0-ef13-4933-8cae-9e35ea93c857" name="TO_BE_REVIEWED"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="a41dcc3a-40e4-4f3c-94c8-6a74fffa39aa" name="TO_BE_DISCUSSED"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="28c38d9c-7edc-4eee-b6e0-732d9c414b20" name="REWORK_NECESSARY"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="f16af4ad-5016-41ec-8ed1-975fedfc1b6f" name="UNDER_REWORK"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="67682089-e4f4-4b55-9157-cd1e5877ff3c" name="REVIEWED_OK"/>
+  </ownedEnumerationPropertyTypes>
+  <keyValuePairs xsi:type="org.polarsys.capella.core.data.capellacore:KeyValue" id="9aa954d7-ea66-4f21-85d8-9374da600190"
+      key="projectApproach" value="SingletonComponents"/>
+  <ownedModelRoots xsi:type="org.polarsys.capella.core.data.capellamodeller:SystemEngineering"
+      id="2ba71196-f4ad-48cb-934d-e357ae142753" name="empty_project_52">
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.oa:OperationalAnalysis"
+        id="c1abf2ee-a6e5-48a6-91ac-5a9d0393d9e9" name="Operational Analysis">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.oa:OperationalActivityPkg"
+          id="0e3b6244-fa20-4c4c-95ac-87caaf1eb68d" name="Operational Activities">
+        <ownedOperationalActivities xsi:type="org.polarsys.capella.core.data.oa:OperationalActivity"
+            id="8a3e4111-53f2-450c-bb52-8c5856a2f2e0" name="Root Operational Activity"/>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.oa:OperationalCapabilityPkg"
+          id="933e29c4-f74c-4d59-9c6a-fc0554463ac2" name="Operational Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="4f9b6def-388f-4006-a97a-4aa7e8f9f5fd" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="eae8737b-c085-4a78-9c84-ecb4f83a04c0" name="Data"/>
+      <ownedRolePkg xsi:type="org.polarsys.capella.core.data.oa:RolePkg" id="2821ed3a-c850-4b1c-a5e8-53987a1b7e43"
+          name="Roles"/>
+      <ownedEntityPkg xsi:type="org.polarsys.capella.core.data.oa:EntityPkg" id="31d4122c-b8a3-4e82-a48c-f1409f394111"
+          name="Operational Entities"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.ctx:SystemAnalysis"
+        id="8bd54dcb-81a2-4c22-91cb-e7253fd7c79f" name="System Analysis">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.ctx:SystemFunctionPkg"
+          id="8e6ef668-8f32-46d6-9843-c07bbceaab0c" name="System Functions">
+        <ownedSystemFunctions xsi:type="org.polarsys.capella.core.data.ctx:SystemFunction"
+            id="3f1dc838-274f-4553-a44b-877ca3958d24" name="Root System Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="1daedbf3-3788-45cb-9e49-da1b5ade2983" targetElement="#8a3e4111-53f2-450c-bb52-8c5856a2f2e0"
+              sourceElement="#3f1dc838-274f-4553-a44b-877ca3958d24"/>
+        </ownedSystemFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.ctx:CapabilityPkg"
+          id="bc7f17c6-57a9-4adf-8f01-5f71e830b6fa" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="004f3475-1923-4206-97c5-8207a9d42b92" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="b971d23b-fa3e-492a-8b35-b7150beb16a9" name="Data">
+        <ownedDataPkgs xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+            id="bc3792e4-0979-44b9-8e21-c2b07122bdc2" name="Predefined Types">
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:BooleanType"
+              id="e0de98bf-6fbe-4371-93cf-830019022f7a" name="Boolean" visibility="PUBLIC">
+            <ownedLiterals xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralBooleanValue"
+                id="73292449-0dfc-4441-803c-c37ecf7a5b26" name="True" abstractType="#e0de98bf-6fbe-4371-93cf-830019022f7a"
+                value="true"/>
+            <ownedLiterals xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralBooleanValue"
+                id="c87cad9f-09f8-4540-83a5-ad947446e3cf" name="False" abstractType="#e0de98bf-6fbe-4371-93cf-830019022f7a"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="51504462-484f-4b21-8aa9-2eaebfdcaa39" name="Byte" visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="c1a6dfb2-4cff-4664-821c-3996420fced6" name="" abstractType="#51504462-484f-4b21-8aa9-2eaebfdcaa39"
+                value="0"/>
+            <ownedMaxValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="522df832-cd99-46bd-a6e8-5c505e4bbf89" name="" abstractType="#51504462-484f-4b21-8aa9-2eaebfdcaa39"
+                value="255"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:StringType"
+              id="bc0c9b42-7dd1-4bac-aa05-6c18ea1bd187" name="Char" visibility="PUBLIC">
+            <ownedMinLength xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="a1d7a039-d187-4829-9a50-3c1714deda25" name="" abstractType="#07124dfc-aadc-4ae1-8dc3-4f52d91b8423"
+                value="1"/>
+            <ownedMaxLength xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="e01f1fc4-3cb7-417d-ab0c-c3e830da7bf5" name="" abstractType="#07124dfc-aadc-4ae1-8dc3-4f52d91b8423"
+                value="1"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="777cf04f-9349-4a55-96d1-b1c1171f0217" name="Double" discrete="false"
+              visibility="PUBLIC" kind="FLOAT"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="4e9f2bf4-af06-4349-9494-c2d1b791019a" name="Float" discrete="false"
+              visibility="PUBLIC" kind="FLOAT"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="120f7354-a5af-4d87-984a-7de059f9d9db" name="Hexadecimal" visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="6cd274a1-581a-456f-9e20-4d03b148857b" name="" abstractType="#120f7354-a5af-4d87-984a-7de059f9d9db"
+                value="0"/>
+            <ownedMaxValue xsi:type="org.polarsys.capella.core.data.information.datavalue:BinaryExpression"
+                id="47c9d82a-a0c4-4da8-bf0d-482ea703b3ce" abstractType="#120f7354-a5af-4d87-984a-7de059f9d9db"
+                operator="SUB">
+              <ownedLeftOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:BinaryExpression"
+                  id="35e086d0-6cbc-4454-8cda-169c448a9150" operator="POW">
+                <ownedLeftOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="6c341b3d-5c06-4f8e-a120-acf50843aeb6" value="2"/>
+                <ownedRightOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="418231d4-a0dd-4bc8-a7ba-9c010760b5cd" value="64"/>
+              </ownedLeftOperand>
+              <ownedRightOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                  id="a872be8b-5afd-4eff-84ab-7df60ff571f4" value="1"/>
+            </ownedMaxValue>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="4e08751d-2675-4237-8817-7bf0936f8a19" name="Integer" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="4313993a-1ca2-4638-96a9-6fe1066615b3" name="Long" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="26230caf-00f6-402c-a6ee-0b444f4c1e3f" name="LongLong" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="51f6e135-b32c-44d1-bf26-f860ed5d4771" name="Short" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:StringType"
+              id="8e27ce3d-29ef-4f17-80ec-2438dea086c9" name="String" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="5b985e45-49bb-45f8-9867-55a35120d597" name="UnsignedInteger" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="8e2ff6db-8ad8-4bf4-8993-84ad79c6d7cc" name="" abstractType="#5b985e45-49bb-45f8-9867-55a35120d597"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="07124dfc-aadc-4ae1-8dc3-4f52d91b8423" name="UnsignedShort" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="1edf1944-e3e8-482c-b21a-2ac5baaef32c" name="" abstractType="#07124dfc-aadc-4ae1-8dc3-4f52d91b8423"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="5d685782-5ecd-4a46-b62d-2191e4bfa7e1" name="UnsignedLong" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="f694b8bf-6fa3-4130-ac86-783d16d811d1" name="" abstractType="#5d685782-5ecd-4a46-b62d-2191e4bfa7e1"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="4148024a-bc90-4a45-a6c8-52eac0626ebb" name="UnsignedLongLong" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="9c14512f-c1e3-43e5-8f85-44ba17eb8f3e" name="" abstractType="#4148024a-bc90-4a45-a6c8-52eac0626ebb"
+                value="0"/>
+          </ownedDataTypes>
+        </ownedDataPkgs>
+      </ownedDataPkg>
+      <ownedSystemComponentPkg xsi:type="org.polarsys.capella.core.data.ctx:SystemComponentPkg"
+          id="09811574-6d09-4dad-8584-6e2d4f954b49" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="80fdd36b-144f-4b09-ae7e-588a5728f076"
+            name="System" abstractType="#7af5971f-1a6c-47d3-b9a8-4e709444113e"/>
+        <ownedSystemComponents xsi:type="org.polarsys.capella.core.data.ctx:SystemComponent"
+            id="7af5971f-1a6c-47d3-b9a8-4e709444113e" name="System">
+          <ownedStateMachines xsi:type="org.polarsys.capella.core.data.capellacommon:StateMachine"
+              id="28009118-a16a-47c5-9aaa-9c5391bc5a00" name="System State Machine">
+            <ownedRegions xsi:type="org.polarsys.capella.core.data.capellacommon:Region"
+                id="bc4bb044-4873-4449-9b26-cff529943ac4" name="Default Region"/>
+          </ownedStateMachines>
+        </ownedSystemComponents>
+      </ownedSystemComponentPkg>
+      <ownedMissionPkg xsi:type="org.polarsys.capella.core.data.ctx:MissionPkg" id="a1338705-2a85-4c24-a5eb-a47ec5e42f2d"
+          name="Missions"/>
+      <ownedOperationalAnalysisRealizations xsi:type="org.polarsys.capella.core.data.ctx:OperationalAnalysisRealization"
+          id="48a149f7-e8fd-4250-bef9-52c76a63a949" targetElement="#c1abf2ee-a6e5-48a6-91ac-5a9d0393d9e9"
+          sourceElement="#8bd54dcb-81a2-4c22-91cb-e7253fd7c79f"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.la:LogicalArchitecture"
+        id="56d2c105-cb15-4a0a-8800-120ddbb426fc" name="Logical Architecture">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.la:LogicalFunctionPkg"
+          id="d2dfd572-8549-4b2b-9388-556c90b1d8aa" name="Logical Functions">
+        <ownedLogicalFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
+            id="894f4504-85ce-4d1b-9189-02cb8d234355" name="Root Logical Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="bb8f2dd7-395e-40a7-8291-6c86bd3bfbf3" targetElement="#3f1dc838-274f-4553-a44b-877ca3958d24"
+              sourceElement="#894f4504-85ce-4d1b-9189-02cb8d234355"/>
+        </ownedLogicalFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="291083d5-8708-4734-9861-72a6c09b4445" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="1ed34c92-799e-48fe-9f5b-247242151f09" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="d755d151-7b1f-4df3-b4b8-329953b177dc" name="Data"/>
+      <ownedLogicalComponentPkg xsi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg"
+          id="474e84b1-3485-4012-86ba-c638767cb529" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="93fe69a7-45ac-4f91-b78a-1f3f8b198200"
+            name="Logical System" abstractType="#495208df-e9d1-48b8-8258-17f62184ab90"/>
+        <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+            id="495208df-e9d1-48b8-8258-17f62184ab90" name="Logical System">
+          <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
+              id="6d7e2a8a-43f7-4aa8-b331-ddc3cba3191e" targetElement="#7af5971f-1a6c-47d3-b9a8-4e709444113e"
+              sourceElement="#495208df-e9d1-48b8-8258-17f62184ab90"/>
+        </ownedLogicalComponents>
+      </ownedLogicalComponentPkg>
+      <ownedSystemAnalysisRealizations xsi:type="org.polarsys.capella.core.data.la:SystemAnalysisRealization"
+          id="0e5346ab-f7d4-4438-92be-bea3e5c50de3" targetElement="#8bd54dcb-81a2-4c22-91cb-e7253fd7c79f"
+          sourceElement="#56d2c105-cb15-4a0a-8800-120ddbb426fc"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.pa:PhysicalArchitecture"
+        id="aa49e2c8-b754-49f4-9528-d2aea0e89648" name="Physical Architecture">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunctionPkg"
+          id="71e0a9c8-29bf-4e18-a664-746213bea06d" name="Physical Functions">
+        <ownedPhysicalFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+            id="979c84d7-a19c-4806-9743-3c4bf6a60684" name="Root Physical Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="7702ef35-7257-4c66-81ff-8f525cf37ff1" targetElement="#894f4504-85ce-4d1b-9189-02cb8d234355"
+              sourceElement="#979c84d7-a19c-4806-9743-3c4bf6a60684"/>
+        </ownedPhysicalFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="82a7a1de-9410-477e-aa78-c641b373a423" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="4228c41b-05c7-4c99-a248-d742a04bcfa5" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="b1bb0291-e569-41f9-b629-2b0b89c1ffd4" name="Data"/>
+      <ownedPhysicalComponentPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponentPkg"
+          id="494fd973-8168-4c0e-bc0e-0c3d604a7009" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="c1735919-95cc-47de-b13d-d4476512e727"
+            name="Physical System" abstractType="#c4d19ab1-7f2b-41a1-8ecb-9f372dc9a41d"/>
+        <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+            id="c4d19ab1-7f2b-41a1-8ecb-9f372dc9a41d" name="Physical System">
+          <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
+              id="47e8fd62-8a15-4440-96d3-f68263a097dd" targetElement="#495208df-e9d1-48b8-8258-17f62184ab90"
+              sourceElement="#c4d19ab1-7f2b-41a1-8ecb-9f372dc9a41d"/>
+        </ownedPhysicalComponents>
+      </ownedPhysicalComponentPkg>
+      <ownedLogicalArchitectureRealizations xsi:type="org.polarsys.capella.core.data.pa:LogicalArchitectureRealization"
+          id="312c4cda-3123-4209-8d06-006af3464bff" targetElement="#56d2c105-cb15-4a0a-8800-120ddbb426fc"
+          sourceElement="#aa49e2c8-b754-49f4-9528-d2aea0e89648"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.epbs:EPBSArchitecture"
+        id="07424d25-4b15-4fe7-8635-26a68987e2ff" name="EPBS Architecture">
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="21b1e4c3-895a-4001-95b0-f55c51deb5a3" name="Capabilities"/>
+      <ownedConfigurationItemPkg xsi:type="org.polarsys.capella.core.data.epbs:ConfigurationItemPkg"
+          id="05fa6cf2-c4ad-44f8-b43c-86ba67cdcebd" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="cb4e8aef-c800-4e05-a088-02e509178f2d"
+            name="System" abstractType="#b871fd0f-9cee-4eb1-af4c-adec649c9a37"/>
+        <ownedConfigurationItems xsi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem"
+            id="b871fd0f-9cee-4eb1-af4c-adec649c9a37" name="System" kind="SystemCI">
+          <ownedPhysicalArtifactRealizations xsi:type="org.polarsys.capella.core.data.epbs:PhysicalArtifactRealization"
+              id="dff27b9b-67f2-48c8-a1bf-44ea53e87ff0" targetElement="#c4d19ab1-7f2b-41a1-8ecb-9f372dc9a41d"
+              sourceElement="#b871fd0f-9cee-4eb1-af4c-adec649c9a37"/>
+        </ownedConfigurationItems>
+      </ownedConfigurationItemPkg>
+      <ownedPhysicalArchitectureRealizations xsi:type="org.polarsys.capella.core.data.epbs:PhysicalArchitectureRealization"
+          id="689e8f15-e46c-4572-95be-ff6d4e38506a" targetElement="#aa49e2c8-b754-49f4-9528-d2aea0e89648"
+          sourceElement="#07424d25-4b15-4fe7-8635-26a68987e2ff"/>
+    </ownedArchitectures>
+  </ownedModelRoots>
+</org.polarsys.capella.core.data.capellamodeller:Project>

--- a/tests/data/decl/empty_project_52/empty_project_52.capella.license
+++ b/tests/data/decl/empty_project_52/empty_project_52.capella.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
+SPDX-License-Identifier: Apache-2.0

--- a/tests/test_decl.py
+++ b/tests/test_decl.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import io
+import pathlib
 
 import pytest
 
 import capellambse
 from capellambse import decl, helpers
+
+DATAPATH = pathlib.Path(__file__).parent / "data" / "decl"
 
 ROOT_COMPONENT = helpers.UUIDString("0d2edb8f-fa34-4e73-89ec-fb9a63001440")
 ROOT_FUNCTION = helpers.UUIDString("f28ec0f8-f3b3-43a0-8af7-79f194b29a2d")
@@ -434,3 +437,8 @@ class TestApplyDelete:
         decl.apply(model, io.StringIO(yml))
 
         assert len(root_function.functions) == 0
+
+
+@pytest.mark.parametrize("filename", ["coffee-machine.yml"])
+def test_full_example(model: capellambse.MelodyModel, filename: str):
+    decl.apply(model, DATAPATH / filename)

--- a/tests/test_decl.py
+++ b/tests/test_decl.py
@@ -120,3 +120,28 @@ class TestApplyCreate:
         assert actual_len == expected_len
         for i in ("first", "second", "third"):
             assert f"pass the {i} test" in parent_obj.functions.by_name
+
+    @staticmethod
+    def test_decl_creates_nested_complex_objects_where_they_belong(
+        model: capellambse.MelodyModel,
+    ) -> None:
+        root = model.by_uuid(ROOT_FUNCTION)
+        yml = f"""\
+            - parent: !uuid {ROOT_FUNCTION}
+              create:
+                functions:
+                  - name: pass the unit test
+                    functions:
+                      - name: run the test function
+                      - name: make assertions
+            """
+        expected_len = len(model.search()) + 3
+
+        decl.apply(model, io.StringIO(yml))
+
+        actual_len = len(model.search())
+        assert actual_len == expected_len
+        assert "pass the unit test" in root.functions.by_name
+        parent = root.functions.by_name("pass the unit test", single=True)
+        assert "run the test function" in parent.functions.by_name
+        assert "make assertions" in parent.functions.by_name

--- a/tests/test_decl.py
+++ b/tests/test_decl.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import io
+
+from capellambse import decl, helpers
+
+
+class TestDumpLoad:
+    @staticmethod
+    def test_promises_are_serialized_with_promise_tag():
+        id = "some-future-object"
+        data = [{"parent": decl.Promise(id)}]
+        expected = f"- parent: !promise {id!r}\n"
+
+        actual = decl.dump(data)
+
+        assert actual == expected
+
+    @staticmethod
+    def test_uuid_references_are_serialized_with_uuid_tag():
+        uuid = helpers.UUIDString("00000000-0000-0000-0000-000000000000")
+        data = [{"parent": decl.UUIDReference(uuid)}]
+        expected = f"- parent: !uuid {uuid!r}\n"
+
+        actual = decl.dump(data)
+
+        assert actual == expected
+
+    @staticmethod
+    def test_promise_tags_are_deserialized_as_promise():
+        id = "some-future-object"
+        yaml = f"- parent: !promise {id!r}\n"
+        expected = [{"parent": decl.Promise(id)}]
+
+        actual = decl.load(io.StringIO(yaml))
+
+        assert actual == expected
+
+    @staticmethod
+    def test_uuid_tags_are_deserialized_as_uuidreference():
+        uuid = helpers.UUIDString("00000000-0000-0000-0000-000000000000")
+        yaml = f"- parent: !uuid {uuid!r}\n"
+        expected = [{"parent": decl.UUIDReference(uuid)}]
+
+        actual = decl.load(io.StringIO(yaml))
+
+        assert actual == expected

--- a/tests/test_decl.py
+++ b/tests/test_decl.py
@@ -173,6 +173,24 @@ class TestApplyCreate:
         newdef = attrdefs.by_long_name("New attribute", single=True)
         assert newdef.xtype.endswith(f":{type}")
 
+    @staticmethod
+    def test_decl_can_create_simple_objects_by_passing_plain_strings(
+        model: capellambse.MelodyModel,
+    ) -> None:
+        attrdef_id = "637caf95-3229-4607-99a0-7d7b990bc97f"
+        attrdef = model.by_uuid(attrdef_id)
+        yml = f"""\
+            - parent: !uuid {attrdef_id}
+              create:
+                values:
+                  - NewGame++
+            """
+        assert "NewGame++" not in attrdef.values
+
+        decl.apply(model, io.StringIO(yml))
+
+        assert "NewGame++" in attrdef.values
+
 
 class TestApplyPromises:
     @staticmethod

--- a/tests/test_decl.py
+++ b/tests/test_decl.py
@@ -147,6 +147,32 @@ class TestApplyCreate:
         assert "run the test function" in parent.functions.by_name
         assert "make assertions" in parent.functions.by_name
 
+    @staticmethod
+    @pytest.mark.parametrize(
+        "type",
+        ["AttributeDefinition", "AttributeDefinitionEnumeration"],
+    )
+    def test_decl_can_disambiguate_creations_with_type_hints(
+        model: capellambse.MelodyModel, type: str
+    ) -> None:
+        module_id = "db47fca9-ddb6-4397-8d4b-e397e53d277e"
+        module = model.by_uuid(module_id)
+        yml = f"""\
+            - parent: !uuid {module_id}
+              create:
+                attribute_definitions:
+                  - long_name: New attribute
+                    _type: {type}
+            """
+        assert "New attribute" not in module.attribute_definitions.by_long_name
+
+        decl.apply(model, io.StringIO(yml))
+
+        attrdefs = module.attribute_definitions
+        assert "New attribute" in attrdefs.by_long_name
+        newdef = attrdefs.by_long_name("New attribute", single=True)
+        assert newdef.xtype.endswith(f":{type}")
+
 
 class TestApplyPromises:
     @staticmethod

--- a/tests/test_reqif.py
+++ b/tests/test_reqif.py
@@ -672,20 +672,9 @@ class TestReqIFModification:
         assert edt_def in reqtypesfolder.data_type_definitions
         assert set(edt_def.values.by_long_name) == {"val", "val1"}
 
-    @pytest.mark.parametrize(
-        "values",
-        [
-            pytest.param(["val", "val1"], id="Singleattr"),
-            pytest.param(
-                [{"long_name": "val"}, {"long_name": "val1"}], id="Dictionary"
-            ),
-            pytest.param(["val", {"long_name": "val1"}], id="Mixed"),
-        ],
-    )
     def test_create_RequirementTypesFolder_EnumDataTypeDefinition_creating_EnumValues(
         self,
         model: capellambse.MelodyModel,
-        values: list[str | t.Dict[str, t.Any]],
     ):
         reqtypesfolder = model.by_uuid("67bba9cf-953c-4f0b-9986-41991c68d241")
         dt_definitions = reqtypesfolder.data_type_definitions
@@ -693,7 +682,7 @@ class TestReqIFModification:
         edt_def = reqtypesfolder.data_type_definitions.create(
             "EnumerationDataTypeDefinition",
             long_name="Enum",
-            values=values,
+            values=["val", "val1"],
         )
 
         assert len(dt_definitions) + 1 == len(
@@ -701,31 +690,6 @@ class TestReqIFModification:
         )
         assert edt_def in reqtypesfolder.data_type_definitions
         assert set(edt_def.values.by_long_name) == {"val", "val1"}
-
-    def test_create_RequirementTypesFolder_from_mapping(
-        self, model: capellambse.MelodyModel
-    ):
-        reqtypesfolder = model.la.requirement_types_folders.create(
-            long_name="Test",
-            data_type_definitions=[
-                {
-                    "_type": "DataTypeDefinition",
-                    "long_name": "TestAttrDataTypeDef",
-                },
-                {
-                    "_type": "EnumerationDataTypeDefinition",
-                    "long_name": "TestEnumAttrDataTypeDef",
-                    "values": ["a", "b"],
-                },
-            ],
-        )
-
-        adtdef, edtdef = reqtypesfolder.data_type_definitions
-        assert isinstance(adtdef, reqif.DataTypeDefinition)
-        assert adtdef.long_name == "TestAttrDataTypeDef"
-        assert isinstance(edtdef, reqif.EnumDataTypeDefinition)
-        assert edtdef.long_name == "TestEnumAttrDataTypeDef"
-        assert edtdef.values == ["a", "b"]
 
 
 class TestRequirementsFiltering:


### PR DESCRIPTION
This PR introduces a modelling language based on a YAML format. Please refer to the added documentation for details.

Mandatory main goals for this PR:

- [x] Implement a `dump` and `load` function, which convert between Python and the YAML format
- [x] Implement the `apply` function, which consumes a YAML file and modifies a model
  - [x] Select existing model objects via `parent: !uuid 1234abcd-...`
  - [x] Create new child objects with the `create:` YAML keyword
  - [x] Modify properties of existing objects with the `modify:` YAML keyword
  - [x] Delete child objects with the `delete:` YAML keyword
- [x] Add documentation

Optional goals, which may also be moved to a separate, later PR:

- [x] Add an example notebook
- [ ] Add a YAML Schema for input validation and LSP support
- [ ] In `apply`, select existing model objects with a query string like `parent: la.root_component`