### PR TITLE
Add namespaces when creating elements

### DIFF
--- a/capellambse/loader/modelinfo.py
+++ b/capellambse/loader/modelinfo.py
@@ -14,3 +14,4 @@ class ModelInfo:
     revision: str | None = None
     rev_hash: str | None = None
     capella_version: str | None = None
+    viewpoints: dict[str, str] = dataclasses.field(default_factory=dict)

--- a/capellambse/model/__init__.py
+++ b/capellambse/model/__init__.py
@@ -224,7 +224,6 @@ class MelodyModel:
 
         self._constructed = False
         self._loader = loader.MelodyLoader(path, **kwargs)
-        self.info = self._loader.get_model_info()
         self.jupyter_untrusted = jupyter_untrusted
 
         try:
@@ -508,6 +507,10 @@ class MelodyModel:
         )
         with self._loader.write_tmp_project_dir() as tmp_project_dir:
             diagram_cache.export_diagrams(tmp_project_dir)
+
+    @property
+    def info(self) -> loader.ModelInfo:
+        return self._loader.get_model_info()
 
     @property
     def description_badge(self) -> str:

--- a/capellambse/model/common/element.py
+++ b/capellambse/model/common/element.py
@@ -212,6 +212,9 @@ class GenericElement:
             for key, val in kw.items():
                 if key == "xtype":
                     self._element.set(helpers.ATT_XT, val)
