### PR TITLE
Terminal improvements (and graphics)

### DIFF
--- a/capellambse/cli_helpers.py
+++ b/capellambse/cli_helpers.py
@@ -34,15 +34,17 @@ try:
                ...
         """
 
-        name = "Capella model"
+        name = "CAPELLA_MODEL"
 
         def convert(self, value: t.Any, param, ctx) -> capellambse.MelodyModel:
-            del param, ctx
-
             if isinstance(value, capellambse.MelodyModel):
                 return value
 
-            return loadcli(value)
+            try:
+                return loadcli(value)
+            except ValueError as err:
+                self.fail(err.args[0], param, ctx)
+                assert False
 
 except ImportError:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,10 @@ png = [
   "cairosvg>=2.5.2",
 ]
 
+termgraphics = [
+  "capellambse[png]",
+]
+
 [project.entry-points."capellambse.diagram.formats"]
 datauri_svg = "capellambse.model.diagram:SVGDataURIFormat"
 html_img = "capellambse.model.diagram:SVGInHTMLIMGFormat"
@@ -90,6 +94,7 @@ png = "capellambse.model.diagram:PNGFormat"
 svg = "capellambse.model.diagram:SVGFormat"
 svg_confluence = "capellambse.model.diagram:ConfluenceSVGFormat"
 svgdiagram = "capellambse.model.diagram:convert_svgdiagram"
+termgraphics = "capellambse.model.diagram:TerminalGraphicsFormat"
 
 [project.entry-points."capellambse.filehandler"]
 file = "capellambse.filehandler.local:LocalFileHandler"


### PR DESCRIPTION
This PR enables printing diagrams straight to a terminal that supports it. (Currently we only recognize [kitty](https://sw.kovidgoyal.net/kitty/) as supporting it. In the future, we might want to look at libraries that implement proper auto-detection.)

This also works with third-party plugins that add new types of diagrams, as long as they inherit from the `AbstractDiagram` class (and don't override `__repr__`). The context-diagram extension was tested and is confirmed working without any modifications.

Here's a screenshot of the feature in action, using the `capellambse.repl` shell:

![grafik](https://user-images.githubusercontent.com/1579756/208084853-43146063-b754-4f7d-9695-54b667331608.png)