### PR TITLE
Add high level `get_styleclass` function

### DIFF
--- a/capellambse/diagram/__init__.py
+++ b/capellambse/diagram/__init__.py
@@ -12,3 +12,4 @@ from ._vector2d import *
 from .capstyle import *
 from ._diagram import *
 from ._json_enc import *
+from ._styleclass import *

--- a/capellambse/diagram/_styleclass.py
+++ b/capellambse/diagram/_styleclass.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Functions for receiving the styleclass from a given ``ModelObject``."""
+from __future__ import annotations
+
+__all__ = ["get_styleclass"]
+
+import collections.abc as cabc
+import re
+import typing as t
+
+from .. import model
+from ..model.crosslayer import capellacommon, cs, fa, information
+
+if t.TYPE_CHECKING:
+    from capellambse import ModelObject
+
+
+def get_styleclass(obj: ModelObject) -> str:
+    """Return the styleclass from an individual ``ModelObject``.
+
+    Parameters
+    ----------
+    obj
+        An object received from querying the High-Level API.
+
+    Returns
+    -------
+    styleclass
+        A string used for styling and decorating given ``obj`` in a
+        diagram representation.
+    """
+    styleclass_factory = _STYLECLASSES.get(type(obj).__name__, _default)
+    return styleclass_factory(obj)
+
+
+def _default(obj: ModelObject) -> str:
+    assert isinstance(obj, model.GenericElement)
+    return obj.xtype.rsplit(":", maxsplit=1)[-1]
+
+
+def _association(obj: ModelObject) -> str:
+    assert isinstance(obj, information.Association)
+    default_kind = kind = "ASSOCIATION"
+    for member in obj.members:  # type: ignore[union-attr]
+        if member.kind != default_kind:
+            kind = member.kind
+    return kind.capitalize()
+
+
+def _component_port(obj: ModelObject) -> str:
+    assert isinstance(obj, fa.ComponentPort)
+    if obj.direction is None:
+        return "CP_UNSET"
+    return f"CP_{obj.direction}"
+
+
+def _control_node(obj: ModelObject) -> str:
+    assert isinstance(obj, fa.ControlNode)
+    return "".join((obj.kind.name.capitalize(), _default(obj)))
+
+
+def _functional_chain_involvement(obj: ModelObject) -> str:
+    assert isinstance(
+        obj,
+        (
+            fa.FunctionalChainInvolvementLink,
+            fa.FunctionalChainInvolvementFunction,
+        ),
+    )
+    styleclass = _default(obj)
+    if _default(obj.parent) == "OperationalProcess":
+        return styleclass.replace("Functional", "Operational")
+    return styleclass
+
+
+def _generic_component(obj: ModelObject) -> str:
+    assert isinstance(obj, cs.Component)
+    styleclass = _default(obj)
+    return "".join(
+        (
+            styleclass[: -len("Component")],
+            "Human" * obj.is_human,
+            ("Component", "Actor")[obj.is_actor],
+        )
+    )
+
+
+def _physical_component(obj: ModelObject) -> str:
+    assert _default(obj) == "PhysicalComponent"
+    styleclass = _generic_component(obj)
+    ptrn = re.compile("^(.*)(Component|Actor)$")
+    nature = obj.nature.name  # type: ignore[attr-defined]
+    return ptrn.sub(rf"\1{nature.capitalize()}\2", styleclass)
+
+
+def _part(obj: ModelObject) -> str:
+    assert isinstance(obj, cs.Part)
+    xclass = _default(obj.type)
+    if xclass == "PhysicalComponent":
+        return _physical_component(obj)
+    elif xclass == "Entity":
+        return _default(obj.type)
+    return _generic_component(obj.type)
+
+
+def _port_allocation(obj: ModelObject) -> str:
+    assert isinstance(obj, information.PortAllocation)
+    styleclasses = set(
+        p for p in (obj.source, obj.target) if _default(p) != "ComponentPort"
+    )
+    return f"{'_'.join(sorted(styleclasses))}Allocation"
+
+
+def _region(obj: ModelObject) -> str:
+    assert isinstance(obj, capellacommon.Region)
+    parent_xclass = _default(obj.parent)
+    return f"{parent_xclass}{_default(obj)}"
+
+
+_STYLECLASSES: dict[str, cabc.Callable[[ModelObject], str]] = {
+    "Association": _association,
+    "CapellaIncomingRelation": lambda _: "RequirementRelation",
+    "CapellaOutgoingRelation": lambda _: "RequirementRelation",
+    "ComponentPort": _component_port,
+    "ControlNode": _control_node,
+    "FunctionalChainInvolvementFunction": _functional_chain_involvement,
+    "FunctionalChainInvolvementLink": _functional_chain_involvement,
+    "FunctionInputPort": lambda _: "FIP",
+    "FunctionOutputPort": lambda _: "FOP",
+    "LogicalComponent": _generic_component,
+    "Part": _part,
+    "PhysicalComponent": _physical_component,
+    "PhysicalPort": lambda _: "PP",
+    "PortAllocation": _port_allocation,
+    "Region": _region,
+    "SystemComponent": _generic_component,
+}

--- a/capellambse/model/crosslayer/capellacommon.py
+++ b/capellambse/model/crosslayer/capellacommon.py
@@ -3,7 +3,7 @@
 
 """Classes handling Mode/State-Machines and related content."""
 from .. import common as c
-from . import capellacore
+from . import capellacore, modellingcore
 
 XT_TRAFO = "org.polarsys.capella.core.data.capellacommon:TransfoLink"
 XT_ABSTRACT_STATE_REAL = (
@@ -114,11 +114,8 @@ class StateTransition(c.GenericElement):
 
 
 @c.xtype_handler(None)
-class GenericTrace(c.GenericElement):
+class GenericTrace(modellingcore.TraceableElement):
     """A trace between two elements."""
-
-    source = c.AttrProxyAccessor(c.GenericElement, attr="sourceElement")
-    target = c.AttrProxyAccessor(c.GenericElement, attr="targetElement")
 
     @property
     def name(self) -> str:  # type: ignore[override]

--- a/capellambse/model/crosslayer/fa.py
+++ b/capellambse/model/crosslayer/fa.py
@@ -37,6 +37,17 @@ XT_FCALLOC = "org.polarsys.capella.core.data.fa:ComponentFunctionalAllocation"
 
 
 @c.xtype_handler(None)
+class ControlNode(c.GenericElement):
+    """A node with a specific control-kind."""
+
+    _xmltag = "ownedSequenceNodes"
+
+    kind = xmltools.EnumAttributeProperty(
+        "_element", "kind", modeltypes.ControlNodeKind, writable=False
+    )
+
+
+@c.xtype_handler(None)
 class FunctionRealization(c.GenericElement):
     """A realization that links to a function."""
 
@@ -176,6 +187,7 @@ class FunctionalChain(c.GenericElement):
         aslist=c.MixedElementList,
         attr="involved",
     )
+    control_nodes = c.DirectProxyAccessor(ControlNode, aslist=c.ElementList)
 
     @property
     def involved(self) -> c.MixedElementList:

--- a/capellambse/model/crosslayer/information/__init__.py
+++ b/capellambse/model/crosslayer/information/__init__.py
@@ -61,6 +61,7 @@ class Association(c.GenericElement):
 
     _xmltag = "ownedAssociations"
 
+    members: c.Accessor[Property]
     navigable_members: c.Accessor[Property]
     source_role: c.Accessor[Property]
 
@@ -282,6 +283,11 @@ c.set_accessor(
     DataPkg, "packages", c.DirectProxyAccessor(DataPkg, aslist=c.ElementList)
 )
 c.set_accessor(ExchangeItemElement, "owner", c.ParentAccessor(ExchangeItem))
+c.set_accessor(
+    Association,
+    "members",
+    c.DirectProxyAccessor(Property, aslist=c.ElementList),
+)
 c.set_accessor(
     Association,
     "navigable_members",

--- a/capellambse/model/crosslayer/information/__init__.py
+++ b/capellambse/model/crosslayer/information/__init__.py
@@ -18,7 +18,7 @@ from capellambse.loader import xmltools
 
 from ... import common as c
 from ... import modeltypes
-from .. import capellacommon, capellacore
+from .. import capellacommon, capellacore, modellingcore
 from . import datatype, datavalue
 
 
@@ -75,6 +75,13 @@ class Association(c.GenericElement):
         assert isinstance(self.navigable_members, c.ElementList)
         roles.extend(prop._element for prop in self.navigable_members)
         return c.ElementList(self._model, roles, Property)
+
+
+@c.xtype_handler(None)
+class PortAllocation(modellingcore.TraceableElement):
+    """An exchange between a ComponentPort and FunctionalPort."""
+
+    _xmltag = "ownedPortAllocations"
 
 
 @c.xtype_handler(None)
@@ -179,13 +186,10 @@ class Class(c.GenericElement):
 
 
 @c.xtype_handler(None)
-class InformationRealization(c.GenericElement):
+class InformationRealization(modellingcore.TraceableElement):
     """A realization for a Class."""
 
     _xmltag = "ownedInformationRealizations"
-
-    source = c.AttrProxyAccessor(Class, "sourceElement")
-    target = c.AttrProxyAccessor(Class, "targetElement")
 
 
 @c.xtype_handler(None)

--- a/capellambse/model/crosslayer/information/__init__.py
+++ b/capellambse/model/crosslayer/information/__init__.py
@@ -14,8 +14,6 @@ Information object-relations map (ontology):
 
 from __future__ import annotations
 
-from lxml import etree
-
 from capellambse.loader import xmltools
 
 from ... import common as c

--- a/capellambse/model/crosslayer/modellingcore.py
+++ b/capellambse/model/crosslayer/modellingcore.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Abstract classes acting as templates for concrete classes.
+
+These base classes are used between different layers.
+"""
+
+from .. import common as c
+
+
+class TraceableElement(c.GenericElement):
+    """A template for traceable ModelObjects."""
+
+    source = c.AttrProxyAccessor(c.GenericElement, attr="sourceElement")
+    target = c.AttrProxyAccessor(c.GenericElement, attr="targetElement")

