### PR TITLE
Fix class diagrams ([CDB])

### DIFF
--- a/capellambse/aird/capstyle.py
+++ b/capellambse/aird/capstyle.py
@@ -349,6 +349,14 @@ STYLES: dict[str, dict[str, dict[str, CSSdef]]] = {
             "stroke": COLORS["_CAP_Association_Color"],
             "marker-end": "FineArrowMark",
         },
+        "Edge.Aggregation": {
+            "stroke": COLORS["_CAP_Association_Color"],
+            "marker-start": "DiamondMark",
+        },
+        "Edge.Composition": {
+            "stroke": COLORS["_CAP_Association_Color"],
+            "marker-start": "FilledDiamondMark",
+        },
         "Edge.ExchangeItemElement": {  # DT_ExchangeItemElement
             "stroke": COLORS["black"],
             "stroke-dasharray": "5",

--- a/capellambse/aird/parser/_edge_factories.py
+++ b/capellambse/aird/parser/_edge_factories.py
@@ -584,15 +584,8 @@ def include_extend_factory(seb: C.SemanticElementBuilder) -> aird.Edge:
 def association_factory(seb: C.SemanticElementBuilder) -> aird.Edge:
     """Create an Association."""
     edge = generic_factory(seb)
-    assert len(edge.labels) == 3
-
-    links = seb.melodyobjs[0].attrib["navigableMembers"]
-    navigable = set(seb.melodyloader.follow_links(seb.data_element, links))
-    if not navigable:
-        navigable = set(seb.melodyobjs[1:])
-
-    for prop, label in zip(seb.melodyobjs, edge.labels):
-        label.label = prop.get("name", "")
-        label.hidden = prop not in navigable
-
+    for member in seb.melodyobjs[0].iterchildren("ownedMembers"):
+        kind = member.get("aggregationKind", "ASSOCIATION").capitalize()
+        if kind != "Association":
+            edge.styleclass = kind
     return edge

--- a/capellambse/aird/parser/_filters/global.py
+++ b/capellambse/aird/parser/_filters/global.py
@@ -12,6 +12,22 @@ from capellambse import aird, helpers, model
 from . import FilterArguments, composite, global_filter
 
 XT_CEX_FEX_ALLOCATION = "org.polarsys.capella.core.data.fa:ComponentExchangeFunctionalExchangeAllocation"
+EXCHANGES_WITH_ROLES = frozenset(
+    ("Association", "Aggregation", "Composition", "Generalization")
+)
+
+
+@global_filter("hide.role.names.filter")
+def hide_role_names(args: FilterArguments, flt: lxml.etree._Element) -> None:
+    """Hide names of roles on an exchange."""
+    del flt
+    classes = EXCHANGES_WITH_ROLES
+    for obj in args.target_diagram:
+        if not isinstance(obj, aird.Edge):
+            continue
+
+        if len(obj.labels) > 1 and obj.styleclass in classes:
+            obj.labels = obj.labels[:1]
 
 
 @global_filter("show.functional.exchanges.exchange.items.filter")

--- a/capellambse/aird/parser/_filters/global.py
+++ b/capellambse/aird/parser/_filters/global.py
@@ -13,7 +13,7 @@ from . import FilterArguments, composite, global_filter
 
 XT_CEX_FEX_ALLOCATION = "org.polarsys.capella.core.data.fa:ComponentExchangeFunctionalExchangeAllocation"
 EXCHANGES_WITH_ROLES = frozenset(
-    ("Association", "Aggregation", "Composition", "Generalization")
+    {"Aggregation", "Association", "Composition", "Generalization"}
 )
 
 
@@ -26,10 +26,8 @@ def hide_association_labels(
 
     classes = EXCHANGES_WITH_ROLES
     for obj in args.target_diagram:
-        if not (isinstance(obj, aird.Edge) or obj.styleclass in classes):
+        if not isinstance(obj, aird.Edge) or obj.styleclass not in classes:
             continue
-
-        assert isinstance(obj, aird.Edge)
         for label in obj.labels:
             label.hidden = True
 

--- a/capellambse/aird/parser/_filters/global.py
+++ b/capellambse/aird/parser/_filters/global.py
@@ -17,10 +17,28 @@ EXCHANGES_WITH_ROLES = frozenset(
 )
 
 
+@global_filter("hide.association.labels.filter")
+def hide_association_labels(
+    args: FilterArguments, flt: lxml.etree._Element
+) -> None:
+    """Hide names of roles on an exchange."""
+    del flt
+
+    classes = EXCHANGES_WITH_ROLES
+    for obj in args.target_diagram:
+        if not (isinstance(obj, aird.Edge) or obj.styleclass in classes):
+            continue
+
+        assert isinstance(obj, aird.Edge)
+        for label in obj.labels:
+            label.hidden = True
+
+
 @global_filter("hide.role.names.filter")
 def hide_role_names(args: FilterArguments, flt: lxml.etree._Element) -> None:
     """Hide names of roles on an exchange."""
     del flt
+
     classes = EXCHANGES_WITH_ROLES
     for obj in args.target_diagram:
         if not isinstance(obj, aird.Edge):

--- a/capellambse/svg/drawing.py
+++ b/capellambse/svg/drawing.py
@@ -504,7 +504,6 @@ class Drawing(drawing.Drawing):
                             self.diagram_class,
                             styling._class,
                             _prefix=styling._prefix,
-                            fill=stroke,
                             stroke=stroke,
                             stroke_width=stroke_width,
                         ),

--- a/capellambse/svg/symbols.py
+++ b/capellambse/svg/symbols.py
@@ -1053,10 +1053,11 @@ def arrow_mark(
     )
 
 
-@decorations.deco_factories
-def diamond_mark(
-    id_: str = "Diamond", *, style: style_.Styling, **kw
+def _make_diamond_marker(
+    id_: str, *, style: style_.Styling, fill: str, **kw
 ) -> container.Marker:
+    if not hasattr(style, "fill"):
+        style.fill = fill
     return _make_marker(
         (0, 3),
         (11, 6),
@@ -1065,6 +1066,20 @@ def diamond_mark(
         style=style,
         **kw,
     )
+
+
+@decorations.deco_factories
+def diamond_mark(
+    id_: str = "Diamond", *, style: style_.Styling, **kw
+) -> container.Marker:
+    return _make_diamond_marker(id_, style=style, fill="white", **kw)
+
+
+@decorations.deco_factories
+def filled_diamond_mark(
+    id_: str = "FilledDiamond", *, style: style_.Styling, **kw
+) -> container.Marker:
+    return _make_diamond_marker(id_, style=style, fill="black", **kw)
 
 
 @decorations.deco_factories


### PR DESCRIPTION
This PR improves the rendering of class diagrams (i.e. diagrams with class type **[CDB]**) provided by the svg submodule.
The following happened:

- Added 2 new filters:
    - `hide.role.names.filter`
    - `hide.association.labels.filter`
- The Association edge factory was fixed. There was a bug that caused wrong labels (only navigable role names) to appear in the SVG. The factory now does only patch the style class from the `aggregationKind` attribute of the first melodyobject. From this syleclass (Association (per default), Aggregation and Composition) we infer which end-marker is to be taken and added to the defs section of the drawing.
- The `FilledDiamondMarker` for the `Aggregation` styleclass was added to decorations.

The bugs around bendpoints calculation causing unorthogonal routing still prevails. I was even able to run into a `Lines are parallel` exception in the `line_intersect` method. Full of joy I await the refactoring of our internal aird-parser and svg calculations...