### PR TITLE
feat: Add white background if needed to diagram cache svg

### DIFF
--- a/capellambse/diagram_cache.py
+++ b/capellambse/diagram_cache.py
@@ -55,6 +55,12 @@ else:
     )
     @click.option("--exe", help="Name or path of the Capella executable")
     @click.option("--docker", help="Name of a Docker image containing Capella")
+    @click.option(
+        "--background/--no-background",
+        help="Inserts a white background into the diagrams.",
+        default=False,
+        show_default=True,
+    )
     def _main(
         model_: capellambse.MelodyModel,
         output: pathlib.Path,
@@ -62,18 +68,29 @@ else:
         index: bool,
         exe: str | None,
         docker: str | None,
+        background: bool,
     ) -> None:
         model_._diagram_cache = capellambse.get_filehandler(output)
         model_._diagram_cache_subdir = pathlib.PurePosixPath(".")
 
         if docker:
             _diagram_cache.export(
-                docker, model_, format=format, index=index, force="docker"
+                docker,
+                model_,
+                format=format,
+                index=index,
+                force="docker",
+                background=background,
             )
         else:
             exe = exe or "capella{VERSION}"
             _diagram_cache.export(
-                exe, model_, format=format, index=index, force="exe"
+                exe,
+                model_,
+                format=format,
+                index=index,
+                force="exe",
+                background=background,
             )
 
 

--- a/capellambse/model/__init__.py
+++ b/capellambse/model/__init__.py
@@ -441,6 +441,7 @@ class MelodyModel:
         *,
         create_index: bool = False,
         force: t.Literal["docker", "exe"] | None = None,
+        background: bool = False,
     ) -> None:
         r"""Update the diagram cache if one has been specified.
 
@@ -519,6 +520,10 @@ class MelodyModel:
             ``capella_cli`` as local executable, ``"docker"`` always
             interprets it as a docker image name. ``None`` (the default)
             enables automatic detection.
+        background
+            Add a white background to exported SVG images.
+
+            Ignored if the ``image_format`` is not ``"svg"``.
 
         Raises
         ------
@@ -573,6 +578,7 @@ class MelodyModel:
             format=image_format,
             index=create_index,
             force=force,
+            background=background,
         )
 
     @classmethod


### PR DESCRIPTION
This PR adds the option to add white background to the diagram cache via the cli

Example in green to show the extend of the background and that it is only around the diagram
![Bildschirmfoto 2023-08-15 um 16 30 00](https://github.com/DSD-DBS/py-capellambse/assets/49535291/8c52d519-b7d8-4237-9515-4a417d2fca9a)

