### PR TITLE
fix: Fix broken references to `.functions`

### DIFF
--- a/capellambse/extensions/pvmt.py
+++ b/capellambse/extensions/pvmt.py
@@ -18,9 +18,9 @@ class PropertyValueProxy:
 
     Example for accessing property values on any object that has pvmt::
 
-        >>> model.la.functions[0].pvmt['domain.group.property']
+        >>> model.la.all_functions[0].pvmt['domain.group.property']
         'property'
-        >>> model.la.functions[0].pvmt['domain.group']
+        >>> model.la.all_functions[0].pvmt['domain.group']
         <pvmt.AppliedPropertyValueGroup "domain.group"(abcdef01-2345-6789-abcd-ef0123456789)>
 
     .. note::

--- a/capellambse/model/layers/la.py
+++ b/capellambse/model/layers/la.py
@@ -36,7 +36,7 @@ class LogicalFunction(fa.Function):
             return next(
                 i
                 for i in self._model.search("LogicalComponent")
-                if self in i.functions
+                if self in i.allocated_functions
             )
         except StopIteration:
             return None

--- a/capellambse/model/layers/pa.py
+++ b/capellambse/model/layers/pa.py
@@ -32,7 +32,7 @@ class PhysicalFunction(fa.Function):
     owner = c.CustomAccessor(
         c.GenericElement,
         operator.attrgetter("_model.pa.all_components"),
-        matchtransform=operator.attrgetter("functions"),
+        matchtransform=operator.attrgetter("allocated_functions"),
     )
     realized_logical_functions = c.ReferencingProxyAccessor(
         la.LogicalFunction,


### PR DESCRIPTION
27e998634db1d424270720945b179c94a3894ab2 and other, even earlier commits broke references to `.functions` attributes (both in code as well as docstrings). This commit fixes those references by updating them to their correct names.