### PR TITLE
Model description (complexity) badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,9 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Mac garbage
+.DS_Store
+
+# vscode settings might be very user-specifc, lets ignore it for now
+.vscode/settings.json

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -69,6 +69,21 @@ We additionally recommend that you set up your editor / IDE as follows.
   save. Language server clients are available for a wide range of editors, from
   Vim/Emacs to PyCharm/IDEA.
 
+Quality controls
+----------------
+
+We rely on pre-commit__ to perform basic quality control / self assessment.
+
+__ https://pre-commit.com/
+
+Commit message format
+---------------------
+
+Within the project core group we agreed on using `Conventional Commits`__.
+Compliance checking is automated via pre-commit.
+
+__ https://www.conventionalcommits.org/en/v1.0.0/#summary
+
 Code style
 ----------
 

--- a/capellambse/extensions/metrics/__init__.py
+++ b/capellambse/extensions/metrics/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tools for statistical evaluation of model contents."""
+
+import capellambse
+
+from .collector import quantify_model_layers
+from .composer import draw_summary_badge
+
+
+def get_summary_badge(model: capellambse.MelodyModel) -> str:
+    """Provide visual summary of model contents."""
+    objects, diagrams = quantify_model_layers(model)
+    return draw_summary_badge(objects, diagrams)

--- a/capellambse/extensions/metrics/collector.py
+++ b/capellambse/extensions/metrics/collector.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Collection of tools for collection of statistical data from a model.
+
+Objects of interest are those that we see people working on most. We
+think that counting those may help us with model complexity evaluation -
+for example identify if a model is big or small or see where the
+modeling focus is (problem space / solution space / balanced)
+"""
+
+import capellambse
+
+COMMON_OBJECTS = [
+    "Requirement",
+    "Class",
+    "StateMachine",
+    "PhysicalLink",
+    "FunctionalExchange",
+    "ComponentExchange",
+    "ExchangeItem",
+]
+
+OBJECTS_OF_INTEREST = [
+    [  # Operational Analysis
+        "OperationalCapability",
+        "OperationalActivity",
+        "Entity",
+    ]
+    + COMMON_OBJECTS,
+    ["SystemFunction", "SystemComponent"] + COMMON_OBJECTS,  # System Analysis
+    [  # Logical Architecture
+        "LogicalFunction",
+        "LogicalComponent",
+    ]
+    + COMMON_OBJECTS,
+    [  # Physical Architecture
+        "PhysicalFunction",
+        "PhysicalComponent",
+    ]
+    + COMMON_OBJECTS,
+]
+
+
+def quantify_model_layers(
+    model: capellambse.MelodyModel,
+) -> tuple[list[int], list[int]]:
+    """Count objects of interest and diagrams on model layers.
+
+    Returns
+    -------
+    list
+        The number of interesting objects per model layer
+    list
+        The number of diagrams per model layer
+
+    Notes
+    -----
+    The order of numbers in a list corresponds to the order of model
+    layers - OA, SA, LA, PA.
+    """
+    objects = []
+    diagrams = []
+    for layer, object_types in zip(
+        [model.oa, model.sa, model.la, model.pa], OBJECTS_OF_INTEREST
+    ):
+        layer_objects = len(model.search(*object_types, below=layer))
+        objects.append(layer_objects)
+        diagrams.append(len(layer.diagrams))
+    return objects, diagrams

