### PR TITLE
Autodetect the `entrypoint` when loading models

### DIFF
--- a/capellambse/aird/_box_factories.py
+++ b/capellambse/aird/_box_factories.py
@@ -144,7 +144,7 @@ def generic_stacked_factory(seb: C.SemanticElementBuilder) -> C.StackingBox:
 def class_factory(seb: C.SemanticElementBuilder) -> diagram.Box:
     """Create a Class.
 
-    Classes contain multiple `Property` sub-elements.  These aren't
+    Classes contain multiple `Property` sub-elements. These aren't
     actual boxes, but should instead be shown as part of the Class'
     regular label text.
     """
@@ -230,7 +230,7 @@ def component_port_factory(seb: C.SemanticElementBuilder) -> diagram.Box:
 def constraint_factory(seb: C.SemanticElementBuilder) -> diagram.Box:
     """Create the box for a Constraint.
 
-    Constraints are comprised of two parts: A Box and some Edges.  The
+    Constraints are comprised of two parts: A Box and some Edges. The
     Box' label must be extracted from the semantic object, because it
     isn't always easily accessible for the ``generic_factory``.
 
@@ -373,7 +373,7 @@ def statemode_factory(seb: C.SemanticElementBuilder) -> diagram.Box:
     """Create a State or Mode.
 
     Unlike other elements, these have their immediate children rendered
-    as stacked boxes.  The child boxes themselves can in turn have more
+    as stacked boxes. The child boxes themselves can in turn have more
     children either in floating or stacked form.
 
     Additionally, States and Modes can have associated activities. These
