### PR TITLE
Add a note for save and update_cache dependance

### DIFF
--- a/capellambse/loader/core.py
+++ b/capellambse/loader/core.py
@@ -382,6 +382,11 @@ class MelodyLoader:
     def save(self, **kw: t.Any) -> None:
         """Save all model files back to their original locations.
 
+        .. note:: Write transactions to the model needs an updated
+            cache. If :attr:`filehandler` is of type ``GitFileHandler``
+            make sure that you loaded the model with the
+            ``update_cache`` paremeter set to ``True``.
+
         Parameters
         ----------
         kw

--- a/capellambse/loader/core.py
+++ b/capellambse/loader/core.py
@@ -382,11 +382,6 @@ class MelodyLoader:
     def save(self, **kw: t.Any) -> None:
         """Save all model files back to their original locations.
 
-        .. note:: Write transactions to the model needs an updated
-            cache. If :attr:`filehandler` is of type ``GitFileHandler``
-            make sure that you loaded the model with the
-            ``update_cache`` paremeter set to ``True``.
-
         Parameters
         ----------
         kw
@@ -399,6 +394,15 @@ class MelodyLoader:
             Accepted ``**kw`` when using local directories
         capellambse.loader.filehandler.gitfilehandler.GitFileHandler.write_transaction :
             Accepted ``**kw`` when using ``git://`` and similar URLs
+
+        Notes
+        -----
+        With a :attr:`filehandler` that contacts a remote location (such
+        as the :class:`filehandler.gitfilehandler.GitFileHandler` with
+        non-local repositories), saving might fail if the local state
+        has gone out of sync with the remote state. To avoid this,
+        always leave the ``update_cache`` parameter at its default value
+        of ``True`` if you intend to save changes.
         """
         self.check_duplicate_uuids()
         LOGGER.debug("Saving model %r", self.get_model_info().title)

--- a/capellambse/loader/filehandler/__init__.py
+++ b/capellambse/loader/filehandler/__init__.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import abc
 import collections.abc as cabc
-import contextlib
 import logging
 import os
 import pathlib

--- a/capellambse/model/__init__.py
+++ b/capellambse/model/__init__.py
@@ -109,6 +109,10 @@ class MelodyModel:
               * ``git://git.example.com/model/coffeemaker.git``
               * ``git+https://git.example.com/model/coffeemaker.git``
               * ``git+ssh://git@git.example.com/model/coffeemaker.git``
+
+              .. note :: Usage of :meth:`save` needs an updated cache
+                if path is a remote URL. Make sure to not set
+                ``update_cache`` to ``False``.
         entrypoint
             Entrypoint from path to the main ``.aird`` file.
         revision
@@ -221,6 +225,13 @@ class MelodyModel:
 
     def save(self, **kw: t.Any) -> None:
         """Save the model back to where it was loaded from.
+
+        .. note:: Write transactions to the model need an updated cache.
+            If the :class:`~capellambse.loader.filehandler.FileHandler`
+            is of type
+            :class:`~capellambse.loader.filehandler.gitfilehandler.GitFileHandler`
+            make sure that you loaded the model with the
+            ``update_cache`` paremeter set to ``True``.
 
         Parameters
         ----------

--- a/capellambse/model/__init__.py
+++ b/capellambse/model/__init__.py
@@ -110,9 +110,9 @@ class MelodyModel:
               * ``git+https://git.example.com/model/coffeemaker.git``
               * ``git+ssh://git@git.example.com/model/coffeemaker.git``
 
-              .. note :: Usage of :meth:`save` needs an updated cache
-                if path is a remote URL. Make sure to not set
-                ``update_cache`` to ``False``.
+              .. note:: Depending on the exact file handler, saving back
+                 to a remote location might fail with ``update_cache``
+                 set to ``False``. See :meth:`save` for more details.
         entrypoint
             Entrypoint from path to the main ``.aird`` file.
         revision

--- a/capellambse/model/__init__.py
+++ b/capellambse/model/__init__.py
@@ -226,13 +226,6 @@ class MelodyModel:
     def save(self, **kw: t.Any) -> None:
         """Save the model back to where it was loaded from.
 
-        .. note:: Write transactions to the model need an updated cache.
-            If the :class:`~capellambse.loader.filehandler.FileHandler`
-            is of type
-            :class:`~capellambse.loader.filehandler.gitfilehandler.GitFileHandler`
-            make sure that you loaded the model with the
-            ``update_cache`` paremeter set to ``True``.
-
         Parameters
         ----------
         kw
@@ -245,6 +238,15 @@ class MelodyModel:
             Accepted ``**kw`` when using local directories
         capellambse.loader.filehandler.gitfilehandler.GitFileHandler.write_transaction :
             Accepted ``**kw`` when using ``git://`` and similar URLs
+
+        Notes
+        -----
+        With a file handler that contacts a remote location (such as the
+        :class:`~capellambse.loader.filehandler.gitfilehandler.GitFileHandler`
+        with non-local repositories), saving might fail if the local
+        state has gone out of sync with the remote state. To avoid this,
+        always leave the ``update_cache`` parameter at its default value
+        of ``True`` if you intend to save changes.
         """
         self._loader.save(**kw)
 


### PR DESCRIPTION
If the `MelodyModel` was initialzed from a remote URL and the user intents to use `.save(push=True)` (i.e. `write_transaction` is executed) an up2date cache is needed. This is ensured by the default `update_cache=True` parameter. I felt the urge to update the docs with additional notes about this dependence at the right places.

Take notice that I used a `~` in `:class:`~capellambse.loader.filehandler.FileHandler`` to shorten the rendered reference to only `FileHandler`. 