### PR TITLE
Make `diagram.nodes` faster

### DIFF
--- a/capellambse/model/diagram.py
+++ b/capellambse/model/diagram.py
@@ -417,6 +417,15 @@ class Diagram(AbstractDiagram):
         return self._model is other._model and self._element == other._element
 
     @property
+    def nodes(self) -> c.MixedElementList:
+        diagram_elements = list(
+            aird.iter_visible(self._model._loader, self._element)
+        )
+        return c.MixedElementList(
+            self._model, diagram_elements, c.GenericElement
+        )
+
+    @property
     def _allow_render(self) -> bool:
         return self._model._fallback_render_aird
 

--- a/tests/test_aird_parser.py
+++ b/tests/test_aird_parser.py
@@ -92,3 +92,53 @@ def test_airdparser_msm_produces_valid_json_without_error(
 
     generated_json = diagram.DiagramJSONEncoder(indent=4).encode(parsed)
     json.loads(generated_json)
+
+
+@pytest.mark.parametrize(
+    ["diag_uid", "num_nodes"],
+    [
+        ("_7FWu4KrxEeqOgqWuHJrXFA", 34),
+        ("_KK2wcKyJEeqCdMaqCWkrKg", 14),
+        ("_beibwNYrEeqiU8uzTY0Puw", 11),
+        ("_9inmIKgWEeujco-rU7ZOtA", 1),
+        ("_Go81cDaWEey5m4gkio8hew", 2),
+        ("_-NRNIF2mEey8erljvkS-pQ", 13),
+        ("_KZOz4GA9Eey8erljvkS-pQ", 15),
+        ("_joc_sGDdEey8erljvkS-pQ", 5),
+        ("_bpsckGDhEey8erljvkS-pQ", 4),
+        ("_OAg8QHPIEeyW3OIB4qRWZA", 18),
+        ("_RSWgcHPIEeyW3OIB4qRWZA", 8),
+        ("_bNLx4HPIEeyW3OIB4qRWZA", 6),
+        ("_sB8k8Mn-EeyS2Zr7ZWFrXA", 7),
+        ("_1adB8GpbEe2Scdb2k-Fvhg", 17),
+        ("_fqzi8BKnEeuBCogvtwwNBw", 42),
+        ("_ervhAFIqEeyiRNlyKPJwqw", 44),
+        ("_8BMtsIQzEeyxv9w6U6_UQg", 6),
+        ("_al3zwKg0EeujRPrkuugYGw", 5),
+        ("_1sCb8OSREeulYvEGRaHazg", 5),
+        ("_APMboAPhEeynfbzU12yy7w", 11),
+        ("_K9160IKBEeyd4IW8P6K-AQ", 14),
+        ("_0g-esB4cEe2Jgqeci1tAhA", 1),
+        ("_hIt8QKWXEeqh-bahrg4jkA", 18),
+        ("_u8lIgLB-EeqP7JXhmLvOsg", 26),
+        ("_2SjcgAL8EeuogvvqBpYPnQ", 6),
+        ("_KTxZ8KJwEeusg-blS2y7tg", 18),
+        ("_ZNrYAKJxEeusg-blS2y7tg", 21),
+        ("_mKI_kKZwEeuRO5WMG4dh5w", 2),
+        ("_MDoM4AWrEeyIAukYgdUX5A", 11),
+        ("_VKPRsIQTEeyxv9w6U6_UQg", 26),
+        ("_dpUi4LB8EeqLtsTDMgEHBw", 48),
+        ("_gRewkLB_EeqLtsTDMgEHBw", 11),
+        ("__dDrANZLEeqiU8uzTY0Puw", 14),
+        ("_jGNGMOCUEeu-FsE4WGMncQ", 4),
+        ("_Ne8zEAATEeykFulkDFvkrg", 7),
+        ("_I0nugeQUEe2jpIKbeHI0hw", 14),
+    ],
+)
+def test_iter_visible(model, diag_uid, num_nodes):
+    diag = model.diagrams.by_uuid(diag_uid)
+    diagram_elements = sum(
+        1 for _ in aird.iter_visible(model._loader, diag._element)
+    )
+
+    assert diagram_elements == num_nodes


### PR DESCRIPTION
This commit adds `yield_diagram_elements` which is then used in the `nodes` property of `AbstractDiagram`. This function doesn't build the whole diagram and all elements as aird objects (Box, Edge, ...). Instead it just collects the targets and finds the referenced semantic elements. This saves a lot of time when requesting `nodes`.