### PR TITLE
Documentation improvements

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
           python -m pip install '.[docs]'
       - name: Auto-generate APIDOC sources
         run: |-
-          sphinx-apidoc --output-dir docs/source/code --force .
+          make -C docs apidoc
       - name: Create docs
         run: |
           make -C docs html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,6 @@ name: Docs
 
 on:
   push:
-    branches: ["master"]
 
 jobs:
   sphinx:
@@ -31,7 +30,18 @@ jobs:
       - name: Create docs
         run: |
           make -C docs html
+      - name: Archive the docs
+        # https://github.com/actions/upload-artifact#too-many-uploads-resulting-in-429-responses
+        run: (cd docs/build/html && zip -Xr ../html.zip .)
+      - name: Upload built docs as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Documentation
+          path: 'docs/build/html.zip'
+          if-no-files-found: error
+          retention-days: 5
       - name: Deploy
+        if: github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v3
         with:
           force_orphan: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,20 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.5.0
+    hooks:
+      - id: docformatter
+        additional_dependencies:
+          - docformatter[tomli]
+  - repo: https://github.com/PyCQA/pydocstyle
+    rev: 6.1.1
+    hooks:
+      - id: pydocstyle
+        additional_dependencies:
+          - pydocstyle[toml]
+        args:
+          - --add-ignore=D1
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.942
     hooks:

--- a/capellambse/aird/diagram.py
+++ b/capellambse/aird/diagram.py
@@ -39,7 +39,10 @@ class RoutingStyle(enum.Enum):
 
 
 class Box:
-    """A Box.  Some may call it rectangle."""
+    """A Box.
+
+    Some may call it rectangle.
+    """
 
     # The number of pixels that a port hangs over its parent's border
     PORT_OVERHANG = 2
@@ -348,6 +351,8 @@ class Box:
 
         Parameters
         ----------
+        offset
+            The offset to move the box by.
         children
             Recursively move children as well.  If False, the positions
             of children need to be adjusted separately.
@@ -461,12 +466,12 @@ class Box:
 
     @property
     def center(self) -> aird.Vector2D:
-        """The center point of this Box."""
+        """Return the center point of this Box."""
         return self.pos + self.size / 2
 
     @property
     def parent(self) -> Box | None:
-        """The parent element of this Box."""
+        """Return the parent element of this Box."""
         return self._parent
 
     @parent.setter
@@ -908,6 +913,11 @@ class Diagram:
         extend_viewport
             True to automatically extend the diagram viewport so that
             the added element is fully visible.
+        force
+            Normally an exception will be raised if another element with
+            the same UUID as the new one already exists in the diagram.
+            If this is set to True, the old element will be overwritten
+            instead.
         """
         if element.uuid is not None:
             if element.uuid in self:

--- a/capellambse/aird/json_enc.py
+++ b/capellambse/aird/json_enc.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""This module handles converting diagrams to the intermediary JSON format."""
+"""Module that handles converting diagrams to the intermediary JSON format."""
 from __future__ import annotations
 
 __all__ = ["DiagramJSONEncoder"]