--- a/capellambse/model/layers/oa.py
+++ b/capellambse/model/layers/oa.py
@@ -22,10 +22,6 @@ from ..crosslayer import (
 
 XT_ARCH = "org.polarsys.capella.core.data.oa:OperationalAnalysis"
 
-XT_EOCI = (
-    "org.polarsys.capella.core.data.oa:EntityOperationalCapabilityInvolvement"
-)
-
 
 @c.xtype_handler(XT_ARCH)
 class OperationalActivity(fa.AbstractFunction):

--- a/capellambse/model/modeltypes.py
+++ b/capellambse/model/modeltypes.py
@@ -208,3 +208,11 @@ class ScenarioKind(_StringyEnumMixin, _enum.Enum):
     FUNCTIONAL = _enum.auto()
     INTERACTION = _enum.auto()
     INTERFACE = _enum.auto()
+
+
+class ControlNodeKind(_StringyEnumMixin, _enum.Enum):
+    """ControlNode kind."""
+
+    OR = _enum.auto()
+    AND = _enum.auto()
+    ITERATE = _enum.auto()

--- a/tests/test_model_layers.py
+++ b/tests/test_model_layers.py
@@ -692,6 +692,25 @@ def test_FunctionalChainInvolvementFunction_appears_in_chain_involvements(
     )
 
 
+@pytest.mark.parametrize(
+    ["chain_uuid", "control_nodes"],
+    [
+        pytest.param(
+            "d588e41f-ec4d-4fa9-ad6d-056868c66274", 3, id="OperationalProcess"
+        ),
+        pytest.param(
+            "dfc4341d-253a-4ae9-8a30-63a9d9faca39", 9, id="FunctionalChain"
+        ),
+    ],
+)
+def test_FunctionalChainInvolvement_has_control_nodes(
+    model_5_2: capellambse.MelodyModel, chain_uuid: str, control_nodes: int
+) -> None:
+    chain = model_5_2.by_uuid(chain_uuid)
+
+    assert len(chain.control_nodes) == control_nodes
+
+
 class TestArchitectureLayers:
     @pytest.mark.parametrize(
         "layer,definitions",


### PR DESCRIPTION
This PR publishes the new `get_styleclass` function which is used in DSD-DBS/capellambse-context-diagrams#27. With this function the user can receive the necessary styleclass string used for styling objects in a diagram representation.