### PR TITLE
Delete dangling references to deleted model objects

### DIFF
--- a/capellambse/extensions/reqif/_capellareq.py
+++ b/capellambse/extensions/reqif/_capellareq.py
@@ -15,6 +15,7 @@ __all__ = [
 ]
 
 import collections.abc as cabc
+import contextlib
 import os
 import sys
 import typing as t
@@ -227,6 +228,19 @@ class RequirementsRelationAccessor(
         parent.insert(index, value._element)
         elmlist._model._loader.idcache_index(value._element)
 
+    @contextlib.contextmanager
+    def purge_references(
+        self, obj: c.ModelObject, target: c.ModelObject
+    ) -> cabc.Generator[None, None, None]:
+        """Do nothing.
+
+        This is a no-op, as this accessor provides a virtual relation.
+
+        The relation objects it handles are cleaned up by removing the
+        source or target attribute.
+        """
+        yield
+
     def _find_relation_type(
         self, target: c.GenericElement
     ) -> type[rq.InternalRelation | CapellaIncomingRelation]:
@@ -338,6 +352,19 @@ class ElementRelationAccessor(
             sys.audit("capellambse.read_attribute", obj, self.__name__, rv)
             sys.audit("capellambse.getattr", obj, self.__name__, rv)
         return rv
+
+    @contextlib.contextmanager
+    def purge_references(
+        self, obj: c.ModelObject, target: c.ModelObject
+    ) -> cabc.Generator[None, None, None]:
+        """Do nothing.
+
+        This is a no-op, as this accessor provides a virtual relation.
+
+        The relation objects it handles are cleaned up by removing the
+        source or target attribute.
+        """
+        yield
 
     def _make_list(self, parent_obj, elements):
         assert self.aslist is not None

--- a/capellambse/loader/core.py
+++ b/capellambse/loader/core.py
@@ -1198,7 +1198,7 @@ class MelodyLoader:
                 part = f"{next_xtype} {part}"
             try:
                 targets.append(self.follow_link(from_element, part))
-            except KeyError:
+            except (KeyError, ValueError):
                 if not ignore_broken:
                     raise
         return targets

--- a/capellambse/model/common/accessors.py
+++ b/capellambse/model/common/accessors.py
@@ -68,6 +68,13 @@ class Accessor(t.Generic[T], metaclass=abc.ABCMeta):
     __objclass__: type[t.Any]
     __name__: str
 
+    def __init__(self) -> None:
+        super().__init__()
+        self.__doc__ = (
+            f"A {type(self).__name__} that was not properly configured."
+            " Ensure that ``__set_name__`` gets called after construction."
+        )
+
     @t.overload
     def __get__(self, obj: None, objtype: type[t.Any]) -> te.Self:
         ...
@@ -95,6 +102,8 @@ class Accessor(t.Generic[T], metaclass=abc.ABCMeta):
     def __set_name__(self, owner: type[t.Any], name: str) -> None:
         self.__objclass__ = owner
         self.__name__ = name
+        friendly_name = name.replace("_", " ")
+        self.__doc__ = f"The {friendly_name} of this {owner.__name__}."
 
     def __repr__(self) -> str:
         return f"<{self._qualname!r} {type(self).__name__}>"
@@ -113,6 +122,7 @@ class DeprecatedAccessor(Accessor[T]):
     __slots__ = ("alternative",)
 
     def __init__(self, alternative: str, /) -> None:
+        super().__init__()
         self.alternative = alternative
 
     @t.overload

--- a/docs/source/start/audit-events.rst
+++ b/docs/source/start/audit-events.rst
@@ -81,6 +81,9 @@ The following table shows all audit events that are fired by ``capellambse``.
 | ``capellambse.delete``         | An object or a list of objects is about to |
 |                                | be deleted from the model.                 |
 | .. versionadded:: 0.5.11       |                                            |
+|                                | This is also fired when purging left-over  |
+|                                | references while deleting another object.  |
+|                                |                                            |
 |                                | **Arguments:**                             |
 |                                |                                            |
 |                                | 1. ``parent``: The current parent object.  |

--- a/tests/test_auditing.py
+++ b/tests/test_auditing.py
@@ -418,7 +418,7 @@ def test_creating_objects_fires_exactly_one_create_event(
         ),
     ],
 )
