### PR TITLE
Rename the `exchanges` attribute to `related_exchanges` on OperationalActivity

### DIFF
--- a/capellambse/model/layers/oa.py
+++ b/capellambse/model/layers/oa.py
@@ -38,6 +38,9 @@ class OperationalActivity(fa.AbstractFunction):
         operator.attrgetter("_model.oa.all_entities"),
         matchtransform=operator.attrgetter("activities"),
     )
+    exchanges = c.DirectProxyAccessor(
+        fa.FunctionalExchange, aslist=c.ElementList
+    )
 
     @property
     def inputs(self) -> c.ElementList[fa.FunctionalExchange]:
@@ -48,7 +51,7 @@ class OperationalActivity(fa.AbstractFunction):
         return self._model.oa.all_activity_exchanges.by_source(self)
 
     @property
-    def exchanges(self) -> c.ElementList[fa.FunctionalExchange]:
+    def related_exchanges(self) -> c.ElementList[fa.FunctionalExchange]:
         seen: set[str] = set()
         exchanges = []
         for fex in self.inputs + self.outputs:


### PR DESCRIPTION
In order to standardize the `.related_exchanges` attribute I propose to rename the `exchanges` property of `OperationalActivity` to `related_exchanges`. This makes my life easier in the context diagrams collection stage.