### PR TITLE
Fix physical links

### DIFF
--- a/capellambse/model/common/accessors.py
+++ b/capellambse/model/common/accessors.py
@@ -120,6 +120,9 @@ class DeprecatedAccessor(Accessor[T]):
 
     def __get__(self, obj, objtype=None):
         self.__warn()
+        if obj is None:
+            return self
+
         return getattr(obj, self.alternative)
 
     def __set__(self, obj: element.GenericElement, value: t.Any) -> None:

--- a/capellambse/model/crosslayer/cs.py
+++ b/capellambse/model/crosslayer/cs.py
@@ -75,14 +75,18 @@ class PhysicalPort(c.GenericElement):
 class PhysicalLink(PhysicalPort):
     """A physical link."""
 
-    linkEnds = c.AttrProxyAccessor(
+    ends = c.PhysicalLinkEndsAccessor(
         PhysicalPort, "linkEnds", aslist=c.ElementList
     )
+    linkEnds = c.DeprecatedAccessor[PhysicalPort]("ends")
     exchanges = c.LinkAccessor[fa.ComponentExchange](
         None, fa.XT_COMP_EX_ALLOC, aslist=c.ElementList, attr="targetElement"
     )
 
     physical_paths: c.Accessor
+
+    source = c.IndexAccessor[PhysicalPort]("ends", 0)
+    target = c.IndexAccessor[PhysicalPort]("ends", 1)
 
 
 @c.xtype_handler(None)

--- a/capellambse/model/crosslayer/cs.py
+++ b/capellambse/model/crosslayer/cs.py
@@ -159,6 +159,13 @@ c.set_accessor(
     ),
 )
 c.set_accessor(
+    PhysicalPort,
+    "exchanges",
+    c.ReferenceSearchingAccessor(
+        PhysicalLink, "link_ends", aslist=c.ElementList
+    ),
+)
+c.set_accessor(
     PhysicalLink,
     "physical_paths",
     c.CustomAccessor(

--- a/tests/test_xlayer_cs.py
+++ b/tests/test_xlayer_cs.py
@@ -47,3 +47,30 @@ def test_PhysicalLink_has_exchanges(model: MelodyModel):
     link = model.pa.all_physical_links.by_name("Eth Cable 2")
     exchange = model.pa.all_component_exchanges.by_name("C 3")
     assert link.exchanges == [exchange]
+
+
+def test_PhysicalLink_setting_ends(model: MelodyModel):
+    link = model.pa.all_physical_links.by_name("Eth Cable 2")
+    source_pp = model.by_uuid("76d9c301-c0ad-4615-9f02-b804b018decf")
+    target_pp = model.by_uuid("53c9fe29-18e2-4642-906e-b7507bf0ff39")
+
+    link.ends = [source_pp, target_pp]
+
+    assert source_pp == link.ends[0]
+    assert source_pp == link.source
+    assert target_pp == link.ends[1]
+    assert target_pp == link.target
+
+
+def test_PhysicalLink_setting_source_and_target(model: MelodyModel):
+    link = model.pa.all_physical_links.by_name("Eth Cable 2")
+    source_pp = model.by_uuid("76d9c301-c0ad-4615-9f02-b804b018decf")
+    target_pp = model.by_uuid("53c9fe29-18e2-4642-906e-b7507bf0ff39")
+
+    link.source = source_pp
+    link.target = target_pp
+
+    assert source_pp == link.ends[0]
+    assert source_pp == link.source
+    assert target_pp == link.ends[1]
+    assert target_pp == link.target

--- a/tests/test_xlayer_cs.py
+++ b/tests/test_xlayer_cs.py
@@ -4,7 +4,7 @@
 from capellambse import MelodyModel
 
 
-def test_physical_path_has_ordered_list_of_involved_items(model: MelodyModel):
+def test_PhysicalPath_has_ordered_list_of_involved_items(model: MelodyModel):
     expected = [
         "544549d6-2aa4-44c2-b2ae-a86302f48e62",
         "42ee9e89-d445-45a2-8280-028d4fb1038d",
@@ -19,7 +19,7 @@ def test_physical_path_has_ordered_list_of_involved_items(model: MelodyModel):
     assert actual == expected
 
 
-def test_physical_path_has_ordered_list_of_involved_links(model: MelodyModel):
+def test_PhysicalPath_has_ordered_list_of_involved_links(model: MelodyModel):
     expected = [
         "42ee9e89-d445-45a2-8280-028d4fb1038d",
         "3078ec08-956a-4c61-87ed-0143d1d66715",
@@ -31,19 +31,19 @@ def test_physical_path_has_ordered_list_of_involved_links(model: MelodyModel):
     assert actual == expected
 
 
-def test_physical_path_has_exchanges(model: MelodyModel):
+def test_PhysicalPath_has_exchanges(model: MelodyModel):
     exchange = model.pa.all_component_exchanges.by_name("C 6")
     path = model.pa.all_physical_paths.by_name("card1 - card2 connection")
     assert path.exchanges == [exchange]
 
 
-def test_physical_link_has_physical_paths(model: MelodyModel):
+def test_PhysicalLink_has_physical_paths(model: MelodyModel):
     link = model.pa.all_physical_links.by_name("Eth Cable 2")
     path = model.pa.all_physical_paths.by_name("card1 - card2 connection")
     assert link.physical_paths == [path]
 
 
-def test_physical_link_has_exchanges(model: MelodyModel):
+def test_PhysicalLink_has_exchanges(model: MelodyModel):
     link = model.pa.all_physical_links.by_name("Eth Cable 2")
     exchange = model.pa.all_component_exchanges.by_name("C 3")
     assert link.exchanges == [exchange]


### PR DESCRIPTION
This PR enables context collection for `PhysicalComponent`s in the [context-diagrams-extension](https://github.com/DSD-DBS/capellambse-context-diagrams/pull/23).