### PR TITLE
Fix creation of `Relation`s from a `Requirement`

### DIFF
--- a/capellambse/extensions/reqif/_capellareq.py
+++ b/capellambse/extensions/reqif/_capellareq.py
@@ -251,7 +251,7 @@ class RequirementsRelationAccessor(
                 f" {type(target).__name__}"
             )
         else:
-            return rq.InternalRelation
+            return CapellaIncomingRelation
 
 
 class RelationsList(c.ElementList["rq.AbstractRequirementsRelation"]):

--- a/tests/test_reqif.py
+++ b/tests/test_reqif.py
@@ -336,6 +336,38 @@ class TestRequirementRelations:
         )
         assert {i.uuid for i in relations} == target_uuids
 
+    @pytest.mark.parametrize(
+        "obj_uuid,target_uuid,expected_type",
+        (
+            pytest.param(
+                "0a9a68b1-ba9a-4793-b2cf-4448f0b4b8cc",
+                "3c2d312c-37c9-41b5-8c32-67578fa52dc3",
+                reqif.InternalRelation,
+                id="Internal",
+            ),
+            pytest.param(
+                "0a9a68b1-ba9a-4793-b2cf-4448f0b4b8cc",
+                "f708bc29-d69f-42a0-90cc-11fc01054cd0",
+                reqif.CapellaIncomingRelation,
+                id="Incoming",
+            ),
+        ),
+    )
+    def test_creating_RequirementRelations(
+        self,
+        model: capellambse.MelodyModel,
+        obj_uuid: str,
+        target_uuid: str,
+        expected_type: type[reqif.AbstractRequirementsRelation],
+    ):
+        source = model.by_uuid(obj_uuid)
+        target = model.by_uuid(target_uuid)
+        req = source if isinstance(source, reqif.Requirement) else target
+
+        relation = req.relations.create(target=target)
+
+        assert isinstance(relation, expected_type)
+
 
 class TestReqIFAccess:
     def test_RequirementsModule_attributes(


### PR DESCRIPTION
This is needed to bring our RequirementsBot into working state again. 

While fixing the creation of `Relation`s from the `reqif.Requirement` side, what about the other side? So creating `CapellaOutgoingRelation`s from any model object to a `reqif.Requirement` can't be done via capellambse right now, or? I can't find a `.relation` attribute on `GenericElement`. Also there are 2 ways of creating `Relation`. Both lead to different places of where the `Relation` XML element is written to: Either underneath the model object or underneath the Requirement. The GUI accepts both, so I'd root for capellambse creating `Relation`s just underneath the `reqif.Requirement` to keep the reqif content compact and bundled inside the `RequirementsModule`. The latter hasn't been done for now, and is the main factor why this PR is a DRAFT.