### PR TITLE
fix: Add missing default styling of `PhysicalComponent`s for natures

### DIFF
--- a/capellambse/aird/capstyle.py
+++ b/capellambse/aird/capstyle.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 __all__ = ["COLORS", "CSSdef", "STYLES", "RGB", "get_style"]
 
+import collections.abc as cabc
 import logging
 import typing as t
 
@@ -163,6 +164,7 @@ def get_style(diagramclass: str | None, objectclass: str) -> dict[str, t.Any]:
     return retval
 
 
+CSSdef = t.Union[int, str, RGB, cabc.Sequence[RGB], None]
 #: This dict maps the color names used by Capella to RGB tuples.
 COLORS: dict[str, RGB] = {
     # System palette
@@ -239,6 +241,30 @@ COLORS: dict[str, RGB] = {
 }
 
 
+_PHYS_ACTOR: dict[str, CSSdef] = {
+    "fill": [
+        COLORS["_CAP_Actor_Blue_min"],
+        COLORS["_CAP_Actor_Blue"],
+    ],
+    "stroke": COLORS["_CAP_Actor_Border_Blue"],
+    "text_fill": COLORS["_CAP_Actor_Blue_label"],
+    "text_font-style": "italic",
+}
+_PHYS_BEHAVIOR = _PHYS_ACTOR | {
+    "fill": [
+        COLORS["_CAP_Component_Blue_min"],
+        COLORS["_CAP_Component_Blue"],
+    ]
+}
+_PHYS_NODE: dict[str, CSSdef] = {
+    "fill": [
+        COLORS["_CAP_Node_Yellow_min"],
+        COLORS["_CAP_Node_Yellow"],
+    ],
+    "stroke": COLORS["_CAP_Node_Yellow_Border"],
+    "text_fill": COLORS["_CAP_Node_Yellow_Label"],
+}
+
 #: This dict contains the default styles that Capella applies, grouped
 #: by the diagram class they belong to.
 #:
@@ -264,8 +290,7 @@ COLORS: dict[str, RGB] = {
 #: 2. __GLOBAL__, element type and class
 #: 3. Diagram class specific, only element type
 #: 4. __GLOBAL__, only element type
-CSSdef = t.Union[int, str, RGB, t.List[RGB], None]
-STYLES: dict[str, dict[str, dict[str, CSSdef]]] = {
+STYLES: t.Final[cabc.Mapping[str, dict[str, dict[str, CSSdef]]]] = {
     "__GLOBAL__": {  # Global defaults
         "Box": {
             "fill": "transparent",
@@ -744,43 +769,14 @@ STYLES: dict[str, dict[str, dict[str, CSSdef]]] = {
             "fill": COLORS["_CAP_PhysicalPort_Yellow"],
             "stroke": COLORS["_CAP_Class_Border_Brown"],
         },
-        "Box.PhysicalBehaviorComponent": (  # type: ignore[dict-item]
-            PHYS_BEHAVIOR := {
-                "fill": [
-                    COLORS["_CAP_Component_Blue_min"],
-                    COLORS["_CAP_Component_Blue"],
-                ],
-                "stroke": COLORS["_CAP_Actor_Border_Blue"],
-                "text_fill": COLORS["_CAP_Actor_Blue_label"],
-                "text_font-style": "italic",
-            }
-        ),
-        "Box.PhysicalBehaviorActor": (  # type: ignore[dict-item]
-            PHYS_ACTOR := {
-                "fill": [
-                    COLORS["_CAP_Actor_Blue_min"],
-                    COLORS["_CAP_Actor_Blue"],
-                ],
-                "stroke": COLORS["_CAP_Actor_Border_Blue"],
-                "text_fill": COLORS["_CAP_Actor_Blue_label"],
-                "text_font-style": "italic",
-            }
-        ),
-        "Box.PhysicalHumanBehaviorComponent": PHYS_BEHAVIOR,  # type: ignore[dict-item]
-        "Box.PhysicalHumanNodeComponent": (  # type: ignore[dict-item]
-            PHYS_NODE := {
-                "fill": [
-                    COLORS["_CAP_Node_Yellow_min"],
-                    COLORS["_CAP_Node_Yellow"],
-                ],
-                "stroke": COLORS["_CAP_Node_Yellow_Border"],
-                "text_fill": COLORS["_CAP_Node_Yellow_Label"],
-            }
-        ),
-        "Box.PhysicalHumanBehaviorActor": PHYS_ACTOR,  # type: ignore[dict-item]
-        "Box.PhysicalHumanNodeActor": PHYS_ACTOR,  # type: ignore[dict-item]
-        "Box.PhysicalNodeComponent": PHYS_NODE,  # type: ignore[dict-item]
-        "Box.PhysicalNodeActor": PHYS_ACTOR,  # type: ignore[dict-item]
+        "Box.PhysicalBehaviorActor": _PHYS_ACTOR,
+        "Box.PhysicalBehaviorComponent": _PHYS_BEHAVIOR,
+        "Box.PhysicalHumanBehaviorComponent": _PHYS_BEHAVIOR,
+        "Box.PhysicalHumanNodeComponent": _PHYS_NODE,
+        "Box.PhysicalHumanBehaviorActor": _PHYS_ACTOR,
+        "Box.PhysicalHumanNodeActor": _PHYS_ACTOR,
+        "Box.PhysicalNodeComponent": _PHYS_NODE,
+        "Box.PhysicalNodeActor": _PHYS_ACTOR,
         "Box.PhysicalFunction": {
             "fill": COLORS["_CAP_xAB_Function_Green"],
             "stroke": COLORS["_CAP_xAB_Function_Border_Green"],

--- a/capellambse/aird/capstyle.py
+++ b/capellambse/aird/capstyle.py
@@ -744,14 +744,43 @@ STYLES: dict[str, dict[str, dict[str, CSSdef]]] = {
             "fill": COLORS["_CAP_PhysicalPort_Yellow"],
             "stroke": COLORS["_CAP_Class_Border_Brown"],
         },
-        "Box.PhysicalComponent": {
-            "fill": [
-                COLORS["_CAP_Node_Yellow_min"],
-                COLORS["_CAP_Node_Yellow"],
-            ],
-            "stroke": COLORS["_CAP_Node_Yellow_Border"],
-            "text_fill": COLORS["_CAP_Node_Yellow_Label"],
-        },
+        "Box.PhysicalBehaviorComponent": (  # type: ignore[dict-item]
+            PHYS_BEHAVIOR := {
+                "fill": [
+                    COLORS["_CAP_Component_Blue_min"],
+                    COLORS["_CAP_Component_Blue"],
+                ],
+                "stroke": COLORS["_CAP_Actor_Border_Blue"],
+                "text_fill": COLORS["_CAP_Actor_Blue_label"],
+                "text_font-style": "italic",
+            }
+        ),
+        "Box.PhysicalBehaviorActor": (  # type: ignore[dict-item]
+            PHYS_ACTOR := {
+                "fill": [
+                    COLORS["_CAP_Actor_Blue_min"],
+                    COLORS["_CAP_Actor_Blue"],
+                ],
+                "stroke": COLORS["_CAP_Actor_Border_Blue"],
+                "text_fill": COLORS["_CAP_Actor_Blue_label"],
+                "text_font-style": "italic",
+            }
+        ),
+        "Box.PhysicalHumanBehaviorComponent": PHYS_BEHAVIOR,  # type: ignore[dict-item]
+        "Box.PhysicalHumanNodeComponent": (  # type: ignore[dict-item]
+            PHYS_NODE := {
+                "fill": [
+                    COLORS["_CAP_Node_Yellow_min"],
+                    COLORS["_CAP_Node_Yellow"],
+                ],
+                "stroke": COLORS["_CAP_Node_Yellow_Border"],
+                "text_fill": COLORS["_CAP_Node_Yellow_Label"],
+            }
+        ),
+        "Box.PhysicalHumanBehaviorActor": PHYS_ACTOR,  # type: ignore[dict-item]
+        "Box.PhysicalHumanNodeActor": PHYS_ACTOR,  # type: ignore[dict-item]
+        "Box.PhysicalNodeComponent": PHYS_NODE,  # type: ignore[dict-item]
+        "Box.PhysicalNodeActor": PHYS_ACTOR,  # type: ignore[dict-item]
         "Box.PhysicalFunction": {
             "fill": COLORS["_CAP_xAB_Function_Green"],
             "stroke": COLORS["_CAP_xAB_Function_Border_Green"],

--- a/capellambse/aird/capstyle.py
+++ b/capellambse/aird/capstyle.py
@@ -155,7 +155,9 @@ def get_style(diagramclass: str | None, objectclass: str) -> dict[str, t.Any]:
             "No default style for %r in %r", objectclass, diagramclass
         )
     try:
-        retval = STYLES["__GLOBAL__"][objectclass].copy()
+        global_styles = STYLES["__GLOBAL__"][objectclass]
+        assert isinstance(global_styles, dict)
+        retval = global_styles.copy()
     except KeyError:
         retval = {}
 
@@ -166,7 +168,7 @@ def get_style(diagramclass: str | None, objectclass: str) -> dict[str, t.Any]:
 
 CSSdef = t.Union[int, str, RGB, cabc.Sequence[RGB], None]
 #: This dict maps the color names used by Capella to RGB tuples.
-COLORS: dict[str, RGB] = {
+COLORS: cabc.Mapping[str, RGB] = {
     # System palette
     "black": RGB(0, 0, 0),
     "dark_gray": RGB(69, 69, 69),
@@ -290,7 +292,9 @@ _PHYS_NODE: dict[str, CSSdef] = {
 #: 2. __GLOBAL__, element type and class
 #: 3. Diagram class specific, only element type
 #: 4. __GLOBAL__, only element type
-STYLES: t.Final[cabc.Mapping[str, dict[str, dict[str, CSSdef]]]] = {
+STYLES: t.Final[
+    cabc.Mapping[str, cabc.Mapping[str, cabc.Mapping[str, CSSdef]]]
+] = {
     "__GLOBAL__": {  # Global defaults
         "Box": {
             "fill": "transparent",

--- a/capellambse/aird/parser/_box_factories.py
+++ b/capellambse/aird/parser/_box_factories.py
@@ -320,7 +320,7 @@ def physical_part_factory(seb: C.SemanticElementBuilder) -> aird.Box:
         part.styleclass = "".join(
             (
                 part.styleclass[: -len(suffix)],
-                ["Behavior", "Node"][(nature == "NODE")],
+                ("Behavior", "Node")[nature == "NODE"],
                 suffix,
             )
         )

--- a/capellambse/aird/parser/_box_factories.py
+++ b/capellambse/aird/parser/_box_factories.py
@@ -290,10 +290,12 @@ def part_factory(seb: C.SemanticElementBuilder) -> aird.Box:
         seb.styleclass = abstract_obj.attrib[C.ATT_XST].split(":")[-1]
         assert seb.styleclass is not None
         if seb.styleclass.endswith("Component"):
+            nature = ("Behavior", "Node")[abstract_obj.get("nature") == "NODE"]
             seb.styleclass = "".join(
                 (
                     seb.styleclass[: -len("Component")],
                     "Human" * (abstract_obj.get("human") == "true"),
+                    nature * (bool(abstract_obj.get("nature"))),
                     ("Component", "Actor")[
                         abstract_obj.get("actor") == "true"
                     ],
@@ -304,27 +306,6 @@ def part_factory(seb: C.SemanticElementBuilder) -> aird.Box:
 
     C.LOGGER.error("Unhandled Part type: %r; skipping", dgel_type)
     raise C.SkipObject()
-
-
-def physical_part_factory(seb: C.SemanticElementBuilder) -> aird.Box:
-    """Resolve a physical ``Part`` meta-styleclass and create its Box."""
-    part = part_factory(seb)
-    data_obj = seb.melodyobjs[-1]
-    if data_obj.attrib[C.ATT_XST].endswith("PhysicalComponent"):
-        nature = data_obj.get("nature", "BEHAVIOR")
-        assert part.styleclass is not None
-        suffix = "Component"
-        if part.styleclass.endswith("Actor"):
-            suffix = "Actor"
-
-        part.styleclass = "".join(
-            (
-                part.styleclass[: -len(suffix)],
-                ("Behavior", "Node")[nature == "NODE"],
-                suffix,
-            )
-        )
-    return part
 
 
 def requirements_box_factory(seb: C.SemanticElementBuilder) -> aird.Box:

--- a/capellambse/aird/parser/_box_factories.py
+++ b/capellambse/aird/parser/_box_factories.py
@@ -306,6 +306,27 @@ def part_factory(seb: C.SemanticElementBuilder) -> aird.Box:
     raise C.SkipObject()
 
 
+def physical_part_factory(seb: C.SemanticElementBuilder) -> aird.Box:
+    """Resolve a physical ``Part`` meta-styleclass and create its Box."""
+    part = part_factory(seb)
+    data_obj = seb.melodyobjs[-1]
+    if data_obj.attrib[C.ATT_XST].endswith("PhysicalComponent"):
+        nature = data_obj.get("nature", "BEHAVIOR")
+        assert part.styleclass is not None
+        suffix = "Component"
+        if part.styleclass.endswith("Actor"):
+            suffix = "Actor"
+
+        part.styleclass = "".join(
+            (
+                part.styleclass[: -len(suffix)],
+                ["Behavior", "Node"][(nature == "NODE")],
+                suffix,
+            )
+        )
+    return part
+
+
 def requirements_box_factory(seb: C.SemanticElementBuilder) -> aird.Box:
     """Create a Requirement.
 

--- a/capellambse/aird/parser/_box_factories.py
+++ b/capellambse/aird/parser/_box_factories.py
@@ -290,12 +290,12 @@ def part_factory(seb: C.SemanticElementBuilder) -> aird.Box:
         seb.styleclass = abstract_obj.attrib[C.ATT_XST].split(":")[-1]
         assert seb.styleclass is not None
         if seb.styleclass.endswith("Component"):
-            nature = ("Behavior", "Node")[abstract_obj.get("nature") == "NODE"]
+            nature = abstract_obj.get("nature", "")
             seb.styleclass = "".join(
                 (
                     seb.styleclass[: -len("Component")],
                     "Human" * (abstract_obj.get("human") == "true"),
-                    nature * (bool(abstract_obj.get("nature"))),
+                    nature.capitalize() * bool(nature),
                     ("Component", "Actor")[
                         abstract_obj.get("actor") == "true"
                     ],

--- a/capellambse/aird/parser/_semantic.py
+++ b/capellambse/aird/parser/_semantic.py
@@ -204,7 +204,7 @@ STYLECLASS_LOOKUP = {
             _box_factories.generic_factory, _edge_factories.labelless_factory
         ),
     ),
-    "Part": (None, _box_factories.physical_part_factory),
+    "Part": (None, _box_factories.part_factory),
     "Region": ("Region", _box_factories.region_factory),
     "PortAllocation": (
         "PortAllocation",

--- a/capellambse/aird/parser/_semantic.py
+++ b/capellambse/aird/parser/_semantic.py
@@ -204,7 +204,7 @@ STYLECLASS_LOOKUP = {
             _box_factories.generic_factory, _edge_factories.labelless_factory
         ),
     ),
-    "Part": (None, _box_factories.part_factory),
+    "Part": (None, _box_factories.physical_part_factory),
     "Region": ("Region", _box_factories.region_factory),
     "PortAllocation": (
         "PortAllocation",
@@ -214,6 +214,7 @@ STYLECLASS_LOOKUP = {
     "Service": (None, c.SkipObject.raise_),  # Handled as part of `Class`
     "SequenceLink": ("SequenceLink", _edge_factories.sequence_link_factory),
     "PhysicalPort": ("PP", _GENERIC_FACTORIES),
+    "PhysicalComponent": ("PhysicalComponent", _box_factories.part_factory),
     "Requirement": ("Requirement", _box_factories.requirements_box_factory),
     # FunctionalChains
     "FunctionalChainInvolvementFunction": (

--- a/capellambse/svg/style.py
+++ b/capellambse/svg/style.py
@@ -390,7 +390,9 @@ class StyleBuilder:
         self.styles = self._make_styles()
 
     def _make_styles(self) -> dict[str, dict[str, aird.CSSdef]]:
-        styles = aird.STYLES["__GLOBAL__"].copy()
+        global_styles = aird.STYLES["__GLOBAL__"]
+        assert isinstance(global_styles, dict)
+        styles = global_styles.copy()
         try:
             deep_update_dict(styles, aird.STYLES[self.class_])  # type: ignore[index]
         except KeyError:


### PR DESCRIPTION
Does solve #167 but not ideally and dry.

Have a look at the [capstyle default style dict](https://github.com/DSD-DBS/py-capellambse/compare/master...fix-phys-nature-styling#diff-2ce9560a92a80b69c73bea77215b9e2a0297f05c6b377e8edb5e054587e36cd3L747-R783). With this solution we needed to add many styleclasses with the same style-dict due to the `part_factory`. We dynamically add `Node` or `Behavior` to the `.styleclass` attribute of the object like we did in the `Human` and `Actor`  case. Indeed it seems like the `is_human` attribute (causing `Human` in the styleclass) doesn't change the styling in anyway. In the stylesheet generation it seems like we are matching the whole styleclass which limits us to also use the whole styleclass in the key in capstyle's default styledict. We have 2 ways to improve the situation:

1. Make the stylesheet generator compatible with wildcards/regex. This enables usage of styleclasses like e.g.: `Physical*Actor`, `Physical*NodeComponent` and `Physical*BehaviorComponent` and these 3 would be the only needed, differing style pairs.
2. Instead of having one styleclass add support of multiple classes, where the first one is the inferred/original one from the xtype (here `PhysicalComponent`). This would lead to styleclasses `PhysicalComponent`, `Human`, `Actor`, `Node` or `Behavior`. How would we determine which styling class is superior to the others? Take in mind this option does need more changes, especially in the file that declares diagram objects (`Diagram`, `Box`, `Edge`, etc.) and the svg submodule.

I'm looking forward to discuss moving forward.