### PR TITLE
fix: Don't block Capella on error in native client

### DIFF
--- a/capellambse/_native.py
+++ b/capellambse/_native.py
@@ -26,6 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 
 _Runner = t.Union["_SimpleRunner", "_DockerRunner"]
 _COMMON_ARGS: t.Final = (
+    "--launcher.suppressErrors",
     "-nosplash",
     "-consolelog",
     "-forceimport",


### PR DESCRIPTION
When Capella errors, it creates a dialog on the display. The Capella process is blocking until the user clicks "Close" in the GUI, which will never happen in a CI/CD environment.

To suppress errors in the GUI, the `--launcher.suppressErrors` is passed to Capella/Eclipse. As positive side-effect, the errors are now also printed in stderr and are therefore handled by capellambse.