### PR TITLE
Ensure "derived" branch pointers are up to date

### DIFF
--- a/ci-templates/gitlab/filter-derive.yml
+++ b/ci-templates/gitlab/filter-derive.yml
@@ -45,6 +45,7 @@ derive:
         "${derive_results[@]/#/--result=}" \
         --exe="/opt/capella/capella"
     - |
+      git fetch origin "+refs/heads/derived/*:refs/heads/derived/*"
       git config --global user.email "${MODEL_MODIFIER_EMAIL:?}";
       git config --global user.name "Filtering model modifier";
       mkdir -p .git/info && echo "derived-projects/" > .git/info/exclude


### PR DESCRIPTION
This fixes a weird issue that manifested in one of our pipelines. The Gitlab runner had a stale branch pointer still lying around from ... somewhere, which had fallen behind the upstream branch tip; this caused the push to be rejected because it was non fast-forward.

This PR fixes the issue by specifically fetching all "derived/*" branches directly into the local branches namespace. This ensures that we have up-to-date branch pointers for all branches that are already known upstream.