### PR TITLE
Don't crash with local files if git isn't installed

### DIFF
--- a/capellambse/filehandler/local.py
+++ b/capellambse/filehandler/local.py
@@ -114,10 +114,12 @@ class LocalFileHandler(FileHandler):
                 .stdout.decode("utf-8")
                 .strip()
             )
-        except subprocess.CalledProcessError:
-            LOGGER.warning(
-                "Git rev-parse with options %s failed",
+        except Exception as err:
+            LOGGER.debug(
+                "Git rev-parse with options %s failed: %s: %s",
                 options,
+                type(err).__name__,
+                err,
             )
             return None
 


### PR DESCRIPTION
If there's no `git` executable to begin with, the exception flying isn't CalledProcessError but FileNotFoundError, which was previously not handled at all.

Since the data provided by the affected `__git_rev_parse` function is optional to begin with, this commit changes it to suppress (and log) every Exception, not just those of a specific subclass.