### PR TITLE
Fix launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.2.0",
   "configurations": [
     {
       "name": "Interact with the documentation model",


### PR DESCRIPTION
Missing the version field causes VSCode to raise an annoying error without helping. Comparing the launch.json with one of my other repos revealed the difference.