### PR TITLE
Move lockfile into $GITDIR

### DIFF
--- a/capellambse/filehandler/git.py
+++ b/capellambse/filehandler/git.py
@@ -677,7 +677,10 @@ class GitFileHandler(FileHandler):
         if isinstance(path, pathlib.WindowsPath):
             path = pathlib.Path(str(path)[1:])
         assert path.is_absolute()
-        self.__repo = self.cache_dir = path.resolve()
+        self.cache_dir = path.resolve()
+        gitdir = self.__git_nolock("rev-parse", "--git-dir", encoding="utf-8")
+        assert isinstance(gitdir, str)
+        self.__repo = pathlib.Path(self.cache_dir, gitdir.strip()).resolve()
 
     def __init_cache_dir_remote(self) -> None:
         slug_pattern = '[\x00-\x1f\x7f"*/:<>?\\|]+'
@@ -755,7 +758,6 @@ class GitFileHandler(FileHandler):
         except:
             os.rmdir(worktree)
             raise
-        self.__repo = self.cache_dir
         self.cache_dir = worktree
 
         self.__fnz = weakref.finalize(  # pylint: disable=unused-private-member

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -56,6 +56,7 @@ def test_model_loading_via_GitFileHandler():
     capellambse.MelodyModel(
         path, entrypoint="tests/data/melodymodel/5_0/Melody Model Test.aird"
     )
+    assert not pathlib.Path.cwd().joinpath("capellambse.lock").exists()
 
 
 def test_GitFileHandler_locks_repo_during_tasks(monkeypatch, caplog):


### PR DESCRIPTION
For local git repos, the locking mechanism would put the `capellambse.lock` file into the root of the worktree. This was annoying, as that file had to be explicitly gitignore'd or it would show up in diffs and `git status`.

This commit changes `self.__repo` to point to the $GITDIR instead of the main worktree root, thereby moving the lockfile there. This more closely mirrors the behavior of remote git repos, which don't have a main worktree and therefore also have `__repo` point to the $GITDIR.