### PR TITLE
Fix diagram rich display in JupyterLab

### DIFF
--- a/capellambse/model/diagram.py
+++ b/capellambse/model/diagram.py
@@ -594,31 +594,6 @@ class SVGInHTMLIMGFormat:
         return markupsafe.Markup(f'<img src="{payload}"/>')
 
 
-class JSONFormat:
-    filename_extension = ".json"
-
-    @staticmethod
-    def convert(dg: diagram.Diagram) -> str:
-        return diagram.DiagramJSONEncoder().encode(dg)
-
-    @staticmethod
-    def from_cache(cache: bytes) -> str:
-        return cache.decode("utf-8")
-
-
-class PrettyJSONFormat:
-    filename_extension = ".json"
-    mimetype = "application/json"
-
-    @staticmethod
-    def convert(dg: diagram.Diagram) -> str:
-        return diagram.DiagramJSONEncoder(indent=4).encode(dg)
-
-    @staticmethod
-    def from_cache(cache: bytes) -> str:
-        return cache.decode("utf-8")
-
-
 class TerminalGraphicsFormat:
     """The kitty terminal graphics protocol diagram format.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,6 @@ termgraphics = [
 [project.entry-points."capellambse.diagram.formats"]
 datauri_svg = "capellambse.model.diagram:SVGDataURIFormat"
 html_img = "capellambse.model.diagram:SVGInHTMLIMGFormat"
-json = "capellambse.model.diagram:JSONFormat"
-json_pretty = "capellambse.model.diagram:PrettyJSONFormat"
 png = "capellambse.model.diagram:PNGFormat"
 svg = "capellambse.model.diagram:SVGFormat"
 svg_confluence = "capellambse.model.diagram:ConfluenceSVGFormat"

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -12,6 +12,7 @@ import pytest
 from lxml import etree
 
 import capellambse
+import capellambse.diagram
 from capellambse.svg import (
     SVGDiagram,
     decorations,
@@ -55,7 +56,8 @@ def tmp_json_fixture(
 ) -> pathlib.Path:
     """Return tmp path of diagram json file."""
     dest = tmp_path / (TEST_LAB + ".json")
-    diagram_json: str = model.diagrams.by_name(TEST_LAB).render("json_pretty")
+    diagram = model.diagrams.by_name(TEST_LAB).render(None)
+    diagram_json = capellambse.diagram.DiagramJSONEncoder().encode(diagram)
     dest.write_text(diagram_json)
     return dest
 


### PR DESCRIPTION
JupyterLab (unlike the legacy "Jupyter notebook server") prefers JSON over SVG for display purposes. Capellambse used to expose its internally used JSON format in the diagrams' `_repr_mimebundle_()` method. This caused JupyterLab to not show diagrams properly when using `display()` or when a Diagram instance was the result of a cell.

Furthermore, the way that the `_repr_mimebundle_()` method returned its `application/json` mimetype (encoded as a string, instead of as regular Python dict) was never supported to begin with.

This PR fixes both of these issues by no longer exposing this internal format publicly. This means that:

- `_repr_mimebundle_()` will no longer contain `application/json`
- `AbstractDiagram.render()` will no longer accept `json` and `json_pretty` as format argument
- The `AbstractDiagram.as_json` and `as_json_pretty` auto-generated properties are no longer present and will raise AttributeErrors