### PR TITLE
Diagram cache CLI usability improvements

### DIFF
--- a/capellambse/diagram_cache.py
+++ b/capellambse/diagram_cache.py
@@ -71,13 +71,11 @@ else:
             _diagram_cache.export(
                 docker, model_, format=format, index=index, force="docker"
             )
-        elif exe:
+        else:
+            exe = exe or "capella{VERSION}"
             _diagram_cache.export(
                 exe, model_, format=format, index=index, force="exe"
             )
-        else:
-            click.echo("Error: Missing --exe or --docker option", err=True)
-            raise SystemExit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR makes some improvements to the built-in diagram caching functionality:

- The generated `index.json` now contains new `viewpoint` and `type` keys for each diagram.
- The `index.html` was restyled. Diagrams are now grouped by viewpoint and prefixed with the diagram type.
- The CLI will try to use executables named like `capella5.2.0` or `capella6.0.0` by default if no means of running native Capella was specified.

The added keys in the JSON index might be interesting for the [DSD-DBS/capella-collab-manager](https://github.com/DSD-DBS/capella-collab-manager) team, and could be a nice addition to display somewhere (and allow filtering for) in the diagram UI. @MoritzWeber0 what are your thoughts? Do you think you can work with this? Particularly, would it make more sense to have the short type code or the long type name in the JSON, or both? (You could also look them up in `capellambse.model.modeltypes.DiagramType`.)

Screenshot of the new HTML index:

![image](https://github.com/DSD-DBS/py-capellambse/assets/1579756/cf77a3c5-0c1b-4802-a5c0-2c3c1756a77b)