### PR TITLE
Fix wrong `_xmltag` for `AttributeDefinitionEnumeration`

### DIFF
--- a/capellambse/extensions/reqif/elements.py
+++ b/capellambse/extensions/reqif/elements.py
@@ -487,7 +487,7 @@ class EnumDataTypeDefinition(ReqIFElement):
 class AttributeDefinitionEnumeration(ReqIFElement):
     """An enumeration attribute definition for requirement types"""
 
-    _xmltag = "enumeration"
+    _xmltag = "ownedAttributes"
 
     data_type = c.AttrProxyAccessor(EnumDataTypeDefinition, "definitionType")
     multi_valued = xmltools.BooleanAttributeProperty(


### PR DESCRIPTION
Fix a bug where creation of `AttributeDefinitionEnumeration`s and saving them would make Capella not show any layers anymore.