### PR TITLE
docs: Set type-hints format to `short`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,6 +74,7 @@ rst_epilog = f"""
 autoclass_content = "class"
 autodoc_class_signature = "separated"
 autodoc_typehints = "description"
+autodoc_typehints_format = "short"
 
 
 # -- Options for napoleon ----------------------------------------------------


### PR DESCRIPTION
During a review I noticed that we have long hyperlinks for the type annotations that come from **autodoc** implemented in [PR#7018](https://github.com/sphinx-doc/sphinx/pull/7018) (not napoleon (!) ). Since we have a very structured code base with many submodules I want to shorten these. It is accomplished with the [`autodoc_typehints_format = "short"`](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_typehints_format) configuration. This should be the default configuration but somehow it is not. Do we need to upgrade sphinx?

The effects can be seen here:
**`autodoc_typehints_format = "fully-qualified"`**:
![image](https://user-images.githubusercontent.com/50786483/198259609-13072114-1fd2-4fce-b1a4-bb6418a8060c.png)

**`autodoc_typehints_format = "short"`**:
![image](https://user-images.githubusercontent.com/50786483/198259650-8136aa64-5795-4a45-8a02-eb37ffa664d6.png)

Unfortunately the typehints that use a mixture of `typing.*` or `collections.abc.*` and our own types are not shortened (example: **aslist** parameter). This can be fixed by introducing nice type aliases and maintain them in the `conf.py` via [`autodoc_type_aliases`](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_type_aliases). Or maybe even using [sphinx-autodoc-typehints](https://github.com/tox-dev/sphinx-autodoc-typehints) extension for this?

Do you think further investigation is worth it?