### PR TITLE
Solved bug in ComponentExchange.exchange_items

### DIFF
--- a/capellambse/model/crosslayer/fa.py
+++ b/capellambse/model/crosslayer/fa.py
@@ -224,11 +224,12 @@ class ComponentExchange(AbstractExchange):
     def exchange_items(
         self,
     ) -> c.ElementList[information.ExchangeItem]:
-        items = self.allocated_exchange_items
-        func_exchanges = self.allocated_functional_exchanges
-        assert isinstance(func_exchanges, cabc.Iterable)
-        for exchange in func_exchanges:
-            items += exchange.exchange_items
+
+        items = c.ElementList(self._model, [], information.ExchangeItem)
+        items.extend(self.allocated_exchange_items)
+        items.extend([item 
+            for fexch in self.allocated_functional_exchanges 
+            for item in fexch.exchange_items])
         return items
 
     def __dir__(self) -> list[str]:


### PR DESCRIPTION
A local list variable in the object was being modified on each call. This caused a bug where code calling this property will produce more elements each time it was called. 

