### PR TITLE
Fix exports of diagram images

### DIFF
--- a/capellambse/_diagram_cache.py
+++ b/capellambse/_diagram_cache.py
@@ -313,7 +313,7 @@ class DiagramCache:
                 subprocess.check_call(self._cli_cmd)
             except subprocess.CalledProcessError as err:
                 raise RuntimeError("Failed to update diagram cache") from err
-            for p in pathlib.Path(workspace).glob(
+            for p in pathlib.Path(project_dir).glob(
                 f"main_model/**/*.{self.image_format}"
             ):
                 shutil.copyfile(p, self.diagrams_dir / p.name)

--- a/capellambse/loader/core.py
+++ b/capellambse/loader/core.py
@@ -1289,8 +1289,9 @@ class MelodyLoader:
         given, library files) into a temporary directory. This is of
         interest when one wants the Capella CLI to import the project
         for instance. For the Capella model project this method ensures
-        that a ``.project`` file will be created. The model files will
-        be located in a subdirectory named `main_model` to separate them
+        that a ``.project`` file will be created, which contains the
+        hard coded project name "main_model". The model files will be
+        located in a subdirectory named `main_model` to separate them
         from library files.
         """
         E = builder.ElementMaker()
@@ -1312,7 +1313,7 @@ class MelodyLoader:
             ele = next(self.iterall("ownedModelRoots"), None)
             assert ele is not None
             xml = E.projectDescription(
-                E.name(ele.attrib["name"]),
+                E.name("main_model"),
                 E.comment(),
                 E.projects(),
                 E.buildSpec(),
@@ -1332,6 +1333,8 @@ class MelodyLoader:
             ):
                 for path in paths:
                     with self.filehandler.open(path) as fsrc:
-                        with open(dst / path.parts[-1], "wb") as fdst:
+                        dstpath = dst / path
+                        dstpath.parent.mkdir(parents=True, exist_ok=True)
+                        with open(dstpath, "wb") as fdst:
                             shutil.copyfileobj(fsrc, fdst)
             yield tmp_model_dir


### PR DESCRIPTION
Two issues were discovered, which could break the automatic generation of diagram images in certain scenarios.

Firstly, the `MelodyLoader.write_tmp_project_dir` function did not correctly reproduce the directory hierarchy within the project. This is especially relevant if the project uses fragment files, as in non-fragmented cases all model files usually are in a single flat folder anyways. This issue caused Capella to not find the associated fragment files, which in turn led to it not seeing all diagrams for export.

Secondly, the generated `.project` file contained the `model.name` as the project name property. This dynamic name caused issues in the diagram image caching function, which expected it to be `main_model`, just like the parent folder's name in the temporary folder. For consistency, the `.project` file now contains the hardcoded project name "main_model".