### PR TITLE
Fix `ElementList.__html__` with `None` members

### DIFF
--- a/capellambse/model/common/element.py
+++ b/capellambse/model/common/element.py
@@ -686,7 +686,8 @@ class ElementList(cabc.MutableSequence, t.Generic[T]):
 
         fragments = ['<ol start="0" style="text-align: left;">']
         for i in self:
-            fragments.append(f"<li>{i._short_html_()}</li>")
+            rep = i._short_html_() if hasattr(i, "_short_html_") else repr(i)
+            fragments.append(f"<li>{rep}</li>")
         fragments.append("</ol>")
         return markupsafe.Markup("".join(fragments))
 

--- a/tests/data/melodymodel/5_2/Melody Model Test.capella
+++ b/tests/data/melodymodel/5_2/Melody Model Test.capella
@@ -80,6 +80,9 @@
             <ownedRelations xsi:type="CapellaRequirements:CapellaIncomingRelation"
                 id="24c824ef-b187-4725-a051-a68707e82d70" ReqIFLongName="Test req"
                 source="#3c2d312c-37c9-41b5-8c32-67578fa52dc3" target="#00e7b925-cf4c-4cb0-929e-5409a1cd872b"/>
+            <ownedRelations xsi:type="CapellaRequirements:CapellaIncomingRelation"
+                id="2a59d2a4-f460-4fcd-a907-57b6b4ea42ae" relationType="#f1aceb81-5f70-4469-a127-94830eb9be04"
+                source="#3c2d312c-37c9-41b5-8c32-67578fa52dc3"/>
           </ownedRequirements>
           <ownedRequirements xsi:type="Requirements:Requirement" id="0a9a68b1-ba9a-4793-b2cf-4448f0b4b8cc"
               ReqIFLongName="TypedReq2" ReqIFName="" requirementType="#db47fca9-ddb6-4397-8d4b-e397e53d277e">
@@ -3139,7 +3142,11 @@ The predator is far away</bodies>
       <ownedConfigurationItemPkg xsi:type="org.polarsys.capella.core.data.epbs:ConfigurationItemPkg"
           id="7e7a78fe-8769-4dff-9e4f-dd740d298592" name="Structure">
         <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="db7ca640-2a70-4550-bca9-60f480941cee"
-            name="System" abstractType="#9abb92e7-24d3-4156-ba41-9151bb2fe4b1"/>
+            name="System" abstractType="#9abb92e7-24d3-4156-ba41-9151bb2fe4b1">
+          <ownedExtensions xsi:type="CapellaRequirements:CapellaOutgoingRelation"
+              id="e3ecc8b4-3535-414d-b14a-affad1942e93" relationType="#f1aceb81-5f70-4469-a127-94830eb9be04"
+              source="#db7ca640-2a70-4550-bca9-60f480941cee"/>
+        </ownedParts>
         <ownedConfigurationItems xsi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem"
             id="9abb92e7-24d3-4156-ba41-9151bb2fe4b1" name="System" kind="SystemCI">
           <ownedPhysicalArtifactRealizations xsi:type="org.polarsys.capella.core.data.epbs:PhysicalArtifactRealization"

--- a/tests/test_reqif.py
+++ b/tests/test_reqif.py
@@ -112,7 +112,7 @@ def test_broken_RequirementRelation_short_html_works(
     else:
         req = relation.target
 
-    assert req._short_html_()
+    assert req.__html__()
 
 
 def test_extension_was_loaded():

--- a/tests/test_reqif.py
+++ b/tests/test_reqif.py
@@ -91,6 +91,30 @@ def test_ReqIFElement_short_repr_(
     assert repr(obj).startswith(expected)
 
 
+@pytest.mark.parametrize(
+    "uuid",
+    [
+        pytest.param("e3ecc8b4-3535-414d-b14a-affad1942e93", id="Outgoing"),
+        pytest.param("2a59d2a4-f460-4fcd-a907-57b6b4ea42ae", id="Incoming"),
+    ],
+)
+def test_broken_RequirementRelation_short_html_works(
+    model_5_2: capellambse.MelodyModel, uuid: str
+) -> None:
+    """Test display of requirements with broken relations.
+
+    When the target of the relation is deleted, Capella misses on
+    deleting the invalid relation.
+    """
+    relation = model_5_2.by_uuid(uuid)
+    if isinstance(relation, reqif.RequirementsIncRelation):
+        req = relation.source
+    else:
+        req = relation.target
+
+    assert req._short_html_()
+
+
 def test_extension_was_loaded():
     capellambse.load_model_extensions()
 


### PR DESCRIPTION
When deleting targets of `RequirementOutRelation` or `RequirementIncRelation`s Capella doesn't delete these relations. The leftover and invalid relations caused an exception of requirement display in a jupyter notebook environment. This PR makes this more safe and adds a test for 2 broken relations.