@@ -442,8 +442,8 @@ def fcif_factory(seb: C.SemanticElementBuilder) -> diagram.Box:
     """Create a FunctionalChainInvolvementFunction.
 
     These are special boxes that point to another element via their
-    ``involved`` attribute.  As there's no relevant information stored
-    in the original target attribute, we can simply use the "involved"
+    ``involved`` attribute. As there's no relevant information stored in
+    the original target attribute, we can simply use the "involved"
     element for constructing the actual box.
     """
     seb.melodyobjs[0] = seb.melodyloader.follow_link(

--- a/capellambse/aird/_edge_factories.py
+++ b/capellambse/aird/_edge_factories.py
@@ -497,7 +497,7 @@ def sequence_link_factory(seb: C.SemanticElementBuilder) -> diagram.Edge:
     """Create a SequenceLink.
 
     Sequence links (in Operational Process Diagrams) use the guard
-    condition as label, if it is set.  Otherwise the label stays empty.
+    condition as label, if it is set. Otherwise the label stays empty.
     """
     edge = generic_factory(seb)
     guard = _guard_condition(seb, "condition")

--- a/capellambse/aird/_filters/__init__.py
+++ b/capellambse/aird/_filters/__init__.py
@@ -43,8 +43,8 @@ def composite_filter(
 ) -> cabc.Callable[[CompositeFilter], CompositeFilter]:
     """Register a composite filter.
 
-    Composite filters are executed in two phases.  The first phase
-    occurs during each diagram element's creation.  Here the callables
+    Composite filters are executed in two phases. The first phase occurs
+    during each diagram element's creation. Here the callables
     registered with this decorator are directly executed with the
     diagram under construction and the to-be-filtered element as
     arguments.
@@ -54,7 +54,7 @@ def composite_filter(
     callable object during the first phase; this object will then be
     called with the same (now constructed) diagram and the element.
 
-    Composite filters should always operate in place.  They may append
+    Composite filters should always operate in place. They may append
     additional elements to the diagram, but they should never remove
     any; instead they should simply change their "hidden" flag to True.
     """
@@ -112,7 +112,7 @@ def setfilters(
     Returns
     -------
     dgobject
-        The modified ``dgobject``.  This is done for convenience; the
+        The modified ``dgobject``. This is done for convenience; the
         object is modified in place.
 
     See Also
@@ -153,7 +153,7 @@ def applyfilters(args: FilterArguments) -> None:
     Firstly it executes phase 2 of all elements' composite filters; see
     :func:`composite_filter` for more details.
 
-    Secondly it applies the diagram's global filters.  These are always
+    Secondly it applies the diagram's global filters. These are always
     applied after all composite filters have run.
     """
     # Apply post-processing filters on elements

--- a/capellambse/aird/_filters/composite.py
+++ b/capellambse/aird/_filters/composite.py
@@ -37,8 +37,8 @@ def hide_empty_ports(
     """Hide child ports without context.
 
     This filter utilizes the fact that boxes track all connected edges
-    as their "context".  As ports do not have children, their context
-    can only be the edge(s) that connect directly to them.
+    as their "context". As ports do not have children, their context can
+    only be the edge(s) that connect directly to them.
     """
     del ebd
     assert isinstance(dgobject, diagram.Box)

--- a/capellambse/aird/_semantic.py
+++ b/capellambse/aird/_semantic.py
@@ -3,7 +3,7 @@
 """Parser entry point for semantic elements.
 
 Semantic elements have a ``<target>`` which references the represented
-object in the ``.melodymodeller`` or ``.melodyfragment`` file.  The
+object in the ``.melodymodeller`` or ``.melodyfragment`` file. The
 melody file is the source of truth for all attributes that are not
 specific to a single diagram, i.e. basically everything except position,
 size and styling.

--- a/capellambse/aird/_visual.py
+++ b/capellambse/aird/_visual.py
@@ -3,7 +3,7 @@
 """Parser entry point for visual elements.
 
 Visual elements, contrary to semantic ones, do not exist in the melody
-files at all.  They are used for things such as Notes and inter-diagram
+files at all. They are used for things such as Notes and inter-diagram
 hyperlinks.
 """
 from __future__ import annotations
@@ -118,7 +118,7 @@ VISUAL_TYPES: dict[
 ] = {
     "BasicDecorationNode": c.SkipObject.raise_,
     "Connector": connector_factory,
-    # Nodes are actually semantic elements.  If one got through to here,
+    # Nodes are actually semantic elements. If one got through to here,
     # it's an internal node, not an element root.
     "Node": c.SkipObject.raise_,
     "Shape": shape_factory,

--- a/capellambse/diagram/_diagram.py
+++ b/capellambse/diagram/_diagram.py
@@ -82,7 +82,7 @@ class Box:
         pos
             A Vector2D describing the spatial position.
         size
-            A Vector2D describing the box' size.  If one or both of its
+            A Vector2D describing the box' size. If one or both of its
             components are 0, it/they will be calculated based on the
             Box' label text and contained children.
         label
@@ -92,19 +92,19 @@ class Box:
         parent
             This box' parent box.
         collapsed
-            Collapse this box and hide all its children.  Note that
+            Collapse this box and hide all its children. Note that
             setting this flag does not change the box' size.
         minsize
             When dynamically calculating Box size, the minimum size it
-            should have.  Default: zero.
+            should have. Default: zero.
         maxsize
             When dynamically calculating Box size, the maximum size it
-            can have.  Default: inifite.
+            can have. Default: infinite.
         context
-            A list of UUIDs of objects in this box' context.  This
+            A list of UUIDs of objects in this box' context. This
             includes children and associated edges.
         port
-            Flag this box as a port.  Affects how context is added.
+            Flag this box as a port. Affects how context is added.
         features
             Certain classes of Box (like ``Class``) have features, which
             is a list of strings that will be displayed inside the Box,
@@ -359,7 +359,7 @@ class Box:
         offset
             The offset to move the box by.
         children
-            Recursively move children as well.  If False, the positions
+            Recursively move children as well. If False, the positions
             of children need to be adjusted separately.
         """
         self.pos += offset
@@ -533,7 +533,7 @@ class Edge(diagram.Vec2List):
     """An edge in the diagram.
 
     An Edge consists of a series of points that are traversed in order.
-    Each point is given as Vector2D containing absolute coordinates.  At
+    Each point is given as Vector2D containing absolute coordinates. At
     least two points are required.
     """
 

--- a/capellambse/diagram/capstyle.py
+++ b/capellambse/diagram/capstyle.py
@@ -17,8 +17,8 @@ class RGB(t.NamedTuple):
     """A color.
 
     Each color component (red, green, blue) is an integer in the range
-    of 0..255 (inclusive).  The alpha channel is a float between 0.0 and
-    1.0 (inclusive).  If it is 1, then the ``str()`` form does not
+    of 0..255 (inclusive). The alpha channel is a float between 0.0 and
+    1.0 (inclusive). If it is 1, then the ``str()`` form does not
     include transparency information.
     """
 
@@ -80,7 +80,7 @@ class RGB(t.NamedTuple):
     def fromhex(cls, hexstring: str) -> RGB:
         """Create an RGB from a hexadecimal string.
 
-        The string can have 3, 4, 6 or 8 hexadecimal characters.  In the
+        The string can have 3, 4, 6 or 8 hexadecimal characters. In the
         cases of 3 and 6 characters, the alpha channel is set to 1.0
         (fully opaque) and the remaining characters are interpreted as
         the red, green and blue components.
@@ -138,7 +138,7 @@ def get_style(diagramclass: str | None, objectclass: str) -> dict[str, t.Any]:
 
             Type.StyleClass
 
-        The type can be: ``Box``, ``Edge``.  The style class can be any
+        The type can be: ``Box``, ``Edge``. The style class can be any
         known style class.
     """
     if "symbol" in objectclass.lower():
@@ -241,11 +241,11 @@ COLORS: dict[str, RGB] = {
 #: This dict contains the default styles that Capella applies, grouped
 #: by the diagram class they belong to.
 #:
-#: The first level of keys are the diagrams' styleclasses.  The special
+#: The first level of keys are the diagrams' styleclasses. The special
 #: key "__GLOBAL__" applies to all diagrams.
 #:
 #: The second level contains the style definitions for each element that
-#: can appear in the diagram.  The keys work in the following way:
+#: can appear in the diagram. The keys work in the following way:
 #:
 #:     Type.Class
 #:

--- a/capellambse/filehandler/__init__.py
+++ b/capellambse/filehandler/__init__.py
@@ -9,18 +9,14 @@ __all__ = [
     "get_filehandler",
 ]
 
-import abc
-import collections.abc as cabc
 import logging
 import os
-import pathlib
 import re
 import sys
 import typing as t
 from importlib import metadata
 
-if t.TYPE_CHECKING:
-    from capellambse.loader.modelinfo import ModelInfo
+from .abc import *
 
 LOGGER = logging.getLogger(__name__)
 
@@ -83,136 +79,3 @@ def get_filehandler(path: str | os.PathLike, **kwargs: t.Any) -> FileHandler:
     handler_name, path = split_protocol(path)
     handler = load_entrypoint(handler_name)
     return handler(path, **kwargs)
-
-
-class FileHandler(metaclass=abc.ABCMeta):
-    """Abstract super class for file handler implementations.
-
-    Parameters
-    ----------
-    path
-        The location of the remote. The exact accepted forms are
-        determined by the specific file handler implementation, for
-        example the ``LocalFileHandler`` accepts only local paths, and
-        the ``GitFileHandler`` accepts everything that Git accepts.
-    subdir
-        Consider all paths relative to this subdirectory, instead of the
-        root of the file handler's hierarchy.
-    """
-
-    path: str | os.PathLike
-
-    def __init__(
-        self,
-        path: str | os.PathLike,
-        *,
-        subdir: str | pathlib.PurePosixPath = "/",
-        **kw: t.Any,
-    ) -> None:
-        super().__init__(**kw)
-        self.path = path
-        self.subdir = subdir
-
-    @abc.abstractmethod
-    def get_model_info(self) -> ModelInfo:
-        pass
-
-    @abc.abstractmethod
-    def open(
-        self,
-        filename: str | pathlib.PurePosixPath,
-        mode: t.Literal["r", "rb", "w", "wb"] = "rb",
-    ) -> t.BinaryIO:
-        """Open the model file for reading or writing.
-
-        A "file" in this context does not necessarily refer to a
-        physical file on disk; it may just as well be streamed in via
-        network or other means. Due to this, the file-like returned by
-        this method is not required to support random access.
-
-        Parameters
-        ----------
-        filename
-            The name of the file, relative to the ``path`` that was
-            given to the constructor.
-        mode
-            The mode to open the file in. Either ``"r"`` or ``"rb"`` for
-            reading, or ``"w"`` or ``"wb"`` for writing a new file. Be
-            aware that this method may refuse to open a file for writing
-            unless a transaction was started with
-            :meth:`write_transaction()` first.
-        """
-
-    def write_transaction(
-        self, **kw: t.Any
-    ) -> t.ContextManager[cabc.Mapping[str, t.Any]]:
-        """Start a transaction for writing new model files.
-
-        During a transaction, writable objects returned by
-        :meth:`open()` buffer their contents in a temporary location,
-        and once the transaction ends, all updated files are committed
-        to their destinations at once. If the transaction is aborted,
-        for example because an exception was raised, then all changes
-        must be rolled back to the state immediately before the
-        transaction. If, during a transaction, any relevant file is
-        touched without the file handler knowing about it, the behavior
-        is undefined.
-
-        Note that :meth:`open()` may refuse to open a file as writable
-        if no transaction is currently open. This depends on the needs
-        of the underlying abstract file system.
-
-        Transaction arguments
-        ---------------------
-        A concrete file handler implementation may accept arbitrary
-        additional arguments to this method. The implementation should
-        however always support the case of no arguments given, in which
-        case it should start a transaction with sensible defaults, and
-        it should also accept and ignore any arguments it does not
-        understand. All additional arguments must be passed in via
-        keywords. Positional arguments are not supported.
-
-        The return value of the context manager's ``__enter__()`` method
-        is expected to be a mapping of all the keyword arguments that
-        were not understood. Client code may use this to react properly
-        (e.g. by aborting the transaction early) if a required keyword
-        argument is found to be not supported by the underlying file
-        handler. If a subclass wishes to call its super class'
-        ``write_transaction()`` method, it should remove all the keyword
-        arguments that it handles itself and pass on the others
-        unchanged.
-
-        Well-known arguments
-        --------------------
-        The following arguments are considered well-known, and their
-        meaning is expected to be the same for all file handlers that
-        support them.
-
-        -   ``dry_run`` (``bool``): If set to ``True``, changes made
-            during the transaction should be rolled back instead of
-            being committed, just as if an exception had been raised.
-        -   ``author_name`` (``str``): The name of the author of the
-            changes.
-        -   ``author_email`` (``str``): The e-mail address to record
-            alongside the ``author_name``.
-        -   ``commit_msg`` (``str``): A message describing the changes,
-            which will be recorded in the version control system.
-        -   ``remote_branch`` (``str``): If the model came from a remote
-            version control system, changes are normally pushed back to
-            the same branch on that remote. This argument specifies an
-            alternative branch name to push to (which may not yet exist
-            on the remote).
-        """
-
-        class EmptyTransaction:
-            def __enter__(self):
-                return kw
-
-            def __exit__(self, *_):
-                pass
-
-        return EmptyTransaction()
-
-
-class TransactionClosedError(RuntimeError):
-    """Raised when a transaction must be opened first to write files."""

--- a/capellambse/filehandler/__init__.py
+++ b/capellambse/filehandler/__init__.py
@@ -127,7 +127,7 @@ class FileHandler(metaclass=abc.ABCMeta):
 
         A "file" in this context does not necessarily refer to a
         physical file on disk; it may just as well be streamed in via
-        network or other means.  Due to this, the file-like returned by
+        network or other means. Due to this, the file-like returned by
         this method is not required to support random access.
 
         Parameters
@@ -136,10 +136,10 @@ class FileHandler(metaclass=abc.ABCMeta):
             The name of the file, relative to the ``path`` that was
             given to the constructor.
         mode
-            The mode to open the file in.  Either ``"r"`` or ``"rb"``
-            for reading, or ``"w"`` or ``"wb"`` for writing a new file.
-            Be aware that this method may refuse to open a file for
-            writing unless a transaction was started with
+            The mode to open the file in. Either ``"r"`` or ``"rb"`` for
+            reading, or ``"w"`` or ``"wb"`` for writing a new file. Be
+            aware that this method may refuse to open a file for writing
+            unless a transaction was started with
             :meth:`write_transaction()` first.
         """
 
@@ -151,33 +151,33 @@ class FileHandler(metaclass=abc.ABCMeta):
         During a transaction, writable objects returned by
         :meth:`open()` buffer their contents in a temporary location,
         and once the transaction ends, all updated files are committed
-        to their destinations at once.  If the transaction is aborted,
+        to their destinations at once. If the transaction is aborted,
         for example because an exception was raised, then all changes
         must be rolled back to the state immediately before the
-        transaction.  If, during a transaction, any relevant file is
+        transaction. If, during a transaction, any relevant file is
         touched without the file handler knowing about it, the behavior
         is undefined.
 
         Note that :meth:`open()` may refuse to open a file as writable
-        if no transaction is currently open.  This depends on the needs
+        if no transaction is currently open. This depends on the needs
         of the underlying abstract file system.
 
         Transaction arguments
         ---------------------
         A concrete file handler implementation may accept arbitrary
-        additional arguments to this method.  The implementation should
+        additional arguments to this method. The implementation should
         however always support the case of no arguments given, in which
         case it should start a transaction with sensible defaults, and
         it should also accept and ignore any arguments it does not
-        understand.  All additional arguments must be passed in via
-        keywords.  Positional arguments are not supported.
+        understand. All additional arguments must be passed in via
+        keywords. Positional arguments are not supported.
 
         The return value of the context manager's ``__enter__()`` method
         is expected to be a mapping of all the keyword arguments that
-        were not understood.  Client code may use this to react properly
+        were not understood. Client code may use this to react properly
         (e.g. by aborting the transaction early) if a required keyword
         argument is found to be not supported by the underlying file
-        handler.  If a subclass wishes to call its super class'
+        handler. If a subclass wishes to call its super class'
         ``write_transaction()`` method, it should remove all the keyword
         arguments that it handles itself and pass on the others
         unchanged.
@@ -199,7 +199,7 @@ class FileHandler(metaclass=abc.ABCMeta):
             which will be recorded in the version control system.
         -   ``remote_branch`` (``str``): If the model came from a remote
             version control system, changes are normally pushed back to
-            the same branch on that remote.  This argument specifies an
+            the same branch on that remote. This argument specifies an
             alternative branch name to push to (which may not yet exist
             on the remote).
         """

--- a/capellambse/filehandler/abc.py
+++ b/capellambse/filehandler/abc.py
@@ -79,6 +79,26 @@ class FileHandler(metaclass=abc.ABCMeta):
             :meth:`write_transaction()` first.
         """
 
+    def write_file(
+        self, path: str | pathlib.PurePosixPath, content: bytes, /
+    ) -> None:
+        """Write a file.
+
+        This method is a convenience wrapper around
+        :meth:`open()`.
+        """
+        with self.open(path, "wb") as f:
+            f.write(content)
+
+    def read_file(self, path: str | pathlib.PurePosixPath, /) -> bytes:
+        """Read a file.
+
+        This method is a convenience wrapper around
+        :meth:`open()`.
+        """
+        with self.open(path, "rb") as f:
+            return f.read()
+
     def write_transaction(
         self, **kw: t.Any
     ) -> t.ContextManager[cabc.Mapping[str, t.Any]]:

--- a/capellambse/filehandler/abc.py
+++ b/capellambse/filehandler/abc.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
+# SPDX-License-Identifier: Apache-2.0
+"""The abstract FileHandler superclass and utilities."""
+from __future__ import annotations
+
+__all__ = [
+    "FileHandler",
+    "TransactionClosedError",
+]
+
+import abc
+import collections.abc as cabc
+import os
+import pathlib
+import typing as t
+
+if t.TYPE_CHECKING:
+    from capellambse.loader import modelinfo
+
+
+_F = t.TypeVar("_F", bound="FileHandler")
+
+
+class FileHandler(metaclass=abc.ABCMeta):
+    """Abstract super class for file handler implementations.
+
+    Parameters
+    ----------
+    path
+        The location of the remote. The exact accepted forms are
+        determined by the specific file handler implementation, for
+        example the ``LocalFileHandler`` accepts only local paths, and
+        the ``GitFileHandler`` accepts everything that Git accepts.
+    subdir
+        Consider all paths relative to this subdirectory, instead of the
+        root of the file handler's hierarchy.
+    """
+
+    path: str | os.PathLike
+
+    def __init__(
+        self,
+        path: str | os.PathLike,
+        *,
+        subdir: str | pathlib.PurePosixPath = "/",
+        **kw: t.Any,
+    ) -> None:
+        super().__init__(**kw)
+        self.path = path
+        self.subdir = subdir
+
+    @abc.abstractmethod
+    def get_model_info(self) -> modelinfo.ModelInfo:
+        pass
+
+    @abc.abstractmethod
+    def open(
+        self,
+        filename: str | pathlib.PurePosixPath,
+        mode: t.Literal["r", "rb", "w", "wb"] = "rb",
+    ) -> t.BinaryIO:
+        """Open the model file for reading or writing.
+
+        A "file" in this context does not necessarily refer to a
+        physical file on disk; it may just as well be streamed in via
+        network or other means. Due to this, the file-like returned by
+        this method is not required to support random access.
+
+        Parameters
+        ----------
+        filename
+            The name of the file, relative to the ``path`` that was
+            given to the constructor.
+        mode
+            The mode to open the file in. Either ``"r"`` or ``"rb"`` for
+            reading, or ``"w"`` or ``"wb"`` for writing a new file. Be
+            aware that this method may refuse to open a file for writing
+            unless a transaction was started with
+            :meth:`write_transaction()` first.
+        """
+
+    def write_transaction(
+        self, **kw: t.Any
+    ) -> t.ContextManager[cabc.Mapping[str, t.Any]]:
+        """Start a transaction for writing new model files.
+
+        During a transaction, writable objects returned by
+        :meth:`open()` buffer their contents in a temporary location,
+        and once the transaction ends, all updated files are committed
+        to their destinations at once. If the transaction is aborted,
+        for example because an exception was raised, then all changes
+        must be rolled back to the state immediately before the
+        transaction. If, during a transaction, any relevant file is
+        touched without the file handler knowing about it, the behavior
+        is undefined.
+
+        Note that :meth:`open()` may refuse to open a file as writable
+        if no transaction is currently open. This depends on the needs
+        of the underlying abstract file system.
+
+        Transaction arguments
+        ---------------------
+        A concrete file handler implementation may accept arbitrary
+        additional arguments to this method. The implementation should
+        however always support the case of no arguments given, in which
+        case it should start a transaction with sensible defaults, and
+        it should also accept and ignore any arguments it does not
+        understand. All additional arguments must be passed in via
+        keywords. Positional arguments are not supported.
+
+        The return value of the context manager's ``__enter__()`` method
+        is expected to be a mapping of all the keyword arguments that
+        were not understood. Client code may use this to react properly
+        (e.g. by aborting the transaction early) if a required keyword
+        argument is found to be not supported by the underlying file
+        handler. If a subclass wishes to call its super class'
+        ``write_transaction()`` method, it should remove all the keyword
+        arguments that it handles itself and pass on the others
+        unchanged.
+
+        Well-known arguments
+        --------------------
+        The following arguments are considered well-known, and their
+        meaning is expected to be the same for all file handlers that
+        support them.
+
+        -   ``dry_run`` (``bool``): If set to ``True``, changes made
+            during the transaction should be rolled back instead of
+            being committed, just as if an exception had been raised.
+        -   ``author_name`` (``str``): The name of the author of the
+            changes.
+        -   ``author_email`` (``str``): The e-mail address to record
+            alongside the ``author_name``.
+        -   ``commit_msg`` (``str``): A message describing the changes,
+            which will be recorded in the version control system.
+        -   ``remote_branch`` (``str``): If the model came from a remote
+            version control system, changes are normally pushed back to
+            the same branch on that remote. This argument specifies an
+            alternative branch name to push to (which may not yet exist
+            on the remote).
+        """
+
+        class EmptyTransaction:
+            def __enter__(self):
+                return kw
+
+            def __exit__(self, *_):
+                pass
+
+        return EmptyTransaction()
+
+
+class TransactionClosedError(RuntimeError):
+    """Raised when a transaction must be opened first to write files."""

--- a/capellambse/filehandler/git.py
+++ b/capellambse/filehandler/git.py
@@ -31,7 +31,7 @@ import weakref
 import capellambse.helpers
 from capellambse.loader import modelinfo
 
-from . import FileHandler, TransactionClosedError
+from . import abc
 
 LOGGER = logging.getLogger(__name__)
 
@@ -445,7 +445,7 @@ class _GitTransaction:
         return tree_hash
 
 
-class GitFileHandler(FileHandler):
+class GitFileHandler(abc.FileHandler):
     """File handler for ``git://`` and related protocols.
 
     Parameters
@@ -490,7 +490,7 @@ class GitFileHandler(FileHandler):
 
     See Also
     --------
-    capellambse.filehandler.FileHandler :
+    capellambse.filehandler.abc.FileHandler :
         Documentation of common parameters.
     """
 
@@ -556,7 +556,7 @@ class GitFileHandler(FileHandler):
         )
         if "w" in mode:
             if self._transaction is None:
-                raise TransactionClosedError(
+                raise abc.TransactionClosedError(
                     "Writing to git requires a transaction"
                 )
             return self.__open_writable(path)

--- a/capellambse/filehandler/git.py
+++ b/capellambse/filehandler/git.py
@@ -210,7 +210,7 @@ class _GitTransaction:
             or tag.
         remote_branch
             An alternative branch name to push to on the remote, instead
-            of pushing back to the same branch.  This is required if
+            of pushing back to the same branch. This is required if
             ``push`` is ``True`` and the ``revision`` that was passed to
             the constructor does not refer to a branch (or looks like a
             git object).
@@ -224,7 +224,7 @@ class _GitTransaction:
         push
             Set to ``False`` to inhibit pushing the changes back.
         push_options
-            Additional git push options.  See ``--push-option`` in
+            Additional git push options. See ``--push-option`` in
             ``git-push(1)``. Ignored if ``push`` is ``False``.
 
         Raises

--- a/capellambse/filehandler/gitlab_artifacts.py
+++ b/capellambse/filehandler/gitlab_artifacts.py
@@ -18,7 +18,7 @@ import requests
 
 from capellambse import helpers, loader
 
-from . import FileHandler
+from . import abc
 
 LOGGER = logging.getLogger(__name__)
 RE_LINK_NEXT = re.compile("<(http.*)>; rel=(?P<quote>[\"']?)next(?P=quote)")
@@ -27,7 +27,7 @@ MAX_SEARCHED_JOBS = (
 )
 
 
-class GitlabArtifactsFiles(FileHandler):
+class GitlabArtifactsFiles(abc.FileHandler):
     """Download files from Gitlab's artifacts hosting service.
 
     This file handler is roughly equivalent to an HTTPFileHandler with

--- a/capellambse/filehandler/http.py
+++ b/capellambse/filehandler/http.py
@@ -98,16 +98,16 @@ class HTTPFileHandler(FileHandler):
 
         This file handler supports three ways of specifying a URL:
 
-        1.  If a plain URL is passed, the requested file name is
-            appended after a forward slash ``/``.
-        2.  If the URL contains ``%s``, it will be replaced by the
-            requested file name, instead of appending it at the end.
-            This allows for example to pass query parameters after the
-            file name. File names are percent-escaped as implemented by
-            ``urllib.parse.quote``.
-        3.  The sequence ``%q`` is replaced similar to ``%s``, but the
-            forward slash ``/`` is not considered a safe character and
-            is percent-escaped as well.
+        1. If a plain URL is passed, the requested file name is appended
+           after a forward slash ``/``.
+        2. If the URL contains ``%s``, it will be replaced by the
+           requested file name, instead of appending it at the end. This
+           allows for example to pass query parameters after the file
+           name. File names are percent-escaped as implemented by
+           ``urllib.parse.quote``.
+        3. The sequence ``%q`` is replaced similar to ``%s``, but the
+           forward slash ``/`` is not considered a safe character and is
+           percent-escaped as well.
 
         Examples: When requesting the file name ``demo/my model.aird``,
         ...

--- a/capellambse/filehandler/http.py
+++ b/capellambse/filehandler/http.py
@@ -22,7 +22,7 @@ import requests
 
 from capellambse import helpers, loader
 
-from . import FileHandler
+from . import abc
 
 
 class DownloadStream(t.BinaryIO):
@@ -78,7 +78,7 @@ class DownloadStream(t.BinaryIO):
         del self.__buffer
 
 
-class HTTPFileHandler(FileHandler):
+class HTTPFileHandler(abc.FileHandler):
     """A remote file handler that fetches files using HTTP GET."""
 
     def __init__(

--- a/capellambse/filehandler/local.py
+++ b/capellambse/filehandler/local.py
@@ -13,12 +13,12 @@ import typing as t
 from capellambse import helpers
 from capellambse.loader.modelinfo import ModelInfo
 
-from . import FileHandler
+from . import abc
 
 LOGGER = logging.getLogger(__name__)
 
 
-class LocalFileHandler(FileHandler):
+class LocalFileHandler(abc.FileHandler):
     def __init__(
         self,
         path: str | os.PathLike,

--- a/capellambse/filehandler/memory.py
+++ b/capellambse/filehandler/memory.py
@@ -21,13 +21,13 @@ import typing as t
 
 from capellambse import helpers
 
-from . import FileHandler
+from . import abc
 
 if t.TYPE_CHECKING:
     from capellambse.loader.modelinfo import ModelInfo
 
 
-class MemoryFileHandler(FileHandler):
+class MemoryFileHandler(abc.FileHandler):
     """A file handler that stores data in memory."""
 
     def __init__(

--- a/capellambse/filehandler/memory.py
+++ b/capellambse/filehandler/memory.py
@@ -14,6 +14,7 @@ __all__ = [
     "MemoryFileHandler",
 ]
 
+import collections.abc as cabc
 import io
 import os
 import pathlib
@@ -78,6 +79,18 @@ class MemoryFileHandler(abc.FileHandler):
             f"{', '.join(map(str, self._data.keys()))}>"
         )
 
+    @property
+    def rootdir(self) -> MemoryFilePath:
+        return MemoryFilePath(self, pathlib.PurePosixPath("."))
+
+    def iterdir(
+        self, path: str | pathlib.PurePosixPath = "/", /
+    ) -> cabc.Iterator[MemoryFilePath]:
+        path = helpers.normalize_pure_path(path)
+        for p in self._data:
+            if p.parent == path:
+                yield MemoryFilePath(self, p)
+
 
 class MemoryFile(t.BinaryIO):
     def __init__(self, data: bytearray, mode: t.Literal["r", "w"]) -> None:
@@ -106,3 +119,11 @@ class MemoryFile(t.BinaryIO):
         result = self._data[self._pos : self._pos + n]
         self._pos += len(result)
         return bytes(result)
+
+
+class MemoryFilePath(abc.AbstractFilePath[MemoryFileHandler]):
+    def is_dir(self) -> bool:
+        return not self.is_file()
+
+    def is_file(self) -> bool:
+        return self._path in self._parent._data

--- a/capellambse/helpers.py
+++ b/capellambse/helpers.py
@@ -105,7 +105,7 @@ def normalize_pure_path(
         The input path to normalize.
     base
         The base directory to which relative paths should be
-        interpreted.  Ignored if the input path is not relative.
+        interpreted. Ignored if the input path is not relative.
 
     Returns
     -------
@@ -253,7 +253,7 @@ def ssvparse(
     cast
         A type to cast the values into.
     parens
-        The parentheses that must exist around the input.  Either a
+        The parentheses that must exist around the input. Either a
         two-character string or a 2-tuple of strings.
     sep
         The separator between values.
@@ -597,10 +597,10 @@ def xpath_fetch_unique(
     elm_name
         A human-readable element name for error messages.
     elm_uid
-        UID of the element which triggered this lookup.  Will be
-        included in the error message if an error occured.
+        UID of the element which triggered this lookup. Will be included
+        in the error message if an error occured.
     optional
-        True to return None in case the element is not found.  Otherwise
+        True to return None in case the element is not found. Otherwise
         a ValueError will be raised.
 
     Returns
@@ -710,7 +710,7 @@ def ntuples(
         An iterable.
     pad
         If the items in ``iterable`` are not evenly divisible by ``n``,
-        pad the last yielded tuple with ``None``\ s.  If False, the last
+        pad the last yielded tuple with ``None``\ s. If False, the last
         tuple will be discarded.
 
     Yields

--- a/capellambse/known_models/coffee-machine.json
+++ b/capellambse/known_models/coffee-machine.json
@@ -1,4 +1,3 @@
 {
-  "path": "git+https://gitlab.com/vik.works/capella-coffee-machine.git",
-  "entrypoint": "coffee-machine-demo.aird"
+  "path": "git+https://github.com/DSD-DBS/coffee-machine.git"
 }

--- a/capellambse/loader/__init__.py
+++ b/capellambse/loader/__init__.py
@@ -3,7 +3,7 @@
 """The MelodyLoader loads and provides access to a Capella model.
 
 It is using LXML internally to efficiently parse and navigate through
-the Capella-generated XML files.  For more information about LXML, see
+the Capella-generated XML files. For more information about LXML, see
 the `LXML Documentation`_.
 
 .. _LXML Documentation: https://lxml.de/

--- a/capellambse/loader/core.py
+++ b/capellambse/loader/core.py
@@ -709,7 +709,7 @@ class MelodyLoader:
         query
             The XPath query
         namespaces
-            Namespaces used in the query.  Defaults to all known
+            Namespaces used in the query. Defaults to all known
             namespaces.
         roots
             A list of XML elements to use as roots for the query.
@@ -747,7 +747,7 @@ class MelodyLoader:
         query
             The XPath query
         namespaces
-            Namespaces used in the query.  Defaults to all known
+            Namespaces used in the query. Defaults to all known
             namespaces.
         roots
             A list of XML elements to use as roots for the query.

--- a/capellambse/loader/exs.py
+++ b/capellambse/loader/exs.py
@@ -3,7 +3,7 @@
 """An Eclipse-like XML serializer.
 
 The libxml2 XML serializer produces very different output from the one
-used by Capella.  This causes a file saved by libxml2 to look vastly
+used by Capella. This causes a file saved by libxml2 to look vastly
 different, even though semantically nothing might have changed at all.
 This module implements a serializer which produces output like Capella
 does.
@@ -69,7 +69,7 @@ def to_bytes(
     """Serialize an XML tree as a ``str``.
 
     At the start of the document, an XML processing instruction will be
-    inserted declaring the used encoding.  Pass
+    inserted declaring the used encoding. Pass
     ``declare_encoding=False`` to inhibit this behavior.
 
     Arguments
@@ -77,7 +77,7 @@ def to_bytes(
     tree
         The XML tree to serialize.
     encoding
-        The encoding to use.  An XML processing instruction will be
+        The encoding to use. An XML processing instruction will be
         inserted which declares the used encoding.
     errors
         How to handle errors during encoding.

--- a/capellambse/loader/xmltools.py
+++ b/capellambse/loader/xmltools.py
@@ -60,10 +60,10 @@ class AttributeProperty:
             ``str`` as argument.
         optional
             If False (default) and the XML attribute does not exist, an
-            AttributeError is raised.  Otherwise a default value is
+            AttributeError is raised. Otherwise a default value is
             returned.
         default
-            A new-style format string to use as fallback value.  You can
+            A new-style format string to use as fallback value. You can
             access the object instance as ``self`` and the XML element
             as ``xml``.
         writable
@@ -382,9 +382,9 @@ class EnumAttributeProperty(AttributeProperty):
     but members of the Enum that was passed into the constructor.
 
     Usually it is expected that the enum members will be directly
-    assigned to this property.  However it is also possible to assign a
-    :class:`str` instead.  In this case, the string will be taken to be
-    an enum member's name.  In both cases, the enum member's value will
+    assigned to this property. However it is also possible to assign a
+    :class:`str` instead. In this case, the string will be taken to be
+    an enum member's name. In both cases, the enum member's value will
     be placed in the underlying XML attribute.
 
     If the XML attribute contains a value that does not correspond to
@@ -415,12 +415,12 @@ class EnumAttributeProperty(AttributeProperty):
         attribute
             The attribute on the XML element to handle.
         enumcls
-            The :class:`enum.Enum` subclass to use.  The class' members'
+            The :class:`enum.Enum` subclass to use. The class' members'
             values are used as the possible values for the XML
             attribute.
         default
             The default value to return if the attribute is not present
-            in the XML.  If None, an AttributeError will be raised
+            in the XML. If None, an AttributeError will be raised
             instead.
         """
         if not (isinstance(enumcls, type) and issubclass(enumcls, enum.Enum)):
@@ -502,7 +502,7 @@ class XMLDictProxy(cabc.MutableMapping):
         keyattr
             The element attribute to use as dictionary key.
         model
-            Reference to the original MelodyLoader.  If not None, the
+            Reference to the original MelodyLoader. If not None, the
             loader will be informed about element creation and deletion.
         """
         super().__init__(*args, **kwargs)

--- a/capellambse/model/common/__init__.py
+++ b/capellambse/model/common/__init__.py
@@ -35,11 +35,11 @@ XTYPE_HANDLERS: dict[
 r"""Defines a mapping between ``xsi:type``\ s and wrapper classes.
 
 The first layer's keys can be either ``None`` or the ``xsi:type`` of the
-architectural layer that the wrapper should be applied to.  In the case
-of ``None``, the wrapper will be applied to all layers.  Note that
+architectural layer that the wrapper should be applied to. In the case
+of ``None``, the wrapper will be applied to all layers. Note that
 layer-specific wrappers have precedence over layer-agnostic ones.
 
-These keys map to a further dictionary.  This second layer maps from the
+These keys map to a further dictionary. This second layer maps from the
 ``xsi:type``\ (s) that each wrapper handles to the wrapper class.
 """
 
@@ -88,19 +88,19 @@ def xtype_handler(  # pylint: disable=keyword-arg-before-vararg  # PEP-570
 ) -> cabc.Callable[[type[T]], type[T]]:
     """Register a class as handler for a specific ``xsi:type``.
 
-    ``arch`` is the ``xsi:type`` of the desired architecture.  It must
-    always be a simple string or None.  In the latter case the
-    definition applies to all elements regardless of their architectural
-    layer.  Architecture-specific definitions will always win over
+    ``arch`` is the ``xsi:type`` of the desired architecture. It must
+    always be a simple string or None. In the latter case the definition
+    applies to all elements regardless of their architectural layer.
+    Architecture-specific definitions will always win over
     architecture-independent ones.
 
     Each string given in ``xtypes`` notes an ``xsi:type`` of elements
-    that this class handles.  It is possible to specify multiple values,
+    that this class handles. It is possible to specify multiple values,
     in which case the class will be registered for each ``xsi:type``
     under the architectural layer given in ``arch``.
 
     Handler classes' ``__init__`` methods must accept two positional
-    arguments.  The first argument is the :class:`MelodyModel` instance
+    arguments. The first argument is the :class:`MelodyModel` instance
     which loaded the corresponding model, and the second one is the LXML
     element that needs to be handled.
 

--- a/capellambse/model/common/accessors.py
+++ b/capellambse/model/common/accessors.py
@@ -516,9 +516,9 @@ class DirectProxyAccessor(WritableAccessor[T], PhysicalAccessor[T]):
         class_
             The proxy class.
         xtypes
-            The ``xsi:type``\ (s) of the child element(s).  If None,
-            then the constructed proxy will be passed the original
-            element instead of a child.
+            The ``xsi:type``\ (s) of the child element(s). If None, then
+            the constructed proxy will be passed the original element
+            instead of a child.
         aslist
             If None, only a single element must match, which will be
             returned directly. If not None, must be a subclass of
@@ -1251,7 +1251,7 @@ class CustomAccessor(PhysicalAccessor[T]):
         class_
             The target subclass of ``GenericElement``
         elmfinders
-            Functions that are called on the current element.  Each
+            Functions that are called on the current element. Each
             returns an iterable of possible targets.
         aslist
             If None, only a single element must match, which will be
@@ -1645,12 +1645,12 @@ class ElementListCouplingMixin(element.ElementList[T], t.Generic[T]):
 
         Instead of specifying the full ``xsi:type`` including the
         namespace, you can also pass in just the part after the ``:``
-        separator.  If this is unambiguous, the appropriate
+        separator. If this is unambiguous, the appropriate
         layer-specific type will be selected automatically.
 
         This method can be called with or without the ``layertype``
-        argument.  If a layertype is not given, all layers will be tried
-        to find an appropriate ``xsi:type`` handler.  Note that setting
+        argument. If a layertype is not given, all layers will be tried
+        to find an appropriate ``xsi:type`` handler. Note that setting
         the layertype to ``None`` explicitly is different from not
         specifying it at all; ``None`` tries only the "Transverse
         modelling" type elements.

--- a/capellambse/model/common/element.py
+++ b/capellambse/model/common/element.py
@@ -84,9 +84,9 @@ class ModelObject(t.Protocol):
     """A class that wraps a specific model object.
 
     Most of the time, you'll want to subclass the concrete
-    ``GenericElement`` class.  However, some special classes (e.g. AIRD
+    ``GenericElement`` class. However, some special classes (e.g. AIRD
     diagrams) provide a compatible interface, but it doesn't make sense
-    to wrap a specific XML element.  This protocol class is used in type
+    to wrap a specific XML element. This protocol class is used in type
     annotations to catch both "normal" GenericElement subclasses and the
     mentioned special cases.
     """
@@ -446,9 +446,9 @@ class ElementList(cabc.MutableSequence, t.Generic[T]):
                 Use elements that match (True) or don't (False)
             single
                 When listing all matches, return a single element
-                instead.  If multiple elements match, it is an error; if
-                none match, a ``KeyError`` is raised.
-                Can be overridden at call time.
+                instead. If multiple elements match, it is an error; if
+                none match, a ``KeyError`` is raised. Can be overridden
+                at call time.
             """
             self._attr = attr
             self._parent = parent
@@ -510,8 +510,8 @@ class ElementList(cabc.MutableSequence, t.Generic[T]):
 
             The returned iterator yields all values that, when given to
             :meth:`__call__`, will result in a non-empty list being
-            returned.  Consequently, if the original list was empty,
-            this iterator will yield no values.
+            returned. Consequently, if the original list was empty, this
+            iterator will yield no values.
 
             The order in which the values are yielded is undefined.
             """

--- a/capellambse/model/common/properties.py
+++ b/capellambse/model/common/properties.py
@@ -60,10 +60,10 @@ class AttributeProperty:
             ``str`` as argument.
         optional
             If False (default) and the XML attribute does not exist, an
-            AttributeError is raised.  Otherwise a default value is
+            AttributeError is raised. Otherwise a default value is
             returned.
         default
-            A new-style format string to use as fallback value.  You can
+            A new-style format string to use as fallback value. You can
             access the object instance as ``self`` and the XML element
             as ``xml``.
         writable
@@ -389,9 +389,9 @@ class EnumAttributeProperty(AttributeProperty):
     but members of the Enum that was passed into the constructor.
 
     Usually it is expected that the enum members will be directly
-    assigned to this property.  However it is also possible to assign a
-    :class:`str` instead.  In this case, the string will be taken to be
-    an enum member's name.  In both cases, the enum member's value will
+    assigned to this property. However it is also possible to assign a
+    :class:`str` instead. In this case, the string will be taken to be
+    an enum member's name. In both cases, the enum member's value will
     be placed in the underlying XML attribute.
 
     If the XML attribute contains a value that does not correspond to
@@ -418,12 +418,12 @@ class EnumAttributeProperty(AttributeProperty):
         attribute
             The attribute on the XML element to handle.
         enumcls
-            The :class:`enum.Enum` subclass to use.  The class' members'
+            The :class:`enum.Enum` subclass to use. The class' members'
             values are used as the possible values for the XML
             attribute.
         default
             The default value to return if the attribute is not present
-            in the XML.  If None, an AttributeError will be raised
+            in the XML. If None, an AttributeError will be raised
             instead.
         """
         if not (isinstance(enumcls, type) and issubclass(enumcls, enum.Enum)):

--- a/capellambse/pvmt/__init__.py
+++ b/capellambse/pvmt/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Provides easy access to the Polarsys Capella PVMT extension.
 
-The public API of this submodule uses raw LXML elements.  For a more
+The public API of this submodule uses raw LXML elements. For a more
 object oriented and user friendly way to access property values in a
 model, see the :class:`capellambse.MelodyModel` class.
 """

--- a/capellambse/pvmt/model.py
+++ b/capellambse/pvmt/model.py
@@ -182,10 +182,10 @@ class PVMTExtension(XMLDictProxy):
 def load_pvmt_from_model(model):
     """Load the Property Value management extension for the given model.
 
-    This function is the main entry point for the ``pvmt`` module.  It
+    This function is the main entry point for the ``pvmt`` module. It
     should be called after constructing a ``MelodyLoader`` instance on
-    the model file.  It will return a ``PVMTExtension`` object, which
-    can be used to easily access the property values of the model given
+    the model file. It will return a ``PVMTExtension`` object, which can
+    be used to easily access the property values of the model given
     during intialization.
     """
     pkgs = model.xpath(

--- a/capellambse/pvmt/types.py
+++ b/capellambse/pvmt/types.py
@@ -89,7 +89,7 @@ class GenericPropertyValue(Generic, metaclass=abc.ABCMeta):
         value
             The value that should be serialized.
         element
-            The XML element into which the value will be inserted.  This
+            The XML element into which the value will be inserted. This
             may be used to construct links across fragment boundaries.
             This parameter may be None, in which case it is assumed that
             all elements exist within the same fragment.
@@ -231,7 +231,7 @@ class EnumerationPropertyValue(GenericPropertyValue):
 
         value = value.split("#")[-1]
         if value in self.typedef:
-            # It's already the UUID.  Normalize it.
+            # It's already the UUID. Normalize it.
             return pvext.model.create_link(element, pvext.model[value])
 
         raise ValueError(f"Not a valid value for this enumeration: {value}")

--- a/capellambse/sphinx.py
+++ b/capellambse/sphinx.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
 # SPDX-License-Identifier: Apache-2.0
-"""Sphinx extension for python-capella-mbse.
+"""Sphinx extension for capellambse.
 
 This extension is be used to display diagrams in Sphinx-generated
 documentation.
@@ -37,20 +37,20 @@ To enable this extension, add it to your list of extensions in Sphinx'
 
 The following configuration variables are understood by this extension:
 
-*   ``capellambse_model``: Path to the Capella model.
+* ``capellambse_model``: Path to the Capella model.
 
-    Set this variable to the root ``.aird`` file of the model you want
-    to use in the documentation.  The path must be relative to Sphinx'
-    current working directory, which should be the directory containing
-    the ``conf.py`` file.
+  Set this variable to the root ``.aird`` file of the model you want to
+  use in the documentation. The path must be relative to Sphinx' current
+  working directory, which should be the directory containing the
+  ``conf.py`` file.
 
 Known limitations
 -----------------
 
-*   The extension currently does not detect changes to the model, nor
-    does it track which source files are using it.  This means that,
-    after changing the model, you need to force a full rebuild of all
-    pages by passing ``--fresh-env`` to Sphinx' build command.
+* The extension currently does not detect changes to the model, nor does
+  it track which source files are using it. This means that, after
+  changing the model, you need to force a full rebuild of all pages by
+  passing ``--fresh-env`` to Sphinx' build command.
 """
 from __future__ import annotations
 
@@ -108,7 +108,7 @@ def unload_model(_: t.Any, env: sphinx.environment.BuildEnvironment) -> None:
     """Unload the model.
 
     The LXML tree cannot be pickled together with the rest of the build
-    environment.  This means we need to unload the model again after
+    environment. This means we need to unload the model again after
     processing the source files.
     """
     if hasattr(env, "capellambse_loaded_model"):

--- a/capellambse/svg/style.py
+++ b/capellambse/svg/style.py
@@ -379,9 +379,9 @@ class StyleBuilder:
     def create(self) -> None:
         """Create style builder and all needed components.
 
-        Create sheet string buffer from _base string template.  Copy
+        Create sheet string buffer from _base string template. Copy
         global styles from aird.STYLES and update with class-specific
-        styles.  Write styles to sheet.
+        styles. Write styles to sheet.
         """
         self.sheet = io.StringIO(
             self._base.format(
@@ -547,7 +547,7 @@ def deep_update_dict(
     target
         The target dict, which will be modified in place.
     updates
-        A dict containing the updates to apply.  If one of the values is
+        A dict containing the updates to apply. If one of the values is
         the special object ``deep_update_dict.delete``, the
         corresponding key will be deleted from the target.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -92,8 +92,8 @@ intersphinx_mapping = {
 
 # -- Options for HTML output -------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
+# The theme to use for HTML and HTML Help pages. See the documentation
+# for a list of builtin themes.
 
 html_theme = "furo"
 html_theme_options = {

--- a/tests/test_filehandler_memory.py
+++ b/tests/test_filehandler_memory.py
@@ -1,9 +1,32 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
 # SPDX-License-Identifier: Apache-2.0
 
+# pylint: disable=redefined-outer-name
+from __future__ import annotations
+
 import pytest
 
 from capellambse.filehandler import memory
+
+TEST_CONTENT = b"Hello, World!"
+
+
+@pytest.fixture
+def fh() -> memory.MemoryFileHandler:
+    fh = memory.MemoryFileHandler()
+    with fh.open("test.txt", "w") as f:
+        f.write(TEST_CONTENT)
+    return fh
+
+
+@pytest.fixture
+def fhdir() -> memory.MemoryFileHandler:
+    fh = memory.MemoryFileHandler()
+    fh.write_file("top.txt", TEST_CONTENT)
+    fh.write_file("some/test.txt", TEST_CONTENT)
+    fh.write_file("some/test2.txt", TEST_CONTENT)
+    fh.write_file("other/test3.txt", TEST_CONTENT)
+    return fh
 
 
 def test_MemoryFileHandler_raises_ValueError_for_invalid_path():
@@ -17,19 +40,57 @@ def test_MemoryFileHandler_raises_FileNotFoundError_for_nonexistent_file():
         fh.open("test.txt")
 
 
-def test_MemoryFileHandler_preserves_written_data():
-    fh = memory.MemoryFileHandler()
-    with fh.open("test.txt", "w") as f:
-        f.write(b"Hello, World!")
-
+def test_MemoryFileHandler_preserves_written_data(fh):
     with fh.open("test.txt", "r") as f:
-        assert f.read() == b"Hello, World!"
+        assert f.read() == TEST_CONTENT
 
 
-def test_MemoryFiles_return_bytes_objects_from_read():
-    fh = memory.MemoryFileHandler()
-    with fh.open("test.txt", "w") as f:
-        f.write(b"Hello, World!")
-
+def test_MemoryFiles_return_bytes_objects_from_read(fh):
     with fh.open("test.txt", "r") as f:
         assert isinstance(f.read(), bytes)
+
+
+def test_empty_MemoryFileHandler_has_no_files():
+    fh = memory.MemoryFileHandler()
+    assert not [p.name for p in fh.iterdir()]
+
+
+def test_MemoryFileHandler_iterates_over_files(fh):
+    assert [p.name for p in fh.iterdir()] == ["test.txt"]
+
+
+def test_MemoryFileHandler_iterated_files_can_be_read(fh):
+    for p in fh.iterdir():
+        with p.open("rb") as f:
+            assert f.read() == TEST_CONTENT
+
+
+def test_MemoryFilePath_returns_correct_name():
+    fh = memory.MemoryFileHandler()
+    assert fh.rootdir.joinpath("test.txt").name == "test.txt"
+
+
+def test_MemoryFilePath_recognizes_files(fh):
+    assert fh.rootdir.joinpath("test.txt").is_file()
+
+
+def test_MemoryFilePath_recognizes_directories(fh):
+    assert fh.rootdir.is_dir()
+
+
+def test_MemoryFileHandler_can_iterate_subdirs(fhdir):
+    actual = [p.name for p in fhdir.rootdir.iterdir("some")]
+
+    assert actual == ["test.txt", "test2.txt"]
+
+
+def test_MemoryFilePath_can_be_iterated(fhdir):
+    actual = [p.name for p in fhdir.rootdir.joinpath("some").iterdir()]
+
+    assert actual == ["test.txt", "test2.txt"]
+
+
+def test_MemoryFilePath_can_iterate_over_subdirs(fhdir):
+    actual = [p.name for p in fhdir.rootdir.iterdir("some")]
+
+    assert actual == ["test.txt", "test2.txt"]

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -45,7 +45,7 @@ def test_model_loading_via_LocalFileHandler(path: str | pathlib.Path):
     capellambse.MelodyModel(path)
 
 
-@pytest.mark.parametrize("suffix", [".capella", ".melodymodel"])
+@pytest.mark.parametrize("suffix", [".afm", ".capella"])
 def test_model_loading_with_invalid_entrypoint_fails(suffix: str):
     with pytest.raises(ValueError, match="(?i)invalid entrypoint"):
         capellambse.MelodyModel(TEST_MODEL_5_0.with_suffix(suffix))


### PR DESCRIPTION
This PR introduces functionality for the MelodyLoader and MelodyModel to automatically detect the `entrypoint` in more cases. Previously it was only able to "derive" it when the `.aird` file was given as `path`, in which case the filename was simply split off.

With this PR, we introduce the ability to list the contents of FileHandler instances (i.e. directories, Git repos, etc.). This allows to automatically find an AIRD file and use that as entrypoint. The current algorithm expects to find exactly one AIRD file in the FileHandler's root directory (which is defined by combining `path` and `subdir`); if there's more than one, or if it's placed in a further subdirectory, it still must be explicitly specified. However, this does cover the common case of a Git repository housing a single model.

This PR only contains implementations for the `file` and `git` handlers, however adding support for other handlers is a matter of implementing a few new methods. Handlers that don't support listing files can still be used when explicitly specifying the `entrypoint`, as before.