### PR TITLE
Add newline to model badge svg

### DIFF
--- a/capellambse/extensions/metrics/composer.py
+++ b/capellambse/extensions/metrics/composer.py
@@ -174,5 +174,5 @@ def draw_summary_badge(
     return (
         '<svg xmlns="http://www.w3.org/2000/svg"'
         f' width="{scale*134}" height="{scale*30}" viewBox="0 0 134 30">'
-        f"{text}</svg>"
+        f"{text}</svg>\n"
     )


### PR DESCRIPTION
This PR adds a newline at the end of the model badge svg. 

(Helping e.g. to not have failing pre-commit hooks that are checking for a last empty line in files or to have a new line when printing in the console)