--- a/capellambse/extensions/metrics/composer.py
+++ b/capellambse/extensions/metrics/composer.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Collection of tools for drawing model complexity assessment badge."""
+from __future__ import annotations
+
+import collections.abc as cabc
+
+COLORS = ("#ffdd87", "#91cc84", "#a5c2e6", "#f89f9f")
+LEGEND = (
+    (2, "Operational Analysis"),
+    (36, "System Analysis"),
+    (66, "Logical Architecture"),
+    (99, "Physical Architecture"),
+)
+"""The x-offset and label of each legend entry."""
+
+
+def draw_rect(
+    x: float,
+    y: float,
+    width: float,
+    height: float,
+    fill: str = "#FFF",
+    stroke: str = "#333",
+    stroke_width: float = 0,
+) -> str:
+    """Construct a rectangle (SVG string)."""
+    return (
+        f'<rect fill="{fill}" stroke="{stroke}" stroke-width="{stroke_width}"'
+        f' x="{x}" y="{y}" width="{width}" height="{height}" />\n'
+    )
+
+
+def draw_group(
+    contents: list[str],
+    fill: str | None = None,
+    font_size: float | None = None,
+    font_family: str | None = None,
+) -> str:
+    """Construct a group (SVG string)."""
+    return (
+        "<g"
+        + (f' font-family="{font_family}"' if font_family else "")
+        + (f' font-size="{font_size:.2}"' if font_size else "")
+        + (f' fill="{fill}"' if fill else "")
+        + f'>\n{"".join(contents)}</g>\n'
+    )
+
+
+def draw_text(
+    x: float, y: float, text: str, font_size: float | None = None
+) -> str:
+    """Construct a text element (SVG string)."""
+    return (
+        "<text "
+        + (f'font-size="{font_size:.2}"' if font_size else "")
+        + f'x="{x}" y="{y}">{text}</text>\n'
+    )
+
+
+def draw_legend(x: float, y: float):
+    """Construct plot legend (SVG string)."""
+    return draw_group(
+        [
+            draw_rect(x + x_offset, y, 5, 3, fill=COLORS[idx])
+            + draw_text(x + x_offset + 6, y + 2.6, text)
+            for idx, (x_offset, text) in enumerate(LEGEND)
+        ],
+        fill="#555",
+        font_size=2.8,
+    )
+
+
+def draw_bar(
+    data: cabc.Sequence[float],
+    max_width: float,
+    x: float,
+    y: float,
+    height: float = 8,
+    show_label_threshold: float = 0.1,
+) -> str:
+    """Construct a 4-segment bar plot (SVG string).
+
+    Segment spacing is defined by {data}; Sum of {data} must match 1 for
+    the thing to work the right way. Segments are labeled with "%" if
+    the width is above {show_label_threshold}.
+    """
+    widths = [max_width * x for x in data]
+    offsets = [0.0]
+    for i, width in enumerate(widths[:-1]):
+        offsets.append(offsets[i] + width)
+    label = [
+        f"{x*100.0:.0f}%" if x >= show_label_threshold else "" for x in data
+    ]
+    return draw_group(
+        [
+            draw_rect(
+                x=x + x_offset,
+                y=y,
+                width=widths[idx],
+                height=height,
+                fill=COLORS[idx],
+            )
+            + (
+                draw_text(
+                    x=x + x_offset + 1,
+                    y=y + (height / 2.0) + 1,
+                    text=label[idx],
+                )
+                if len(label[idx]) > 0
+                else ""
+            )
+            for idx, x_offset in enumerate(offsets)
+        ],
+        font_size=3.2,
+    )
+
+
+def draw_diagrams_icon(x: float | int, y: float | int):
+    """Create simple diagram icon (SVG string)."""
+    return (
+        '<g stroke="#555" stroke-width=".2">'
+        f'<path fill="#FFF" d="M{x + 0.5} {y + 1.8} h3.6 v3.1 H{x + 0.5} z"/>'
+        f'<path fill="#a5c2e6" d="M{x + 1} {y + 2.4} h1v.7 H{x + 1}z '
+        'm.8 1.2h1v.7h-1z m.9-1.1h.8v.6h-.8z"/><path fill="none" '
+        f'd="M{x + 1}.9 {y + 2.8} h.8 m-1.3.3.4.8 m1 .1.4-.9"/></g>'
+    )
+
+
+def draw_objects_icon(x: float | int, y: float | int):
+    """Create simple objects icon (SVG string)."""
+    return (
+        '<g stroke="#555" stroke-width=".3">'
+        f'<path fill="#ffdd87" d="M{x + 1} {y + 2.1} h1.9 V{y + 4} h-2 z"/>'
+        f'<path fill="#a5c2e6" d="M{x + 1.8} {y + 3} h2 v1.8 h-2 z"/></g>'
+    )
+
+
+def draw_labeled_bar(
+    x: float,
+    y: float,
+    label: str,
+    segments: list[int],
+    draw_icon: cabc.Callable[[float | int, float | int], str],
+) -> str:
+    """Construct a bar with label and icon (SVG string)."""
+    total = sum(segments)
+    normalized_segments = [x / total for x in segments]
+    return (
+        draw_icon(x, y)
+        + draw_text(x + 5, y + 3, f"{total}")
+        + draw_text(x + 5, y + 6, label)
+        + draw_bar(normalized_segments, 104, x + 22.2, y)
+    )
+
+
+def draw_summary_badge(
+    objects: list[int], diagrams: list[int], scale: float = 4.0
+) -> str:
+    """Construct summary badge (SVG string)."""
+    text = draw_group(
+        [
+            draw_rect(1, 0, 132, 30, stroke_width=0.2),
+            draw_rect(23.8, 1.4, 108, 22, stroke_width=0.2),
+            draw_labeled_bar(2, 3.4, "objects", objects, draw_objects_icon),
+            draw_labeled_bar(
+                2, 13.4, "diagrams", diagrams, draw_diagrams_icon
+            ),
+            draw_legend(1, 25),
+        ],
+        font_family="sans-serif",
+        font_size=3.2,
+    )
+    return (
+        f'<SVG xmlns="http://www.w3.org/2000/svg"'
+        f' width="{scale*134}" height="{scale*30}" viewBox="0 0 134 30">'
+        f"{text}</SVG>"
+    )

--- a/capellambse/model/__init__.py
+++ b/capellambse/model/__init__.py
@@ -348,3 +348,10 @@ class MelodyModel:
     def by_uuid(self, uuid: str) -> common.GenericElement:
         """Search the entire model for an element with the given UUID."""
         return common.GenericElement.from_model(self, self._loader[uuid])
+
+    @property
+    def description_badge(self) -> str:
+        """Describe model contents distribution with an SVG badge."""
+        from capellambse.extensions import metrics
+
+        return metrics.get_summary_badge(self)

--- a/docs/source/examples/11 Complexity Assessment.ipynb
+++ b/docs/source/examples/11 Complexity Assessment.ipynb
@@ -1,0 +1,71 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import SVG, display\n",
+    "import capellambse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Cannot load PVMT extension: ValueError: Provided model does not have a PropertyValuePkg\n",
+      "Property values are not available in this model\n"
+     ]
+    },
+    {
+     "data": {
+      "image/svg+xml": "<SVG xmlns=\"http://www.w3.org/2000/svg\" width=\"536.0\" height=\"120.0\" viewBox=\"0 0 134 30\"><g font-family=\"sans-serif\" font-size=\"3.2\">\n<rect fill=\"#FFF\" stroke=\"#333\" stroke-width=\"0.2\" x=\"1\" y=\"0\" width=\"132\" height=\"30\" />\n<rect fill=\"#FFF\" stroke=\"#333\" stroke-width=\"0.2\" x=\"23.8\" y=\"1.4\" width=\"108\" height=\"22\" />\n<g stroke=\"#555\" stroke-width=\".3\"><path fill=\"#ffdd87\" d=\"M3 5.5 h1.9 V7.4 h-2 z\"/><path fill=\"#a5c2e6\" d=\"M3.8 6.4 h2 v1.8 h-2 z\"/></g><text x=\"7\" y=\"6.4\">180</text>\n<text x=\"7\" y=\"9.4\">objects</text>\n<g font-size=\"3.2\">\n<rect fill=\"#ffdd87\" stroke=\"#333\" stroke-width=\"0\" x=\"24.2\" y=\"3.4\" width=\"31.77777777777778\" height=\"8\" />\n<text x=\"25.2\" y=\"8.4\">31%</text>\n<rect fill=\"#91cc84\" stroke=\"#333\" stroke-width=\"0\" x=\"55.977777777777774\" y=\"3.4\" width=\"16.177777777777777\" height=\"8\" />\n<text x=\"56.977777777777774\" y=\"8.4\">16%</text>\n<rect fill=\"#a5c2e6\" stroke=\"#333\" stroke-width=\"0\" x=\"72.15555555555555\" y=\"3.4\" width=\"28.31111111111111\" height=\"8\" />\n<text x=\"73.15555555555555\" y=\"8.4\">27%</text>\n<rect fill=\"#f89f9f\" stroke=\"#333\" stroke-width=\"0\" x=\"100.46666666666667\" y=\"3.4\" width=\"27.733333333333334\" height=\"8\" />\n<text x=\"101.46666666666667\" y=\"8.4\">27%</text>\n</g>\n<g stroke=\"#555\" stroke-width=\".2\"><path fill=\"#FFF\" d=\"M2.5 15.200000000000001 h3.6 v3.1 H2.5 z\"/><path fill=\"#a5c2e6\" d=\"M3 15.8 h1v.7 H3z m.8 1.2h1v.7h-1z m.9-1.1h.8v.6h-.8z\"/><path fill=\"none\" d=\"M3.9 16.2 h.8 m-1.3.3.4.8 m1 .1.4-.9\"/></g><text x=\"7\" y=\"16.4\">18</text>\n<text x=\"7\" y=\"19.4\">diagrams</text>\n<g font-size=\"3.2\">\n<rect fill=\"#ffdd87\" stroke=\"#333\" stroke-width=\"0\" x=\"24.2\" y=\"13.4\" width=\"40.44444444444444\" height=\"8\" />\n<text x=\"25.2\" y=\"18.4\">39%</text>\n<rect fill=\"#91cc84\" stroke=\"#333\" stroke-width=\"0\" x=\"64.64444444444445\" y=\"13.4\" width=\"23.11111111111111\" height=\"8\" />\n<text x=\"65.64444444444445\" y=\"18.4\">22%</text>\n<rect fill=\"#a5c2e6\" stroke=\"#333\" stroke-width=\"0\" x=\"87.75555555555556\" y=\"13.4\" width=\"28.88888888888889\" height=\"8\" />\n<text x=\"88.75555555555556\" y=\"18.4\">28%</text>\n<rect fill=\"#f89f9f\" stroke=\"#333\" stroke-width=\"0\" x=\"116.64444444444445\" y=\"13.4\" width=\"11.555555555555555\" height=\"8\" />\n<text x=\"117.64444444444445\" y=\"18.4\">11%</text>\n</g>\n<g font-size=\"2.8\" fill=\"#555\">\n<rect fill=\"#ffdd87\" stroke=\"#333\" stroke-width=\"0\" x=\"3\" y=\"25\" width=\"5\" height=\"3\" />\n<text x=\"9\" y=\"27.6\">Operational Analysis</text>\n<rect fill=\"#91cc84\" stroke=\"#333\" stroke-width=\"0\" x=\"37\" y=\"25\" width=\"5\" height=\"3\" />\n<text x=\"43\" y=\"27.6\">System Analysis</text>\n<rect fill=\"#a5c2e6\" stroke=\"#333\" stroke-width=\"0\" x=\"67\" y=\"25\" width=\"5\" height=\"3\" />\n<text x=\"73\" y=\"27.6\">Logical Architecture</text>\n<rect fill=\"#f89f9f\" stroke=\"#333\" stroke-width=\"0\" x=\"100\" y=\"25\" width=\"5\" height=\"3\" />\n<text x=\"106\" y=\"27.6\">Physical Architecture</text>\n</g>\n</g>\n</SVG>",
+      "text/plain": [
+       "<IPython.core.display.SVG object>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model = capellambse.MelodyModel(\"../../../tests/data/melodymodel/5_2/Melody Model Test.aird\")\n",
+    "SVG(model.description_badge)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.6 ('.venv': venv)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "f5c9192943a88c565de58e6fd7c534c9de794a35889e45ad6809ab92c821a96c"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/source/examples/11 Complexity Assessment.ipynb.license
+++ b/docs/source/examples/11 Complexity Assessment.ipynb.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
+SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
This adds a basic summary badge property to a model. 

in response to `model.description_badge` we get an SVG string that provides a visual summary of model composition and key object counts across the engineering layers. 

I wonder if we could also make this a default `display` behavior for the model object itself, since this function call doesnt seem to cost much in terms of resources.