### PR TITLE
Filtering Gitlab CI template: Push derived models into different branches

### DIFF
--- a/ci-templates/gitlab/README.rst
+++ b/ci-templates/gitlab/README.rst
@@ -41,12 +41,11 @@ Filtered project derivation
 ---------------------------
 
 If you use the `Capella Filtering extension`__, you can automatically derive
-filtered projects from the main project.
+filtered projects from the main project. The derived projects are stored as
+Gitlab job artifacts, and can optionally be pushed to separate branches.
+
 
 __ https://github.com/eclipse/capella-filtering
-
-This can also be combined with pre-rendering cached diagram images for each
-derived model.
 
 Add the following code to your ``.gitlab-ci.yml``:
 
@@ -56,30 +55,18 @@ Add the following code to your ``.gitlab-ci.yml``:
     - remote: https://raw.githubusercontent.com/DSD-DBS/py-capellambse/${CAPELLAMBSE_REVISION}/ci-templates/gitlab/filter-derive.yml
 
   variables:
+    CAPELLA_VERSION: 6.0.0 # Semantic Capella version
     ENTRYPOINT: test/test.aird # Entry point to the .aird file of the model (relative from root level of the repository)
+    CAPELLAMBSE_REVISION: release-0.5 # Set the capellambse revision. Defaults to release-0.5.
 
   derive:
-    # Use the following line to only derive filtered models.
-    extends: .derive
-    # Use this instead if you also want to generate diagrams after derivation.
-    extends: .derive-and-generate-diagrams
-
     # If you want to change any settings (see filter-derive.yml),
     # add a variables section, like so:
     variables:
-      CAPELLA_DOCKERIMAGE: some/image/name:{VERSION}
+
+      # Push derived model to individual branches.
+      # The branch name is 'derived/<derived-project-name>'.
+      # Defaults to 1, set it to 0 if pushing in separate branches is not wanted.
+      PUSH_DERIVED_MODELS: 1
+
       DERIVE_RESULTS: 01234567-89ab-cdef-0123-456789abcdef;My Result 1;My Result 2
-
-If your Gitlab runner does not support Docker-in-Docker, you can still use this
-template, but you'll have to specify slightly different options. In this case,
-the Capella image you use must have a Python interpreter installed.
-
-.. code:: yaml
-
-  derive:
-    extends: .derive # As above
-    image:
-      name: some/image/name:6.0.0 # You have to pre-select the correct version manually
-      entrypoint: [""]
-    variables:
-      CAPELLA_EXECUTABLE: /opt/capella/capella-in-xvfb.sh

--- a/ci-templates/gitlab/filter-derive.yml
+++ b/ci-templates/gitlab/filter-derive.yml
@@ -2,66 +2,84 @@
 # SPDX-License-Identifier: Apache-2.0
 # yaml-language-server: $schema=https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/assets/javascripts/editor/schema/ci.json
 
-.derive:
-  rules:
-    - if: $CI_COMMIT_BRANCH
+derive:
+  image:
+    name: $DOCKER_REGISTRY/capella/cli:${CAPELLA_DOCKER_IMAGES_TAG}
+    entrypoint: [""]
 
-  script: &script-derive
-    - if [[ -n $DERIVE_RESULTS ]]; then mapfile -d ";" -t derive_results < <(echo -n "$DERIVE_RESULTS"); else derive_results=(); fi
+  script:
+    - |
+      if [[ -z "$MODEL_MODIFIER_EMAIL" ]]; then
+        echo '$MODEL_MODIFIER_EMAIL is required. Please set the environment variable.'
+        exit 1;
+      fi
+    - |
+      if [[ -z "$GIT_USERNAME" || -z "$GIT_PASSWORD" ]]; then
+        echo '$GIT_USERNAME and $GIT_PASSWORD are required. Please set the environment variables.'
+        exit 1;
+      fi
+
+    - |
+      if [[ -n $DERIVE_RESULTS ]]; then
+        mapfile -d ";" -t derive_results < <(echo -n "$DERIVE_RESULTS");
+      else
+        derive_results=();
+      fi
 
     # Reset branch. This is helpful when chaining jobs
     # and a previous job pushes changes that should be
     # considered for the model badge generation.
