### PR TITLE
fix(svg): Draw symbols and circles lastly

### DIFF
--- a/capellambse/svg/generate.py
+++ b/capellambse/svg/generate.py
@@ -67,7 +67,14 @@ class SVGDiagram:
         objects: cabc.Sequence[ContentsDict],
     ) -> None:
         self.drawing = Drawing(metadata)
+        draw_last = list[ContentsDict]()
         for obj in objects:
+            if obj["type"] in {"symbol", "circle"}:
+                draw_last.append(obj)
+            else:
+                self.draw_object(obj)
+
+        for obj in draw_last:
             self.draw_object(obj)
 
     @classmethod


### PR DESCRIPTION
As can be seen in the SVG from [context-diagrams #30](https://github.com/DSD-DBS/capellambse-context-diagrams/pull/30) exchanges might overlap ports. This is fixed by introducing a simple order in drawing objects on the canvas.

The new version of the SVG looks like this:
![image](https://user-images.githubusercontent.com/50786483/228852274-7df3d181-ae5a-4ab4-9731-ff03d31b460d.png)
