### PR TITLE
Disallow model loading from capella files without valid entrypoint

### DIFF
--- a/capellambse/loader/core.py
+++ b/capellambse/loader/core.py
@@ -320,6 +320,8 @@ class MelodyLoader:
             else:
                 self.resources[resname] = reshdl
         self.entrypoint = self.__derive_entrypoint(entrypoint)
+        if self.entrypoint.suffix != ".aird":
+            raise ValueError("Invalid entrypoint, specify the ``.aird`` file")
 
         self.trees: dict[pathlib.PurePosixPath, ModelFile] = {}
         self.__load_referenced_files(

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -33,6 +33,12 @@ def test_model_loading_via_LocalFileHandler(path: str | pathlib.Path):
     capellambse.MelodyModel(path)
 
 
+@pytest.mark.parametrize("suffix", [".capella", ".melodymodel"])
+def test_model_loading_with_invalid_entrypoint_fails(suffix: str):
+    with pytest.raises(ValueError, match="(?i)invalid entrypoint"):
+        capellambse.MelodyModel(TEST_MODEL_5_0.with_suffix(suffix))
+
+
 def test_model_loading_via_GitFileHandler():
     path = "git+" + pathlib.Path.cwd().as_uri()
     capellambse.MelodyModel(
@@ -41,7 +47,7 @@ def test_model_loading_via_GitFileHandler():
 
 
 def test_model_loading_from_badpath_raises_FileNotFoundError():
-    badpath = TEST_ROOT / "TestFile.airdfragment"
+    badpath = TEST_ROOT / "Missing.aird"
     with pytest.raises(FileNotFoundError):
         capellambse.MelodyModel(badpath)
 


### PR DESCRIPTION
Valid entrypoint file-types are `.aird` and `.airdfragment` coming from `VISUAL_EXT`. This solves #159.

Another solution would be to not raise an `InvalidEntrypoint` exception but rather look for valid entrypoints in the same directory of the given entrypoint. Assuming that modelfiles are kept together in the same directory. But this doesn't incentivise to pass the correct entrypoint which is the `.aird`/`.airdfragment` file.