### PR TITLE
Add model arguments to Gitlab CI template

### DIFF
--- a/ci-templates/gitlab/README.rst
+++ b/ci-templates/gitlab/README.rst
@@ -20,6 +20,7 @@ Please add the following section to your ``.gitlab-ci.yml``:
 
   variables:
     ENTRYPOINT: test/test.aird # Entry point to the .aird file of the model (relative from root level of the repository)
+    CAPELLAMBSE_MODEL_KWARGS: '{"ignore_duplicate_uuids_and_void_all_warranties": true}' # Additional arguments as json, passed to the MelodyModel class.
 
   # The following section is only needed if you want to change the output filename or commit message
   generate-model-badge:

--- a/ci-templates/gitlab/model-badge.yml
+++ b/ci-templates/gitlab/model-badge.yml
@@ -14,12 +14,15 @@ generate-model-badge:
     - pip install "git+https://github.com/DSD-DBS/py-capellambse.git@$CAPELLAMBSE_REVISION"
     - |
       python <<EOF
+      import json
       import os
       import pathlib
 
       import capellambse
 
-      model = capellambse.MelodyModel(os.environ["ENTRYPOINT"])
+      model_kwargs = json.loads(os.getenv("CAPELLAMBSE_MODEL_KWARGS", "{}"))
+
+      model = capellambse.MelodyModel(os.environ["ENTRYPOINT"], **model_kwargs)
       pathlib.Path(os.environ["OUTPUT_FILE"]).write_text(model.description_badge)
       EOF
     - git add "$OUTPUT_FILE"


### PR DESCRIPTION
Adds an option in the Gitlab CI template for the model badge to pass additional arguments to the MelodyModel class. Users can set the `CAPELLAMBSE_MODEL_KWARGS` environment variable to a json dict with additional arguments. 