### PR TITLE
Display name of element in `__html__` heading

### DIFF
--- a/capellambse/model/common/element.py
+++ b/capellambse/model/common/element.py
@@ -332,7 +332,7 @@ class GenericElement:
             fragments.append("<h1>Model element")
         else:
             fragments.append("<h1>")
-            fragments.append(escape(type(self).__name__))
+            fragments.append(escape(self.name or type(self).__name__))
         fragments.append(' <span style="font-size: 70%;">(')
         fragments.append(escape(self.xtype))
         fragments.append(")</span>")


### PR DESCRIPTION
In the `__html__` representation, which is used for Jupyter, the name of the type of the element was displayed.

While the type is relatively uninteresting for the user, especially because the xtype is displayed right after it, the name of the element itself was missing completely in the representation.

This commit replaces the type name with the element if a element name is available.

State before this commit: 
![image](https://github.com/DSD-DBS/py-capellambse/assets/23395732/efbdf818-8b04-461e-82d6-d393175d8e03)


State after this commit: 
![image](https://github.com/DSD-DBS/py-capellambse/assets/23395732/afc2644b-683b-435d-a43c-8d70db39a04a)