-def test_deleting_an_object_from_a_list_fires_one_delete_event(
+def test_deleting_an_object_from_a_list_fires_one_delete_event_for_the_object(
     model: capellambse.MelodyModel,
     audit_events: list[tuple[t.Any, ...]],
     obj_id: str,
@@ -434,12 +434,15 @@ def test_deleting_an_object_from_a_list_fires_one_delete_event(
 
     del target[0]
 
-    events = [i for i in audit_events if i[0] == "capellambse.delete"]
+    events = [
+        args
+        for e, o, *args in audit_events
+        if e == "capellambse.delete" and o == obj
+    ]
     assert len(events) == 1
-    _, *ev = events[0]
-    assert ev[0] is obj
-    assert ev[1] == attr
-    assert ev[2] == 0
+    (*ev,) = events[0]
+    assert ev[0] == attr
+    assert ev[1] == 0
 
 
 @pytest.mark.parametrize(
@@ -486,9 +489,12 @@ def test_deleting_an_entire_list_attribute_fires_one_delete_event(
 
     delattr(obj, attr)
 
-    events = [i for i in audit_events if i[0] == "capellambse.delete"]
+    events = [
+        args
+        for e, o, *args in audit_events
+        if e == "capellambse.delete" and o == obj
+    ]
     assert len(events) == 1
-    _, *ev = events[0]
-    assert ev[0] is obj
-    assert ev[1] == attr
-    assert ev[2] is None
+    (*ev,) = events[0]
+    assert ev[0] == attr
+    assert ev[1] is None

--- a/tests/test_model_creation_deletion.py
+++ b/tests/test_model_creation_deletion.py
@@ -8,6 +8,11 @@ import pathlib
 import pytest
 
 import capellambse
+import capellambse.model as metamodel
+import capellambse.model.common as c
+
+# pylint: disable-next=relative-beyond-top-level, unused-import
+from .conftest import model as model50  # type: ignore[import]
 
 TEST_ROOT = pathlib.Path(__file__).parent / "data" / "writemodel"
 TEST_MODEL = "WriteTestModel.aird"
@@ -102,3 +107,73 @@ def test_adding_a_namespace_preserves_the_capella_version_comment(
     prev_elements = list(model._element.itersiblings(preceding=True))
     assert len(prev_elements) == 1
     assert model.info.capella_version != "UNKNOWN"
+
+
+def test_deleting_an_object_purges_references_from_AttrProxyAccessor(
+    model: capellambse.MelodyModel, caplog
+) -> None:
+    part = model.by_uuid("1bd59e23-3d45-4e39-88b4-33a11c56d4e3")
+    assert isinstance(part, metamodel.cs.Part)
+    assert isinstance(type(part).type, c.AttrProxyAccessor)
+    component = model.by_uuid("ea5f09e6-a0ec-46b2-bd3e-b572f9bf99d6")
+
+    component.parent.components.remove(component)
+
+    assert not list(model.find_references(component))
+    assert part.type is None
+    assert not caplog.records
+
+
+def test_deleting_an_object_purges_references_from_LinkAccessor(
+    model50: capellambse.MelodyModel, caplog
+) -> None:
+    entity = model50.by_uuid("e37510b9-3166-4f80-a919-dfaac9b696c7")
+    assert isinstance(entity, metamodel.oa.Entity)
+    assert isinstance(type(entity).activities, c.LinkAccessor)
+    activity = model50.by_uuid("f1cb9586-ce85-4862-849c-2eea257f706b")
+
+    activity.parent.activities.remove(activity)
+
+    assert not list(model50.find_references(activity))
+    assert activity not in entity.activities
+    assert not caplog.records
+
+
+def test_deleting_an_entire_list_purges_references_to_all_list_members(
+    model50: capellambse.MelodyModel, caplog
+) -> None:
+    component = model50.by_uuid("ff7b8672-84db-4b93-9fea-22a410907fb1")
+    assert isinstance(component, metamodel.la.LogicalComponent)
+    p1 = model50.by_uuid("db5681e4-4245-4207-a429-e89979f6ac71")
+    p2 = model50.by_uuid("7c61d723-3658-47ff-9b0c-7b016ac4cb76")
+    current_ports = [i.uuid for i in component.ports]
+    assert current_ports == [p1.uuid, p2.uuid], "Unexpected ports"
+    assert list(model50.find_references(p1)), "Dead port CP 1?"
+    assert list(model50.find_references(p2)), "Dead port CP 2?"
+
+    del component.ports
+
+    assert not list(model50.find_references(p1))
+    assert not list(model50.find_references(p2))
+    assert not caplog.records
+
+
+def test_deleting_an_object_purges_references_to_children(
+    model50: capellambse.MelodyModel, caplog
+) -> None:
+    component = model50.by_uuid("a8c46457-a702-41c4-a971-c815c4c5a674")
+    port = model50.by_uuid("e0dcf8c2-2283-4456-98a2-146e78ba5f26")
+    exchange_id = "d8655737-39ab-4482-a934-ee847c7ff6bd"
+    current_refs = [
+        (getattr(obj, "uuid", None), attr)
+        for obj, attr, _ in model50.find_references(port)
+    ]
+    assert port in component.ports
+    assert len(current_refs) > 1, "Port has no references before test"
+    assert (exchange_id, "target") in current_refs
+
+    model50.la.component_package.components.remove(component)
+
+    assert not list(model50.find_references(port))
+    assert model50.by_uuid(exchange_id).target is None
+    assert not caplog.records


### PR DESCRIPTION
This PR introduces a new function `MelodyModel.find_references(target)`, which enumerates all existing model objects that contain a reference to the given target object. This function is used while deleting objects to ensure that no dangling references are left behind. Dangling references break the model by causing exceptions (in capellambse) and preventing the removal of affected objects (in Capella).

Resolves #256.