### PR TITLE
Fix minor bugs from change audit and requirements merge

### DIFF
--- a/capellambse/extensions/reqif/_capellareq.py
+++ b/capellambse/extensions/reqif/_capellareq.py
@@ -153,6 +153,16 @@ class RequirementsRelationAccessor(
             i.getparent().remove(i)
         obj._element.extend(value)
 
+    def __delete__(self, obj) -> None:
+        assert self.aslist is not None
+
+        if getattr(obj, "_constructed", True):
+            sys.audit("capellambse.delete", obj, self.__name__, None)
+        for i in self._find_relations(obj):
+            parent = i.getparent()
+            assert parent is not None
+            parent.remove(i)
+
     def _find_relations(self, obj) -> list[etree._Element]:
         rels = obj._model.search(
             CapellaIncomingRelation,

--- a/capellambse/model/common/accessors.py
+++ b/capellambse/model/common/accessors.py
@@ -831,11 +831,9 @@ class AttrProxyAccessor(WritableAccessor[T], PhysicalAccessor[T]):
         return rv
 
     def __set__(
-        self,
-        obj: element.GenericElement,
-        values: T | cabc.Iterable[T],
+        self, obj: element.ModelObject, values: T | cabc.Iterable[T]
     ) -> None:
-        if obj._constructed:
+        if getattr(obj, "_constructed", True):
             sys.audit("capellambse.setattr", obj, self.__name__, values)
 
         if not isinstance(values, cabc.Iterable):

--- a/capellambse/pvmt/types.py
+++ b/capellambse/pvmt/types.py
@@ -271,7 +271,7 @@ def select_property_loader(element):
     """Execute the appropriate loader for the PV definition element."""
     xtype = str(element.attrib[XTYPE_KEY]).rsplit(":", maxsplit=1)[-1]
     if xtype not in PROPERTY_LOADER:
-        raise Exception(f"XSI type {xtype} is not yet supported")
+        raise NotImplementedError(f"XSI type {xtype} is not yet supported")
     return PROPERTY_LOADER[xtype](element)
 
 

--- a/tests/test_reqif.py
+++ b/tests/test_reqif.py
@@ -741,6 +741,20 @@ class TestReqIFModification:
         with pytest.raises(TypeError):
             attr.value = value
 
+    def test_setting_values_on_EnumValueAttribute(
+        self, model: capellambse.MelodyModel
+    ):
+        evattr = model.by_uuid("a44b41f3-598c-4250-bca6-1329647e7a02")
+        values = [
+            model.by_uuid("efd6e108-3461-43c6-ad86-24168339ed3c"),
+            model.by_uuid("3c2390a4-ce9c-472c-9982-d0b825931978"),
+        ]
+        assert values[1] not in evattr.values, "Precondition failed"
+
+        evattr.values = values
+
+        assert evattr.values == values
+
     def test_create_RequirementType_AttributeDefinition_creation(
         self, model: capellambse.MelodyModel
     ):


### PR DESCRIPTION
This PR fixes some minor bugs that must have happened during the merge of the requirements into the change-auditing branch.
Somehow the passed element in an `capellambse.delete` audit event wasn't the parent object (as it is documented) but the deleted object itself. Additionally `_operate_modify` would fire an `AttributeError` b/c an `__delete__` was missing on the `AttrProxyAccessor` which is needed for setting a new values-list on an `EnumerationValueAttribute`.