### PR TITLE
feat(declarative-modelling): Add modification from mapping

### DIFF
--- a/capellambse/decl.py
+++ b/capellambse/decl.py
@@ -201,7 +201,7 @@ def _operate_modify(
     modifications: dict[str, t.Any],
 ) -> cabc.Generator[_OperatorResult, t.Any, None]:
     for attr, value in modifications.items():
-        if isinstance(value, (list, Promise, UUIDReference)):
+        if isinstance(value, (dict, list, Promise, UUIDReference)):
             try:
                 value = _resolve(promises, parent, value)
             except _UnresolvablePromise as p:
@@ -227,6 +227,11 @@ def _resolve(
             newv = _resolve(promises, parent, v)
             if newv is not v:
                 value[i] = newv
+    elif isinstance(value, dict):
+        for key, v in value.items():
+            newv = _resolve(promises, parent, v)
+            if newv is not v:
+                value[key] = newv
     return value
 
 

--- a/docs/source/start/declarative.rst
+++ b/docs/source/start/declarative.rst
@@ -225,6 +225,9 @@ After selecting a parent, it is also possible to directly change its properties
 without introducing new objects into the model. This happens by specifying the
 attributes in the ``modify:`` key.
 
+Simple attributes
+^^^^^^^^^^^^^^^^^
+
 The following example would change the ``name`` of the root
 :py:class:`~capellambse.model.layers.la.LogicalComponent` to "Coffee Machine"
 (notice how we use a different UUID than before):
@@ -248,6 +251,56 @@ e.g. numeric properties. This example changes the ``min_card`` property of an
      modify:
        min_card: 0
        max_card: .inf
+
+ElementList attributes
+^^^^^^^^^^^^^^^^^^^^^^
+
+There are two scenarios for modifying attributes exposed by an
+:py:class:`~capellambse.model.common.element.ElementList`: Overwriting
+
+- all objects or
+- only specific objects
+
+by creating new ones in the attributes list. The former can be achieved by
+passing a list of wanted new values and the latter by passing a mapping:
+
+.. code-block:: yaml
+   :emphasize-lines: 4-5
+
+   - parent: !uuid 0a9a68b1-ba9a-4793-b2cf-4448f0b4b8cc
+     modify:
+       attributes:
+         - !uuid
+         - EnumerationAttributeDefinition:
+           - enum 1
+           - enum 2
+
+will set the ``.attributes`` of the
+:py:class:`~capellambse.extensions.reqif.Requirement`
+(`0a9a68b1-ba9a-4793-b2cf-4448f0b4b8cc`) to the declared ones:
+- one
+:py:class:`~capellambse.extensions.reqif.elements.StringValueAttribute` with
+the definition with ``.long_name == StringAttributeDefinition`` and
+``.value == Example``
+- and one
+:py:class:`~capellambse.extensions.reqif.elements.EnumerationValueAttribute`
+with the definition with ``.long_name == EnumerationAttributeDefinition`` and
+``.values == [enum 1, enum 2]`` (i.e.
+:py:class:`~capellambse.extensions.reqif.elements.EnumValue` \s with
+``.long_name`` matching ``enum 1`` and ``enum 2``).
+
+Instead precisive modification can be achieved with:
+
+.. code-block:: yaml
+   :emphasize-lines: 4-5
+
+   - parent: !uuid 0a9a68b1-ba9a-4793-b2cf-4448f0b4b8cc
+     modify:
+       attributes:
+         StringAttributeDefinition: Example
+         EnumerationAttributeDefinition:
+           - enum 1
+           - enum 2
 
 Deleting objects
 ----------------

--- a/tests/data/melodymodel/5_2/Melody Model Test.capella
+++ b/tests/data/melodymodel/5_2/Melody Model Test.capella
@@ -87,6 +87,8 @@
                 definition="#f31d4dd3-99f7-41d1-b1ce-f07b20d26eac" values="#efd6e108-3461-43c6-ad86-24168339ed3c #3c2390a4-ce9c-472c-9982-d0b825931978"/>
             <ownedAttributes xsi:type="Requirements:DateValueAttribute" id="7351093e-2c1c-4b1a-bb47-43443f530e8d"
                 definition="#682bd51d-5451-4930-a97e-8bfca6c3a127"/>
+            <ownedAttributes xsi:type="Requirements:StringValueAttribute" id="9ea92288-12f1-482d-8b90-f29b339155cc"
+                definition="#0bd40628-10a5-451e-86da-187c93bc3b10" value="Dummy"/>
           </ownedRequirements>
           <ownedRequirements xsi:type="Requirements:Folder" id="e179d6ff-5301-42a6-bf6f-4fec79b18827"
               ReqIFName="Subfolder" requirementType="#db47fca9-ddb6-4397-8d4b-e397e53d277e">


### PR DESCRIPTION
In order to handle modify operation from a mapping it is needed to extend `decl._operate_modify` and its `decl._resolve` function.

**WIP**
- The problem left to solve is documented in `accessors.py#L445-452`.
- Rewrite the documentation section