+                    self._model._loader.add_namespace(
+                        parent, val.split(":", maxsplit=1)[0]
+                    )
                 elif not isinstance(
                     getattr(type(self), key),
                     (accessors.Accessor, properties.AttributeProperty),

--- a/tests/data/writemodel/WriteTestModel.afm
+++ b/tests/data/writemodel/WriteTestModel.afm
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_UHFmEBOBEeufW7ftWKiX7w">
   <viewpointReferences id="_UHo_sBOBEeufW7ftWKiX7w" vpId="org.polarsys.capella.core.viewpoint" version="5.2.0"/>
+  <viewpointReferences id="_0gTecKiDEe256I6gDVoEiA" vpId="org.polarsys.kitalpha.vp.requirements" version="0.12.2"/>
+  <viewpointReferences id="_0hNdYKiDEe256I6gDVoEiA" vpId="org.polarsys.capella.vp.requirements" version="0.12.2"/>
 </metadata:Metadata>

--- a/tests/data/writemodel/WriteTestModel.aird
+++ b/tests/data/writemodel/WriteTestModel.aird
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<viewpoint:DAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description" uid="_UHHbQBOBEeufW7ftWKiX7w" selectedViews="_UIPcoBOBEeufW7ftWKiX7w _lQZQYBOBEeufW7ftWKiX7w _lYqbkBOBEeufW7ftWKiX7w _larNwBOBEeufW7ftWKiX7w _lbo3EBOBEeufW7ftWKiX7w _ldOLcBOBEeufW7ftWKiX7w _ledhkBOBEeufW7ftWKiX7w _le_tEBOBEeufW7ftWKiX7w" version="14.6.0.202110251100">
+<viewpoint:DAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description" uid="_UHHbQBOBEeufW7ftWKiX7w" selectedViews="_UIPcoBOBEeufW7ftWKiX7w _lQZQYBOBEeufW7ftWKiX7w _lYqbkBOBEeufW7ftWKiX7w _larNwBOBEeufW7ftWKiX7w _lbo3EBOBEeufW7ftWKiX7w _ldOLcBOBEeufW7ftWKiX7w _ledhkBOBEeufW7ftWKiX7w _le_tEBOBEeufW7ftWKiX7w _0gedkKiDEe256I6gDVoEiA _0hXOYKiDEe256I6gDVoEiA" version="14.6.0.202110251100">
   <semanticResources>WriteTestModel.afm</semanticResources>
   <semanticResources>WriteTestModel.capella</semanticResources>
   <ownedViews xmi:type="viewpoint:DView" uid="_UIPcoBOBEeufW7ftWKiX7w">
@@ -25,5 +25,11 @@
   </ownedViews>
   <ownedViews xmi:type="viewpoint:DView" uid="_le_tEBOBEeufW7ftWKiX7w">
     <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']"/>
+  </ownedViews>
+  <ownedViews xmi:type="viewpoint:DView" uid="_0gedkKiDEe256I6gDVoEiA">
+    <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.kitalpha.vp.requirements.design/description/Requirements.odesign#//@ownedViewpoints[name='Requirements_ID']"/>
+  </ownedViews>
+  <ownedViews xmi:type="viewpoint:DView" uid="_0hXOYKiDEe256I6gDVoEiA">
+    <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.vp.requirements.design/description/CapellaRequirements.odesign#//@ownedViewpoints[name='CapellaRequirements_ID']"/>
   </ownedViews>
 </viewpoint:DAnalysis>

--- a/tests/data/writemodel/WriteTestModel.capella
+++ b/tests/data/writemodel/WriteTestModel.capella
@@ -2,8 +2,8 @@
 
 <!--Capella_Version_5.2.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/5.0.0"
-    xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/5.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:CapellaRequirements="http://www.polarsys.org/capella/requirements"
+    xmlns:libraries="http://www.polarsys.org/capella/common/libraries/5.0.0" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/5.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/5.0.0"
     xmlns:org.polarsys.capella.core.data.capellamodeller="http://www.polarsys.org/capella/core/modeller/5.0.0"
     xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/5.0.0"
@@ -227,6 +227,8 @@
     </ownedArchitectures>
     <ownedArchitectures xsi:type="org.polarsys.capella.core.data.pa:PhysicalArchitecture"
         id="545ed1bf-776e-4fcf-b564-16abec00f821" name="Physical Architecture">
+      <ownedExtensions xsi:type="CapellaRequirements:CapellaModule" id="85a31dd7-7755-486b-b803-1df8915e2cf9"
+          ReqIFLongName="Empty module"/>
       <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunctionPkg"
           id="68726f4c-7f43-405f-a276-67627f84de9c" name="Physical Functions">
         <ownedPhysicalFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"

--- a/tests/test_model_creation_deletion.py
+++ b/tests/test_model_creation_deletion.py
@@ -77,3 +77,28 @@ def test_delete_all_deletes_matching_objects(model: capellambse.MelodyModel):
     comps.delete_all(name="Delete Me")
     assert len(comps) == 1
     assert comps[0].name == "Keep Me"
+
+
+def test_create_adds_missing_namespace_to_fragment(
+    model: capellambse.MelodyModel,
+) -> None:
+    assert "Requirements" not in model._element.nsmap, "Precondition failed"
+    module = model.by_uuid("85a31dd7-7755-486b-b803-1df8915e2cf9")
+
+    module.requirements.create(name="TestReq")
+
+    assert "Requirements" in model._element.nsmap
+
+
+def test_adding_a_namespace_preserves_the_capella_version_comment(
+    model: capellambse.MelodyModel,
+) -> None:
+    assert "Requirements" not in model._element.nsmap, "Precondition failed"
+    prev_elements = list(model._element.itersiblings(preceding=True))
+    assert len(prev_elements) == 1, "No version comment to preserve?"
+
+    model._loader.add_namespace(model._element, "Requirements")
+
+    prev_elements = list(model._element.itersiblings(preceding=True))
+    assert len(prev_elements) == 1
+    assert model.info.capella_version != "UNKNOWN"

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -292,3 +292,13 @@ def test_loading_model_with_unsupported_plugin_fails(
 ) -> None:
     with pytest.raises(capellambse.UnsupportedPluginError):
         capellambse.MelodyModel(model_path_with_patched_version)
+
+
+def test_model_info_contains_viewpoints_and_capella_version() -> None:
+    loader = capellambse.loader.MelodyLoader(TEST_MODEL_5_0)
+
+    info = loader.get_model_info()
+
+    assert hasattr(info, "viewpoints")
+    assert info.viewpoints["org.polarsys.capella.core.viewpoint"] == "5.0.0"
+    assert info.capella_version == "5.0.0"


### PR DESCRIPTION
In order for the types of model elements to be correctly identifiable, the namespace has to be defined on the fragment's respective root element. This commit adds new methods for this purpose, and ensures that `GenericElement.__init__` calls them with the correct values.