### PR TITLE
Fix access to MelodyModel through `.parent` chain

### DIFF
--- a/capellambse/model/__init__.py
+++ b/capellambse/model/__init__.py
@@ -54,6 +54,7 @@ XT_LIBRARY = "org.polarsys.capella.core.data.capellamodeller:Library"
 XT_SYSENG = "org.polarsys.capella.core.data.capellamodeller:SystemEngineering"
 
 
+@common.xtype_handler(None, XT_PROJECT, XT_LIBRARY)
 class MelodyModel:
     """Provides high-level access to a model.
 
@@ -277,6 +278,10 @@ class MelodyModel:
     def _model(self) -> MelodyModel:
         return self
 
+    @property
+    def parent(self) -> None:
+        raise AttributeError("The model root doesn't have a parent object")
+
     def save(self, **kw: t.Any) -> None:
         # pylint: disable=line-too-long
         """Save the model back to where it was loaded from.
@@ -334,7 +339,7 @@ class MelodyModel:
         """
         xtypes_: list[str] = []
         for i in xtypes:
-            if isinstance(i, type) and issubclass(i, common.GenericElement):
+            if isinstance(i, type):
                 xtypes_.append(common.build_xtype(i))
             elif ":" in i:
                 xtypes_.append(i)
@@ -567,8 +572,10 @@ class MelodyModel:
         )
 
     @classmethod
-    def from_model(cls, model: MelodyModel, element: t.Any) -> t.NoReturn:
-        raise TypeError("Cannot instantiate a model from another model")
+    def from_model(cls, model: MelodyModel, element: t.Any) -> MelodyModel:
+        if element is not model._element:
+            raise ValueError("'element' is not the model root")
+        return model
 
     @property
     def info(self) -> loader.ModelInfo:

--- a/capellambse/model/common/__init__.py
+++ b/capellambse/model/common/__init__.py
@@ -19,6 +19,7 @@ U = t.TypeVar("U")
 
 
 XTYPE_ANCHORS = {
+    "capellambse.model": "org.polarsys.capella.core.data.capellamodeller",
     "capellambse.model.crosslayer": "org.polarsys.capella.core.data",
     "capellambse.model.layers": "org.polarsys.capella.core.data",
 }

--- a/capellambse/model/common/__init__.py
+++ b/capellambse/model/common/__init__.py
@@ -45,13 +45,16 @@ These keys map to a further dictionary.  This second layer maps from the
 
 
 def build_xtype(class_: type[ModelObject]) -> str:
-    for anchor, package in XTYPE_ANCHORS.items():
-        if class_.__module__.startswith(anchor):
-            module = class_.__module__[len(anchor) :]
-            break
-    else:
-        package = ""  # https://github.com/PyCQA/pylint/issues/1175
+    anchor = package = ""
+    for a, p in XTYPE_ANCHORS.items():
+        if len(a) > len(anchor) and class_.__module__.startswith(a):
+            anchor = a
+            package = p
+
+    if not anchor:
         raise TypeError(f"Module is not an xtype anchor: {class_.__module__}")
+
+    module = class_.__module__[len(anchor) :]
     clsname = class_.__name__
     return f"{package}{module}:{clsname}"
 

--- a/capellambse/model/common/element.py
+++ b/capellambse/model/common/element.py
@@ -198,6 +198,8 @@ class GenericElement:
                         class_ = XTYPE_HANDLERS[None][xtype]
                     except KeyError:
                         pass
+            if class_ is not cls:
+                return class_.from_model(model, element)
         self = class_.__new__(class_)
         self._model = model
         self._element = element


### PR DESCRIPTION
Previously:

```python
>>> model
<capellambse.model.MelodyModel object at 0x7f627f6d1770>
>>> model.la.parent.parent
<Model element (org.polarsys.capella.core.data.capellamodeller:Project) 'Melody Model Test' (af2196ac-49d3-4063-885c-9fa29adc39a8)>
[...]
```

Now:

```python
>>> model
<capellambse.model.MelodyModel object at 0x7f627f6d1770>
>>> model.la.parent.parent
<capellambse.model.MelodyModel object at 0x7f627f6d1770>
```