-    - git fetch
-    - git reset --hard origin/$CI_COMMIT_BRANCH
-
-    - pip install "capellambse[cli] @ git+https://github.com/DSD-DBS/py-capellambse.git@$CAPELLAMBSE_REVISION"
-
-    - python -m capellambse.extensions.filtering derive -m "${ENTRYPOINT:?}" -o derived-projects -p '{result.name}' "${derive_results[@]/#/--result=}" "$(if [[ -n $CAPELLA_DOCKERIMAGE ]]; then echo "--docker=$CAPELLA_DOCKERIMAGE"; else echo "--exe=$CAPELLA_EXECUTABLE"; fi)"
+    - |
+      if [[ -n $CI_COMMIT_BRANCH ]]; then
+        git fetch;
+        git reset --hard origin/$CI_COMMIT_BRANCH;
+      fi
+    - pip install "capellambse[cli] @ git+https://github.com/DSD-DBS/py-capellambse.git@${CAPELLAMBSE_REVISION:-release-0.5}"
+    - export DISPLAY=:99
+    - |
+      xvfb-run python \
+        -m capellambse.extensions.filtering derive \
+        -m "${ENTRYPOINT:?}" \
+        -o derived-projects \
+        -p '{result.name}' \
+        "${derive_results[@]/#/--result=}" \
+        --exe="/opt/capella/capella"
+    - |
+      git config --global user.email "${MODEL_MODIFIER_EMAIL:?}";
+      git config --global user.name "Filtering model modifier";
+      mkdir -p .git/info && echo "derived-projects/" > .git/info/exclude
+      if [[ "${PUSH_DERIVED_MODELS:-1}" == "1" ]]; then
+        for result in derived-projects/*; do
+          RESULT_DIR_NAME="${result#derived-projects/}"
+          DERIVED_BRANCH_NAME="$(echo "derived/$RESULT_DIR_NAME" | sed 's/[^a-zA-Z0-9.-_]/-/g')";
+          git switch "$DERIVED_BRANCH_NAME" || git switch --orphan "$DERIVED_BRANCH_NAME";
+          cp -r "$result/." .
+          git add .
+          git commit -m "feat: Add/update derived model '$RESULT_DIR_NAME'"
+          git push "https://${GIT_USERNAME:?}:${GIT_PASSWORD:?}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git" "$DERIVED_BRANCH_NAME"
+        done
+      fi
 
   artifacts:
     paths:
       - "derived-projects"
 
   variables:
-    # The path to the model's entrypoint, i.e. the main AIRD file,
-    # relative to the repository root.
-    # Mandatory.
-    #ENTRYPOINT: ""
-
-    # Path to the 'capella' executable. May contain a '{VERSION}' placeholder,
-    # which is replaced by the model's Capella version (e.g. '6.0.0').
-    # The default assumes that Capella is installed into /opt/capella, and
-    # has the correct version for this model.
-    CAPELLA_EXECUTABLE: /opt/capella/capella
-    # Alternatively, set this to the name of a Docker image whose entrypoint is
-    # the Capella binary. CAPELLA_EXECUTABLE will be ignored.
-    #CAPELLA_DOCKERIMAGE: ""
-
     # Limit the derivation to the listed results.
     # A semicolon separated list of result names and/or their UUIDs.
     # Default: Empty, which means derive all results in the model.
     DERIVE_RESULTS: ""
 
-    # Request a specific capellambse version to be installed.
-    # Mandatory.
-    #CAPELLAMBSE_REVISION: ""
+variables:
+  # This is a workaround to set a default value until the following epic is implemented:
+  # https://gitlab.com/groups/gitlab-org/-/epics/7437
+  # Variables defined outside of jobs (globally) have a low precedence, so it's easy to overwrite it.
+  # When the image is overwritten, the variable is ignored.
+  # Otherwise, we recommend to set it to a specific tag.
+  # See the available list of tags here: https://github.com/DSD-DBS/capella-dockerimages/releases
+  CAPELLA_DOCKER_IMAGES_REVISION: main
 
-
-.derive-and-generate-diagrams:
-  extends: .derive
-  script:
-    - *script-derive
-    - for result in derived-project/*; do ( cd "$result" || exit; python -m capellambse.diagram_cache -m "${result##*/}.aird" -o "../../diagram_cache/${result##*/}" -f "$DIAGRAM_FORMAT" "$(if [[ -n $CAPELLA_DOCKERIMAGE ]]; then echo "--docker=$CAPELLA_DOCKERIMAGE"; else echo "--exe=$CAPELLA_EXECUTABLE"; fi)"); done
-
-  artifacts:
-    paths:
-      - "diagram_cache"
-
-  variables:
-    # The same variables as above apply here as well.
-
-    # The format to export the diagrams in.
-    # Supported formats include "bmp", "gif", "jpg", "png", "svg".
-    # Defaults to svg.
-    DIAGRAM_FORMAT: svg
+  # Depending on the local environment, images can be tagged differently.
+  # In this case, we use the tag, which is also used by the predefined images:
+  # https://dsd-dbs.github.io/capella-dockerimages/capella/introduction/#tagging-schema-for-prebuilt-images
+  CAPELLA_DOCKER_IMAGES_TAG: ${CAPELLA_VERSION}-selected-dropins-${CAPELLA_DOCKER_IMAGES_REVISION}

--- a/ci-templates/gitlab/model-badge.yml
+++ b/ci-templates/gitlab/model-badge.yml
@@ -25,7 +25,7 @@ generate-model-badge:
     - git add "$OUTPUT_FILE"
     - "if git diff --cached --exit-code &> /dev/null; then exit 0; fi"
     - 'git commit -m "$COMMIT_MSG"'
-    - git push -o ci.skip --set-upstream "https://${GIT_USERNAME:?}:${GIT_PASSWORD:?}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git" "HEAD:$CI_COMMIT_BRANCH"
+    - git push -o ci.skip "https://${GIT_USERNAME:?}:${GIT_PASSWORD:?}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git" "HEAD:$CI_COMMIT_BRANCH"
   artifacts:
     paths:
       - "$OUTPUT_FILE"


### PR DESCRIPTION
This PR modifies the Gitlab CI template of the filtering CLI feature. While it was previously deriving the projects and just storing them in a Gitlab artefacts, this change introduces a new option to push the derived projects to individual branches.

This opens a new range of possibilities and more flexibility. Users can define custom Gitlab CI pipelines for each branch / derived project. As this also includes the diagram cache, the previously added diagram cache job for derived models has been removed.

Please note: This is a breaking change. Given that the [filtering CLI](https://github.com/DSD-DBS/py-capellambse/pull/266) PR has only been merged recently, I don't expect a broad usage of the existing Gitlab CI template.