--- a/capellambse/aird/parser/__init__.py
+++ b/capellambse/aird/parser/__init__.py
@@ -158,6 +158,8 @@ def parse_diagram(
 
     Parameters
     ----------
+    model
+        A loaded model.
     descriptor
         A DiagramDescriptor as obtained from :func:`enumerate_diagrams`.
     """

--- a/capellambse/aird/parser/_edge_factories.py
+++ b/capellambse/aird/parser/_edge_factories.py
@@ -267,6 +267,8 @@ def snaptarget(
         The Edge target (either a Box or another Edge)
     movetarget
         Allow to move the target under certain conditions
+    routingstyle
+        The routing style of the edge that caused this call
     """
     del movetarget
 
@@ -554,7 +556,7 @@ def _guard_condition(seb: C.SemanticElementBuilder, attr: str) -> str:
 
 
 def req_relation_factory(seb: C.SemanticElementBuilder) -> aird.Edge:
-    """Factory for Capella[Incoming/Outgoing]Relation"""
+    """Create a Capella Incoming or Outgoing Relation."""
     label = seb.melodyobjs[0].attrib.get("name", "")
     if not label:
         try:
@@ -573,14 +575,14 @@ def req_relation_factory(seb: C.SemanticElementBuilder) -> aird.Edge:
 
 
 def include_extend_factory(seb: C.SemanticElementBuilder) -> aird.Edge:
-    """Factory for AbstractCapability[Includes/Extends]"""
+    """Create an AbstractCapabilityIncludes or -Extends edge."""
     if seb.melodyobjs[0].get("name") is None:
         seb.melodyobjs[0].attrib["name"] = seb.diag_element.get("name", "")
     return generic_factory(seb)
 
 
 def association_factory(seb: C.SemanticElementBuilder) -> aird.Edge:
-    """Factory for Associations"""
+    """Create an Association."""
     edge = generic_factory(seb)
     assert len(edge.labels) == 3
 

--- a/capellambse/aird/parser/_filters/__init__.py
+++ b/capellambse/aird/parser/_filters/__init__.py
@@ -303,10 +303,10 @@ class ActiveFilters(t.MutableSet[str]):
         """Add an activated filter to the diagram.
 
         Writes a new ``<activatedFilters>`` XML element to the
-        ``<diagram:DSemanticDiagram>`` XML element. If the ``value`` is not
-        apparent in :data:`aird.parser.GLOBAL_FILTERS` as a key it can
-        not be applied when rendering. It should still be visible in the
-        GUI.
+        ``<diagram:DSemanticDiagram>`` XML element. If the ``value`` is
+        not apparent in :data:`aird.parser.GLOBAL_FILTERS` as a key it
+        can not be applied when rendering. It should still be visible in
+        the GUI.
         """
         if value in self:
             return

--- a/capellambse/cli_helpers.py
+++ b/capellambse/cli_helpers.py
@@ -26,8 +26,7 @@ try:
 
         Examples
         --------
-        .. code-block::
-           :language: python
+        .. code-block:: python
 
            @click.command()
            @click.option("-m", "--model", type=capellambse.ModelCLI())

--- a/capellambse/extensions/reqif/elements.py
+++ b/capellambse/extensions/reqif/elements.py
@@ -292,14 +292,14 @@ class ReqIFElement(c.GenericElement):
 
 @c.xtype_handler(None, XT_REQ_TYPES_DATA_DEF)
 class DataTypeDefinition(ReqIFElement):
-    """A data type definition for requirement types"""
+    """A data type definition for requirement types."""
 
     _xmltag = "ownedDefinitionTypes"
 
 
 @c.xtype_handler(None, XT_REQ_TYPE_ATTR_DEF)
 class AttributeDefinition(ReqIFElement):
-    """An attribute definition for requirement types"""
+    """An attribute definition for requirement types."""
 
     _xmltag = "ownedAttributes"
 
@@ -458,7 +458,7 @@ class StringValueAttribute(AbstractRequirementsAttribute):
 @c.xtype_handler(None, XT_REQ_TYPE_ATTR_ENUM)
 @c.attr_equal("long_name")
 class EnumValue(ReqIFElement):
-    """An enumeration value for :class:`EnumDataTypeDefinition`"""
+    """An enumeration value for :class:`EnumDataTypeDefinition`."""
 
     _xmltag = "specifiedValues"
 
@@ -468,7 +468,7 @@ class EnumValue(ReqIFElement):
 
 @c.xtype_handler(None, XT_REQ_TYPE_ENUM)
 class EnumDataTypeDefinition(ReqIFElement):
-    """An enumeration data type definition for requirement types"""
+    """An enumeration data type definition for requirement types."""
 
     _xmltag = "ownedDefinitionTypes"
 
@@ -482,7 +482,7 @@ class EnumDataTypeDefinition(ReqIFElement):
 
 @c.xtype_handler(None, XT_REQ_TYPE_ENUM_DEF)
 class AttributeDefinitionEnumeration(ReqIFElement):
-    """An enumeration attribute definition for requirement types"""
+    """An enumeration attribute definition for requirement types."""
 
     _xmltag = "ownedAttributes"
 
@@ -525,21 +525,21 @@ class AbstractType(ReqIFElement):
 
 @c.xtype_handler(None, XT_MODULE_TYPE)
 class ModuleType(AbstractType):
-    """A requirement-module type"""
+    """A requirement-module type."""
 
     _xmltag = "ownedTypes"
 
 
 @c.xtype_handler(None, XT_RELATION_TYPE)
 class RelationType(AbstractType):
-    """A requirement-relation type"""
+    """A requirement-relation type."""
 
     _xmltag = "ownedTypes"
 
 
 @c.xtype_handler(None, XT_REQ_TYPE)
 class RequirementType(AbstractType):
-    """A requirement type"""
+    """A requirement type."""
 
     _xmltag = "ownedTypes"
 
@@ -617,7 +617,7 @@ class RequirementsModule(ReqIFElement):
 
         Parameters
         ----------
-        target
+        to
             Where to export to. Can be the name of a file, or a file-like
             object opened in binary mode.
         metadata

--- a/capellambse/extensions/reqif/exporter.py
+++ b/capellambse/extensions/reqif/exporter.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Implementation of a ReqIF 1.1 and 1.2 exporter"""
+"""Implementation of a ReqIF 1.1 and 1.2 exporter."""
 from __future__ import annotations
 
 import collections.abc as cabc

--- a/capellambse/helpers.py
+++ b/capellambse/helpers.py
@@ -634,8 +634,7 @@ def get_transformation(
     pos: tuple[float, float],
     size: tuple[float, float],
 ) -> dict[str, str]:
-    """
-    Calculate transformation for class.
+    """Calculate transformation for class.
 
     The Scaling factor .725, translation constants (6, 5) are arbitrarily
     chosen to fit. Currently only ChoicePseudoState is tranformed.

--- a/capellambse/helpers.py
+++ b/capellambse/helpers.py
@@ -639,8 +639,8 @@ def get_transformation(
     The Scaling factor .725, translation constants (6, 5) are arbitrarily
     chosen to fit. Currently only ChoicePseudoState is tranformed.
 
-    Parameteres
-    -----------
+    Parameters
+    ----------
     class_
         Classtype string
     pos

--- a/capellambse/loader/core.py
+++ b/capellambse/loader/core.py
@@ -262,7 +262,7 @@ class ModelFile:
             )
 
     def unfollow_href(self, element_id: str) -> etree._Element:
-        """ "Unfollow" a fragment link and return the placeholder element.
+        """Unfollow a fragment link and return the placeholder element.
 
         If the given UUID is not linked to from this file, None is
         returned.
@@ -466,6 +466,8 @@ class MelodyLoader:
 
         Parameters
         ----------
+        parent
+            The parent element below which the new UUID will be used.
         want
             Try this UUID first, and use it if it satisfies all other
             constraints. If it does not satisfy all constraints (e.g. it
@@ -521,6 +523,9 @@ class MelodyLoader:
         ----------
         parent
             The parent element below which the new UUID will be used.
+        want
+            Request this UUID. The request may or may not be fulfilled;
+            always use the actual UUID returned by the context manager.
         """
         _, tree = self._find_fragment(parent)
         new_uuid = self.generate_uuid(parent, want=want)

--- a/capellambse/loader/exs.py
+++ b/capellambse/loader/exs.py
@@ -116,6 +116,8 @@ def write(
         The file encoding to use when opening a file.
     errors
         Set the encoding error handling behavior of newly opened files.
+    line_length
+        The number of characters after which to force a line break.
     """
     ctx: t.ContextManager[_HasWrite]
     if isinstance(file, _HasWrite):
@@ -148,6 +150,12 @@ def serialize(
     ----------
     tree
         The XML tree to serialize.
+    encoding
+        The encoding to use when generating XML.
+    errors
+        The encoding error handling behavior.
+    line_length
+        The number of characters after which to force a line break.
 
     Returns
     -------

--- a/capellambse/loader/filehandler/http.py
+++ b/capellambse/loader/filehandler/http.py
@@ -139,6 +139,8 @@ class HTTPFileHandler(FileHandler):
             The username for HTTP Basic Auth.
         password
             The password for HTTP Basic Auth.
+        headers
+            Additional HTTP headers to send to the server.
         subdir
             Prepend this path to all requested files. It is subject to
             the same file name escaping rules explained above.

--- a/capellambse/loader/xmltools.py
+++ b/capellambse/loader/xmltools.py
@@ -387,6 +387,11 @@ class EnumAttributeProperty(AttributeProperty):
 
         Parameters
         ----------
+        xmlattr
+            The owning type's instance attribute pointing to the XML
+            element.
+        attribute
+            The attribute on the XML element to handle.
         enumcls
             The :class:`enum.Enum` subclass to use.  The class' members'
             values are used as the possible values for the XML

--- a/capellambse/model/common/accessors.py
+++ b/capellambse/model/common/accessors.py
@@ -340,22 +340,25 @@ class DirectProxyAccessor(WritableAccessor[T], PhysicalAccessor[T]):
             instead of a child.
         aslist
             If None, only a single element must match, which will be
-            returned directly.  If not None, must be a subclass of
-            :class:`elements.DecoupledElementList`.  It will be used to return a
-            list of all matched objects.  Incompatible with ``xtypes =
-            None``.
+            returned directly. If not None, must be a subclass of
+            :class:`~elements.DecoupledElementList`. It will be used to
+            return a list of all matched objects. Incompatible with
+            ``xtypes = None``.
         follow_abstract
-            If True the element(s) found via the :class:`loader.MelodyLoader`
-            by passing the href behind ``abstractType`` is(are) taken instead.
+            Follow the link in the ``abstractType`` XML attribute of
+            each list member and instantiate that object instead. The
+            default is to instantiate the child elements directly.
         list_extra_args
-            Pass key and value pair for mapping in :class:`elements.ElementList``
+            Extra arguments to pass to the :class:`~element.ElementList`
+            constructor.
         rootelem
             A ``/``-separated list of ``xsi:type``s that defines the
             path from the current object's element to the search root.
             If None, the current element will be used directly.
         single_attr
             The name of the only attribute needed for creation. Passing
-            a string enables convenient creation via `create_singleattr`.
+            a string enables convenient creation via
+            `create_singleattr`.
         """
         super().__init__(
             class_,
@@ -839,6 +842,12 @@ class CustomAccessor(PhysicalAccessor[T]):
         elmfinders
             Functions that are called on the current element.  Each
             returns an iterable of possible targets.
+        aslist
+            If None, only a single element must match, which will be
+            returned directly.  If not None, must be a subclass of
+            :class:`elements.DecoupledElementList`.  It will be used to
+            return a list of all matched objects.  Incompatible with
+            ``xtypes = None``.
         elmmatcher
             Function that is called with the transformed target element
             and the current element to determine if the untransformed
@@ -987,7 +996,7 @@ class _Specification(t.MutableMapping[str, str], element.ModelObject):
     def from_model(
         cls, _1: capellambse.MelodyModel, _2: t.Any
     ) -> element.ModelObject:
-        """Specifications can not be instantiated"""
+        """Specifications can not be instantiated."""
         raise RuntimeError("Can not create a specification from a model")
 
 

--- a/capellambse/model/common/element.py
+++ b/capellambse/model/common/element.py
@@ -376,6 +376,8 @@ class ElementList(cabc.MutableSequence, t.Generic[T]):
             parent
                 Reference to the :class:`ElementList` this filter should
                 operate on
+            attr
+                The attribute on list members to filter on
             extract_key
                 Callable that extracts the key from an element
             positive
@@ -776,8 +778,15 @@ class CachedElementList(ElementList[T], t.Generic[T]):
 
         Parameters
         ----------
+        model
+            The model that all elements are a part of.
+        elements
+            The members of this list.
+        elemclass
+            The :class:`GenericElement` subclass to use for
+            reconstructing elements.
         cacheattr
-            The attribute on the ``model`` to use as cache
+            The attribute on the ``model`` to use as cache.
         """
         super().__init__(model, elements, elemclass, **kw)
         self.cacheattr = cacheattr
@@ -817,6 +826,10 @@ class MixedElementList(ElementList[GenericElement]):
 
         Parameters
         ----------
+        model
+            The model that all elements are a part of.
+        elements
+            The members of this list.
         elemclass
             Ignored; provided for drop-in compatibility.
         """

--- a/capellambse/model/crosslayer/capellacore.py
+++ b/capellambse/model/crosslayer/capellacore.py
@@ -21,7 +21,7 @@ class Constraint(c.GenericElement):
 
 @c.xtype_handler(None)
 class Generalization(c.GenericElement):
-    """A Generalization"""
+    """A Generalization."""
 
     _xmltag = "ownedGeneralizations"
 

--- a/capellambse/model/crosslayer/cs.py
+++ b/capellambse/model/crosslayer/cs.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Implementation of objects and relations for Functional Analysis
+"""Implementation of objects and relations for Functional Analysis.
 
 Composite Structure objects inheritance tree (taxonomy):
 
@@ -27,7 +27,7 @@ XT_PHYS_PATH_INV = "org.polarsys.capella.core.data.cs:PhysicalPathInvolvement"
 
 @c.xtype_handler(None)
 class Part(c.GenericElement):
-    """A representation of a physical component"""
+    """A representation of a physical component."""
 
     _xmltag = "ownedParts"
 

--- a/capellambse/model/crosslayer/information/__init__.py
+++ b/capellambse/model/crosslayer/information/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Implementation of objects and relations for Information capture and data modelling
+"""Objects and relations for information capture and data modelling.
 
 Information objects inheritance tree (taxonomy):
 
@@ -50,7 +50,7 @@ def _search_all_exchanges(
 
 @c.xtype_handler(None)
 class Unit(c.GenericElement):
-    """Unit"""
+    """Unit."""
 
     _xmltag = "ownedUnits"
 

--- a/capellambse/model/crosslayer/information/datavalue.py
+++ b/capellambse/model/crosslayer/information/datavalue.py
@@ -28,7 +28,7 @@ class LiteralNumericValue(LiteralValue):
 
 @c.xtype_handler(None)
 class LiteralStringValue(LiteralValue):
-    """A Literal String Value"""
+    """A Literal String Value."""
 
 
 @c.xtype_handler(None)

--- a/capellambse/model/layers/oa.py
+++ b/capellambse/model/layers/oa.py
@@ -184,7 +184,7 @@ class OperationalActivityPkg(c.GenericElement):
 
 @c.xtype_handler(XT_ARCH)
 class CommunicationMean(fa.AbstractExchange):
-    """An operational entity exchange"""
+    """An operational entity exchange."""
 
     _xmltag = "ownedComponentExchanges"
 

--- a/capellambse/model/modeltypes.py
+++ b/capellambse/model/modeltypes.py
@@ -174,7 +174,7 @@ class Kind(_StringyEnumMixin, _enum.Enum):
 
 
 class VisibilityKind(_StringyEnumMixin, _enum.Enum):
-    """Visibility kind"""
+    """Visibility kind."""
 
     UNSET = _enum.auto()
     PUBLIC = _enum.auto()

--- a/capellambse/sphinx.py
+++ b/capellambse/sphinx.py
@@ -70,7 +70,10 @@ if t.TYPE_CHECKING:
 
 
 def setup(app: sphinx.application.Sphinx) -> dict[str, t.Any]:
-    """Called by Sphinx to set up the extension."""
+    """Set up the extensions.
+
+    Called by Sphinx if the extension is configured in ``conf.py``.
+    """
     app.add_config_value(
         "capellambse_model", "../model/Documentation.aird", "html"
     )
@@ -112,7 +115,7 @@ def unload_model(_: t.Any, env: sphinx.environment.BuildEnvironment) -> None:
 
 
 class DiagramDirective(sphinx.util.docutils.SphinxDirective):
-    """The "``.. diagram::``" reST directive."""
+    """The ``diagram`` reST directive."""
 
     has_content = ...
     required_arguments = 1

--- a/capellambse/svg/drawing.py
+++ b/capellambse/svg/drawing.py
@@ -225,7 +225,7 @@ class Drawing(drawing.Drawing):
         )
 
     def _draw_box_label(self, builder: LabelBuilder) -> container.Group:
-        """Draw label text on given object and return calculated label position."""
+        """Draw label text on given object and return label position."""
         x, text_height, _, y_margin = self._draw_label(builder)
 
         if DEBUG:

--- a/capellambse/svg/style.py
+++ b/capellambse/svg/style.py
@@ -155,9 +155,10 @@ def get_symbol_styleclass(style: str | None, dstyle: str | None) -> str | None:
 class Styling:
     """Container for style attributes of svg objects.
 
-    .. note::
-        Attributes containing '-' are only referenceable via getattr()
-        or subscripting syntax, due to Python identifier naming rules.
+    Notes
+    -----
+    Attributes containing '-' are only referenceable via getattr() or
+    subscripting syntax, due to Python identifier naming rules.
     """
 
     _marker: bool = False

--- a/capellambse/svg/symbols.py
+++ b/capellambse/svg/symbols.py
@@ -968,7 +968,7 @@ def capability_symbol(id_: str = "CapabilitySymbol") -> container.Symbol:
 
 
 def _brown_oval(id_: str) -> container.Symbol:
-    """Create the base symbol of missions and capabilities"""
+    """Create the base symbol of missions and capabilities."""
     symb = container.Symbol(id=id_, viewBox="0 0 50 37")
     symb.add(
         _make_rgradient(

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,3 +21,10 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+
+# Auto-generate API documentation
+apidoc:
+	sphinx-apidoc --output-dir source/code --force ..
+
+.PHONY: apidoc

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -26,8 +26,13 @@ if errorlevel 9009 (
 )
 
 if "%1" == "" goto help
+if "%1" == "apidoc" goto apidoc
 
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:apidoc
+sphinx-apidoc --output-dir source/code ..
 goto end
 
 :help

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,13 +42,12 @@ import sphinx_rtd_theme
 sys.path.append(os.path.abspath("./_ext"))
 
 extensions = [
+    "capellambse.sphinx",
+    "jinja_in_rst",
     "sphinx.ext.autodoc",
     "sphinx.ext.coverage",
     "sphinx.ext.napoleon",
     "sphinx_rtd_theme",
-    "jinja_in_rst",
-    "capellambse.sphinx",
-    "sphinx.ext.autosectionlabel",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/start/developing-docs.rst
+++ b/docs/source/start/developing-docs.rst
@@ -10,7 +10,7 @@ The following command derives docs out of code:
 
 .. code:: bash
 
-    sphinx-apidoc --output-dir docs/source/code --force .
+    make -C docs apidoc
 
 The following command builds the docs:
 

--- a/docs/source/start/developing-docs.rst
+++ b/docs/source/start/developing-docs.rst
@@ -18,4 +18,5 @@ The following command builds the docs:
 
     make -C docs html
 
-The resulting documentation build should be available in `docs/build/html`, entry point is `index.html`
+The resulting documentation build should be available in `docs/build/html`,
+entry point is `index.html`

--- a/docs/source/start/how-to-explore-capella-mm.rst
+++ b/docs/source/start/how-to-explore-capella-mm.rst
@@ -6,24 +6,31 @@
 How to explore Capella meta-model
 *********************************
 
-Initially the API design was mostly based on our understanding of XML files, however we soon moved on into exploring the Capella meta-model. Here is a short summary of how we do it.
+Initially the API design was mostly based on our understanding of XML files,
+however we soon moved on into exploring the Capella meta-model. Here is a short
+summary of how we do it.
 
 Getting the meta-model sources
 ##############################
 
-First of all we need to get the data - the most straight-forward way is to clone the Capella source code:
+First of all we need to get the data - the most straight-forward way is to
+clone the Capella source code:
 
 .. code-block:: bash
 
     mkdir capella-mm && cd capella-mm
     git clone https://github.com/eclipse/capella.git
 
-As there are quite a few files we may want to discover the packages of interest using ``find``:
+As there are quite a few files we may want to discover the packages of interest
+using ``find``:
 
-- ``find -name '*.ecore' -o -name '*.genmodel'`` lists all the ECore models and Generation files and adds Generation viewpoint for related ecore
-- ``find -name '*.odesign'`` lists all the Sirius definitions (if you like to see how the diagram look-and-feel is defined)
+- ``find -name '*.ecore' -o -name '*.genmodel'`` lists all the ECore models and
+  Generation files and adds Generation viewpoint for related ecore
+- ``find -name '*.odesign'`` lists all the Sirius definitions (if you like to
+  see how the diagram look-and-feel is defined)
 
-You could open all the related projects right where they are but I'd prefer to have a clean sandbox.
+You could open all the related projects right where they are but I'd prefer to
+have a clean sandbox.
 
 .. code-block:: bash
 
@@ -37,64 +44,117 @@ You could open all the related projects right where they are but I'd prefer to h
     cp -r capella/releng/cdo/plugins/org.polarsys.kitalpha.emde.model.cdo capella-metamodel
     cp -r capella/tests/plugins/org.polarsys.capella.test.diagram.layout.ju capella-metamodel
 
-Now we have all of the meta-model dependencies in one place and can open it as a single Eclipse project. You could open those with any Eclipse that has EMF (like the Modeling bundle) but I'd advise using `Capella Studio`__ (open the link and search for "Studio") for the best experience - it is provisioned with all the extras that help you visualize / review the meta-model.
+Now we have all of the meta-model dependencies in one place and can open it as
+a single Eclipse project. You could open those with any Eclipse that has EMF
+(like the Modeling bundle) but I'd advise using `Capella Studio`__ (open the
+link and search for "Studio") for the best experience - it is provisioned with
+all the extras that help you visualize / review the meta-model.
 
 __ https://www.eclipse.org/capella/download.html
 
 .. image:: img/2021-05-09_10-32.jpg
 .. image:: img/2021-05-09_10-36.jpg
 
-After import Eclipse may highlight some projects with error or warning sign - that's fine, we'll let it go for now.
+After import Eclipse may highlight some projects with error or warning sign -
+that's fine, we'll let it go for now.
 
-Before we dive into visualizations, let's have a quick look around. The core of Capella metamodel is provided by ``org.polarsys.capella.common.data.core.gen`` project. There you'll find the definitions of the "Capella Layers" and the enabling "EnginereengConcerns" components. For example, the ``SystemAnalysis`` is provided by ``ContextArchitecture.ecore``.
+Before we dive into visualizations, let's have a quick look around. The core of
+Capella metamodel is provided by ``org.polarsys.capella.common.data.core.gen``
+project. There you'll find the definitions of the "Capella Layers" and the
+enabling "EnginereengConcerns" components. For example, the ``SystemAnalysis``
+is provided by ``ContextArchitecture.ecore``.
 
 .. image:: img/2021-05-09_10-50.jpg
 
-Even though the default tree-view (triggered by double-click on a ``.core``) is already giving us something there are much better ways to review the models. We'll talk about that in the `Visualizing ECores`__ chapter. But first we should have a look into the package structure and interdependencies.
+Even though the default tree-view (triggered by double-click on a ``.core``) is
+already giving us something there are much better ways to review the models.
+We'll talk about that in the `Visualizing ECores`__ chapter. But first we
+should have a look into the package structure and interdependencies.
 
 __ #visualizing-ecores
 
 Quick intro to package structure
 ################################
 
-If you are unfamiliar with ECore you might be wondering what are those ECore files anyways. We could say that they act as UML Packages. Every package contains ontology elements (or UML Classes) and "local" element relationships (Associations). The packages depend on each-other as elements frequently build on top of each-other via Generalization relationship. Thats one of the best things about Capella metamodel - it is defined by UML (or well, structural subset, but still pretty cool)!
+If you are unfamiliar with ECore you might be wondering what are those ECore
+files anyways. We could say that they act as UML Packages. Every package
+contains ontology elements (or UML Classes) and "local" element relationships
+(Associations). The packages depend on each-other as elements frequently build
+on top of each-other via Generalization relationship. Thats one of the best
+things about Capella metamodel - it is defined by UML (or well, structural
+subset, but still pretty cool)!
 
-So, from using Capella we know our model layers - Operational Analysis, System Analysis, Logical Architecture, Physical Architecture and EPBS. We can locate the corresponding ECores pretty quick, but what are all the other packages about? To answer that question we should visualize the package dependency - the quickest way to do so is to `create a new representation file`__. And after that follow the steps in `create package dependency overview`__. The result may look like what we have below:
+So, from using Capella we know our model layers - Operational Analysis, System
+Analysis, Logical Architecture, Physical Architecture and EPBS. We can locate
+the corresponding ECores pretty quick, but what are all the other packages
+about? To answer that question we should visualize the package dependency - the
+quickest way to do so is to `create a new representation file`__. And after
+that follow the steps in `create package dependency overview`__. The result may
+look like what we have below:
 
 __ #create-new-representations-file
 __ #package-dependency-overview
 
 .. image:: img/2021-05-09_17-38.jpg
 
-And even though there are not too many packages in the meta-model, when we visualize the inter-package dependency it may be a bit difficult to understand. By the way, the figure above `is also available in SVG`__ - you can open it in a new tab and zoom-in if you like or scroll down for a simplified one (but opinionated).
+And even though there are not too many packages in the meta-model, when we
+visualize the inter-package dependency it may be a bit difficult to understand.
+By the way, the figure above `is also available in SVG`__ - you can open it in
+a new tab and zoom-in if you like or scroll down for a simplified one (but
+opinionated).
 
 __ core-pkg-deps-raw.svg
 
-It almost feels like everything depends on everything but that isn't true really. We could change perspective and look for the dependencies of an end-user exposed package, such as Operational Analysis (oa). I'll use Papyrus to visualize that:
+It almost feels like everything depends on everything but that isn't true
+really. We could change perspective and look for the dependencies of an
+end-user exposed package, such as Operational Analysis (oa). I'll use Papyrus
+to visualize that:
 
 .. image:: img/2021-05-09_17-44.jpg
 
-When we add all the Capella layers to that picture things get a bit more interesting. I added some artificial grouping on top of the existing packages that will help us later on - the artificial groups are: ``CapellaLayers`` - packages that cover the layers we used to see in the tool; ``CrossLayer`` - packages that define ontology and patterns that we see in almost every layer; ``Enablers`` - the low level ontology that enables every element.
+When we add all the Capella layers to that picture things get a bit more
+interesting. I added some artificial grouping on top of the existing packages
+that will help us later on - the artificial groups are: ``CapellaLayers`` -
+packages that cover the layers we used to see in the tool; ``CrossLayer`` -
+packages that define ontology and patterns that we see in almost every layer;
+``Enablers`` - the low level ontology that enables every element.
 
 .. image:: img/2021-05-09_21-21.jpg
 
-To make a further point on ``CrossLayer``, lets have a closer look at a Function. We know that Functions are quite similar in how they look and feel across Capella layers and have a lot in common with OperationalActivity. When we open ``LogicalArchitecture.ecore`` we see it defines a ``LogicalFunction`` as a specialization of ``AbstractFunction`` that comes from ``FunctionalAnalysis.ecore``. There is a very nice feature provided by the `Ecore Tools`__ (that is also included in Capella Studio) - Class Inheritance view (there is also a tiny `how-to use it below`__). We'll use that to visualize the way the functions are made.
+To make a further point on ``CrossLayer``, lets have a closer look at a
+Function. We know that Functions are quite similar in how they look and feel
+across Capella layers and have a lot in common with OperationalActivity. When
+we open ``LogicalArchitecture.ecore`` we see it defines a ``LogicalFunction``
+as a specialization of ``AbstractFunction`` that comes from
+``FunctionalAnalysis.ecore``. There is a very nice feature provided by the
+`Ecore Tools`__ (that is also included in Capella Studio) - Class Inheritance
+view (there is also a tiny `how-to use it below`__). We'll use that to
+visualize the way the functions are made.
 
 __ https://www.eclipse.org/ecoretools/overview.html
 __ #
 
 .. image:: img/2021-05-09_22-09.jpg
 
-Just to be on a safe side I've done the above exercise for ``OperationalActivity``, ``SystemFunction``, ``LogicalFunction`` and ``PhysicalFunction`` - the inheritance tree is exactly the same. I've done this check for a few other familiar ontology elements and got same result. I think this gives a feeling for what the ``CrossLayer`` is about - to me that's the place where most of the magic happens. And this is how the relationship between the ``CapellaLayers`` and ``CrossLayer`` looks like when we de-noise it a bit:
+Just to be on a safe side I've done the above exercise for
+``OperationalActivity``, ``SystemFunction``, ``LogicalFunction`` and
+``PhysicalFunction`` - the inheritance tree is exactly the same. I've done this
+check for a few other familiar ontology elements and got same result. I think
+this gives a feeling for what the ``CrossLayer`` is about - to me that's the
+place where most of the magic happens. And this is how the relationship between
+the ``CapellaLayers`` and ``CrossLayer`` looks like when we de-noise it a bit:
 
 .. image:: img/2021-05-09_22-39.jpg
 
-It's been a lengthy chain of thought and to finish on a hopefully useful visualization - lets have a look at the Class contexts of some things that we use most frequently
+It's been a lengthy chain of thought and to finish on a hopefully useful
+visualization - lets have a look at the Class contexts of some things that we
+use most frequently
 
 Visualizations of some frequently used ontology elements
 ########################################################
 
-Below you'll find some quick visualizations for frequently used ontology elements, grouped by CrossLayer package
+Below you'll find some quick visualizations for frequently used ontology
+elements, grouped by CrossLayer package
 
 Functional Analysis
 *******************
@@ -114,7 +174,9 @@ State Machines
 
 .. image:: img/2021-05-13_20-46.jpg
 
-The figure above is somewhat a "treasure map" to everything related to state machines. It is made in a semi-automatic way with the help of ECore Tools and ELK
+The figure above is somewhat a "treasure map" to everything related to state
+machines. It is made in a semi-automatic way with the help of ECore Tools and
+ELK
 
 Composite Structure
 *******************
@@ -123,7 +185,8 @@ Composite Structure
 
 .. image:: img/2021-05-12_18-51.jpg
 
-You may also want to have a look at the Block context below as it defines some other useful things that a Component (or LogicalComponent) can do.
+You may also want to have a look at the Block context below as it defines some
+other useful things that a Component (or LogicalComponent) can do.
 
 .. image:: img/2021-05-12_20-06.jpg
 
@@ -132,25 +195,31 @@ You may also want to have a look at the Block context below as it defines some o
 Appendix: Visualizing ECores
 ############################
 
-If you are new to CapellaStudio and Ecore, here are some practical hints for how to get stuff done, ignore the below otherwise:
+If you are new to CapellaStudio and Ecore, here are some practical hints for
+how to get stuff done, ignore the below otherwise:
 
 Create new representations file
 *******************************
 
-To start playing with visualizations we need a new representations file (.aird). It is pretty easy to get there but just in case, there is figure below to guide you through that.
+To start playing with visualizations we need a new representations file
+(.aird). It is pretty easy to get there but just in case, there is figure below
+to guide you through that.
 
 .. image:: img/2021-05-09_17-36.jpg
 
 Package dependency overview
 ***************************
 
-To create a package dependency overview for all packages you may follow the guidance in the figure below:
+To create a package dependency overview for all packages you may follow the
+guidance in the figure below:
 
 .. image:: img/2021-05-09_17-57.jpg
 
 Visualizing class inheritance
 *****************************
 
-There is a very nice feature that allows given a class to show all of its super-classes (generalizations) and specializations. The figure below gives you some hints for how to use it:
+There is a very nice feature that allows given a class to show all of its
+super-classes (generalizations) and specializations. The figure below gives you
+some hints for how to use it:
 
 .. image:: img/2021-05-09_21-46.jpg

--- a/docs/source/start/installation.rst
+++ b/docs/source/start/installation.rst
@@ -8,21 +8,25 @@ Installation
 
 .. |project| replace:: py-capellambse
 
-This guide helps you to get |project| installed. There are a few ways to get it done:
+This guide helps you to get |project| installed. There are a few ways to get it
+done:
 
 Install from PyPI
 =================
 
 .. highlight:: bash
 
-Installing |project| from Python Package Index via `pip <http://www.pip-installer.org/>`_ is the quickest way to get started ::
+Installing |project| from Python Package Index via `pip
+<http://www.pip-installer.org/>`_ is the quickest way to get started ::
 
     $ pip install capellambse
 
 Install as a package from Github
 ================================
 
-If you want to have a comfortable playground with examples / jupyter notebooks / export to excel demo and test models you may clone the repository directly from github, create virtual environment and install all the extras: ::
+If you want to have a comfortable playground with examples / jupyter notebooks
+/ export to excel demo and test models you may clone the repository directly
+from github, create virtual environment and install all the extras: ::
 
     $ git clone https://github.com/DSD-DBS/py-capellambse.git
     $ cd py-capella-mbse
@@ -36,4 +40,6 @@ If you want to have a comfortable playground with examples / jupyter notebooks /
 Install for development
 =======================
 
-In case you'd like to contribute to the development or improve documentation, sample models or examples collection please follow the `contribution guide <https://github.com/DSD-DBS/py-capellambse/blob/master/CONTRIBUTING.md>`_
+In case you'd like to contribute to the development or improve documentation,
+sample models or examples collection please follow the `contribution guide
+<https://github.com/DSD-DBS/py-capellambse/blob/master/CONTRIBUTING.md>`_

--- a/docs/source/start/intro-to-api.rst
+++ b/docs/source/start/intro-to-api.rst
@@ -35,32 +35,29 @@ Layer-specific packages
 
 The following packages enable working with model layers:
 
-* :ref:`capellambse.model.layers.oa module` - covers Operational Analysis
-  layer.
-* :ref:`capellambse.model.layers.ctx module` - covers System Analysis layer.
-* :ref:`capellambse.model.layers.la module` - covers Logical Architecture
-  layer.
-* :ref:`capellambse.model.layers.pa module` - covers Physical Architecture
-  layer.
+* :mod:`capellambse.model.layers.oa` - covers Operational Analysis layer.
+* :mod:`capellambse.model.layers.ctx` - covers System Analysis layer.
+* :mod:`capellambse.model.layers.la` - covers Logical Architecture layer.
+* :mod:`capellambse.model.layers.pa` - covers Physical Architecture layer.
 
 Cross-layer packages
 ====================
 
 The following packages enable all (almost) of the layer packages:
 
-* :ref:`capellambse.model.crosslayer.fa module` - covers Functional Analysis
-  concerns, defines things like AbstractFunction or FunctionalExchange
-* :ref:`capellambse.model.crosslayer.cs module` - covers Composite Structure
-  concerns, defines things like Component
-* :ref:`capellambse.model.crosslayer.capellacommon module` - covers common
-  concerns, defines things like StateMachine, State
-* :ref:`capellambse.model.crosslayer.information module` - covers Information
+* :mod:`capellambse.model.crosslayer.fa` - covers Functional Analysis concerns,
+  defines things like AbstractFunction or FunctionalExchange
+* :mod:`capellambse.model.crosslayer.cs` - covers Composite Structure concerns,
+  defines things like Component
+* :mod:`capellambse.model.crosslayer.capellacommon` - covers common concerns,
+  defines things like StateMachine, State
+* :mod:`capellambse.model.crosslayer.information` - covers Information
   concerns, defines things like Class, DataPkg, ExchangeItem
 
 Extension packages
 ==================
 
-* :ref:`capellambse.extensions.reqif module` - provides means for working with
-  ReqIF Requirements within Capella model.
-* :ref:`capellambse.extensions.pvmt module` - provides means for working with
-  object attributes created with PVMT package.
+* :mod:`capellambse.extensions.reqif` - provides means for working with ReqIF
+  Requirements within Capella model.
+* :mod:`capellambse.extensions.pvmt` - provides means for working with object
+  attributes created with PVMT package.

--- a/docs/source/start/intro-to-api.rst
+++ b/docs/source/start/intro-to-api.rst
@@ -6,40 +6,61 @@
 Introduction to py-capellambse API
 **********************************
 
-|project| provides access to model elements using a meta-model similar to the one of Capella. However in this meta-model we make a few simplifications. A collection of automated tests and design reviews help us to ensure that those simplifications don't break compatibility with original Capella models (however coverage isn't complete yet).
+|project| provides access to model elements using a meta-model similar to the
+one of Capella. However in this meta-model we make a few simplifications. A
+collection of automated tests and design reviews help us to ensure that those
+simplifications don't break compatibility with original Capella models (however
+coverage isn't complete yet).
 
-As you may know the meta-model behind Capella is layered. There are many packages involved and there is a long inheritance chain behind almost every model element. We are simplifying that by "flattening" the lower layers.
+As you may know the meta-model behind Capella is layered. There are many
+packages involved and there is a long inheritance chain behind almost every
+model element. We are simplifying that by "flattening" the lower layers.
 
 You may see an example of how that works in the figure below:
 
 .. image:: img/crosslayer_intro.jpg
 
-In the example above we see that `LogicalFunction` is a subtype of `AbstractFunction`, just like `SystemFunction` or `OperationalActivity`. Because of that, all of those subtypes can be `.available_in_states` or have a layer-specific structural `owner`, like `LogicalComponent` for `LogicalFunction`. Any layer-specific class that inherits from `Component` may also have `state_machines`.
+In the example above we see that `LogicalFunction` is a subtype of
+`AbstractFunction`, just like `SystemFunction` or `OperationalActivity`.
+Because of that, all of those subtypes can be `.available_in_states` or have a
+layer-specific structural `owner`, like `LogicalComponent` for
+`LogicalFunction`. Any layer-specific class that inherits from `Component` may
+also have `state_machines`.
 
-The API reference part of this documentation provides you with the complete (as it is generated from the code base) list of available methods and attributes.
+The API reference part of this documentation provides you with the complete (as
+it is generated from the code base) list of available methods and attributes.
 
 Layer-specific packages
 =======================
 
 The following packages enable working with model layers:
 
-* :ref:`capellambse.model.layers.oa module` - covers Operational Analysis layer.
+* :ref:`capellambse.model.layers.oa module` - covers Operational Analysis
+  layer.
 * :ref:`capellambse.model.layers.ctx module` - covers System Analysis layer.
-* :ref:`capellambse.model.layers.la module` - covers Logical Architecture layer.
-* :ref:`capellambse.model.layers.pa module` - covers Physical Architecture layer.
+* :ref:`capellambse.model.layers.la module` - covers Logical Architecture
+  layer.
+* :ref:`capellambse.model.layers.pa module` - covers Physical Architecture
+  layer.
 
 Cross-layer packages
 ====================
 
 The following packages enable all (almost) of the layer packages:
 
-* :ref:`capellambse.model.crosslayer.fa module` - covers Functional Analysis concerns, defines things like AbstractFunction or FunctionalExchange
-* :ref:`capellambse.model.crosslayer.cs module` - covers Composite Structure concerns, defines things like Component
-* :ref:`capellambse.model.crosslayer.capellacommon module` - covers common concerns, defines things like StateMachine, State
-* :ref:`capellambse.model.crosslayer.information module` - covers Information concerns, defines things like Class, DataPkg, ExchangeItem
+* :ref:`capellambse.model.crosslayer.fa module` - covers Functional Analysis
+  concerns, defines things like AbstractFunction or FunctionalExchange
+* :ref:`capellambse.model.crosslayer.cs module` - covers Composite Structure
+  concerns, defines things like Component
+* :ref:`capellambse.model.crosslayer.capellacommon module` - covers common
+  concerns, defines things like StateMachine, State
+* :ref:`capellambse.model.crosslayer.information module` - covers Information
+  concerns, defines things like Class, DataPkg, ExchangeItem
 
 Extension packages
 ==================
 
-* :ref:`capellambse.extensions.reqif module` - provides means for working with ReqIF Requirements within Capella model.
-* :ref:`capellambse.extensions.pvmt module` - provides means for working with object attributes created with PVMT package.
+* :ref:`capellambse.extensions.reqif module` - provides means for working with
+  ReqIF Requirements within Capella model.
+* :ref:`capellambse.extensions.pvmt module` - provides means for working with
+  object attributes created with PVMT package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ Documentation = "https://dsd-dbs.github.io/py-capellambse"
 [project.optional-dependencies]
 docs = [
   "jinja2",
+  "pyyaml>=6.0",
   "sphinx",
   "sphinx-rtd-theme",
   "tomli; python_version<'3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,10 @@ reqif = "capellambse.extensions.reqif:init"
 line-length = 79
 target-version = ["py39"]
 
+[tool.docformatter]
+wrap-descriptions = 72
+wrap-summaries = 79
+
 [tool.isort]
 profile = 'black'
 line_length = 79

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Global fixtures for pytest"""
+"""Global fixtures for pytest."""
 import io
 import pathlib
 import sys
@@ -32,13 +32,13 @@ def session_shared_model() -> capellambse.MelodyModel:
 
 @pytest.fixture
 def model(monkeypatch) -> capellambse.MelodyModel:
-    """Return the Capella 5.0 test model"""
+    """Return the Capella 5.0 test model."""
     monkeypatch.setattr(sys, "stderr", io.StringIO)
     return capellambse.MelodyModel(TEST_ROOT / "5_0" / TEST_MODEL)
 
 
 @pytest.fixture
 def model_5_2(monkeypatch) -> capellambse.MelodyModel:
-    """Return the Capella 5.2 test model"""
+    """Return the Capella 5.2 test model."""
     monkeypatch.setattr(sys, "stderr", io.StringIO)
     return capellambse.MelodyModel(TEST_ROOT / "5_2" / TEST_MODEL)

--- a/tests/test_aird_filters.py
+++ b/tests/test_aird_filters.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for aird-filters applied after rendering a diagram"""
+"""Tests for aird-filters applied after rendering a diagram."""
 import pytest
 
 import capellambse

--- a/tests/test_aird_vector2d.py
+++ b/tests/test_aird_vector2d.py
@@ -276,11 +276,6 @@ class TestVectorSnapping:
     def test_snap_manhattan_to_middle_of_port_side(
         self, points: list[aird.Vector2D], expected: aird.Vector2D
     ):
-        """Test snapping of edges of all sides to the closest point on border
-        of port.
-
-        Port movement not allowed.
-        """
         aird.parser._edge_factories.snaptarget(
             points, -1, -2, self.PORTBOX, False, "manhattan"
         )

--- a/tests/test_model_creation_deletion.py
+++ b/tests/test_model_creation_deletion.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for creating and deleting model elements"""
+"""Tests for creating and deleting model elements."""
 # pylint: disable=missing-function-docstring, redefined-outer-name
 import pathlib
 

--- a/tests/test_pvmt.py
+++ b/tests/test_pvmt.py
@@ -34,7 +34,7 @@ def pvext(model):
 
 
 class TestPVMTBase:
-    """Tests for basic PVMT functionality"""
+    """Tests for basic PVMT functionality."""
 
     domain_uuid = "02e0c435-f085-471f-9f6e-e12fe5f27687"
     domain_name = "Computer"
@@ -197,7 +197,7 @@ class TestAppliedPropertyValueGroup:
 
 
 class TestAppliedPropertyValueGroupXML:
-    """Tests that rely on writing back and comparing the output XML"""
+    """Tests that rely on writing back and comparing the output XML."""
 
     expect_root = TEST_ROOT / "expected-output"
 

--- a/tests/test_reqif.py
+++ b/tests/test_reqif.py
@@ -600,7 +600,6 @@ class TestReqIFModification:
         model: capellambse.MelodyModel,
         default_value: t.Any,
     ):
-        """Accessed value is there but on xml element there is no written value."""
         req = model.by_uuid("3c2d312c-37c9-41b5-8c32-67578fa52dc3")
         definition = model.by_uuid("682bd51d-5451-4930-a97e-8bfca6c3a127")
         assert isinstance(req, reqif.Requirement)

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -58,7 +58,7 @@ FREE_SYMBOLS = {
 def tmp_json_fixture(
     model: capellambse.MelodyModel, tmp_path: pathlib.Path
 ) -> pathlib.Path:
-    """Return tmp path of diagram json file"""
+    """Return tmp path of diagram json file."""
     dest = tmp_path / (TEST_LAB + ".json")
     diagram_json: str = model.diagrams.by_name(TEST_LAB).render("json_pretty")
     dest.write_text(diagram_json)
@@ -389,7 +389,7 @@ class TestSVG:
     def test_diagram_decorations(
         self, model: capellambse.MelodyModel, diagram_name: str
     ):
-        """Test diagrams get rendered successfully"""
+        """Test diagrams get rendered successfully."""
         diag = model.diagrams.by_name(diagram_name)
         diag.render("svg")
 
@@ -405,14 +405,18 @@ class TestSVG:
     def test_box_contains_label_and_symbol_and_icons_dont_overlap_with_text(
         self, diagram_type: str, label: str, width: int, height: int
     ) -> None:
-        """For all registered Diagramtypes with decorations test label and icon
-        containment for boxes exclusively, i.e. exclude the following:
+        """Paint the CI red.
+
+        For all registered Diagramtypes with decorations test label and
+        icon containment for boxes exclusively, i.e. exclude the
+        following:
+
             * Ports
             * Exchanges
             * Markers
 
-        If the label check fails the diagram gets saved to root directory for
-        convinient investigation.
+        If the label check fails the diagram gets saved to root
+        directory for convenient investigation.
         """
         decos = [
             symbol
@@ -468,8 +472,10 @@ class TestSVG:
     def test_edge_contains_label_and_symbol_and_icons_dont_overlap_with_text(
         self, diagram_type: str, label: str, width: int, height: int
     ) -> None:
-        """For all registered Diagramtypes with decorations test edge-symbols on
-        not overlapping/overflowing into label text.
+        """Paint the CI red.
+
+        For all registered Diagramtypes with decorations test edge-
+        symbols on not overlapping/overflowing into label text.
         """
         decos = [
             symbol


### PR DESCRIPTION
This PR:

- [x] Enables the pydocstyle pre-commit hook
- [x] Enables and configures `docformatter`
- [x] Fixes all the issues with docstrings discovered by them, except for D1 issues (i.e. entirely missing docstrings). Most of the changes were reflowing paragraphs, adding missing punctuation, and adding missing documentation on function parameters.

~~@ewuerger Do we want to put the Sphinx theme change in here as well? I'd keep it as draft until then, otherwise it's ready.~~\
That's a little bit more than I anticipated, let's split that up so we can properly use Github's review tools.