### PR TITLE
Make pushing the complexity badge optional in Gitlab

### DIFF
--- a/ci-templates/gitlab/model-badge.yml
+++ b/ci-templates/gitlab/model-badge.yml
@@ -22,6 +22,7 @@ generate-model-badge:
       model = capellambse.MelodyModel(os.environ["ENTRYPOINT"])
       pathlib.Path(os.environ["OUTPUT_FILE"]).write_text(model.description_badge)
       EOF
+    - if [[ "${CAPELLAMBSE_PUSH_MODEL_BADGE:-1}" != 1 ]]; then exit 0; fi
     - git add "$OUTPUT_FILE"
     - "if git diff --cached --exit-code &> /dev/null; then exit 0; fi"
     - 'git commit -m "$COMMIT_MSG"'
@@ -36,3 +37,8 @@ generate-model-badge:
 
     # Specify the commit message when pushing model complexity badge
     COMMIT_MSG: "docs: Add/Modify model complexity badge"
+
+    CAPELLAMBSE_PUSH_MODEL_BADGE:
+      description: Commit the model badge to git and push it back to the current branch. 1 to enable, 0 to disable.
+      value: 1
+      options: ["0", "1"]

--- a/ci-templates/gitlab/model-badge.yml
+++ b/ci-templates/gitlab/model-badge.yml
@@ -13,14 +13,10 @@ generate-model-badge:
     - git reset --hard origin/$CI_COMMIT_BRANCH
     - pip install "git+https://github.com/DSD-DBS/py-capellambse.git@$CAPELLAMBSE_REVISION"
     - |
-      python <<EOF
-      import os
-      import pathlib
-
-      import capellambse
-
-      model = capellambse.MelodyModel(os.environ["ENTRYPOINT"])
-      pathlib.Path(os.environ["OUTPUT_FILE"]).write_text(model.description_badge)
+      python >"$OUTPUT_FILE" <<EOF
+      import os, capellambse
+      model = capellambse.loadcli(os.environ["ENTRYPOINT"])
+      print(model.description_badge, end="")
       EOF
     - if [[ "${CAPELLAMBSE_PUSH_MODEL_BADGE:-1}" != 1 ]]; then exit 0; fi
     - git add "$OUTPUT_FILE"


### PR DESCRIPTION
The push can be disabled by setting the new environment variable `CAPELLAMBSE_PUSH_MODEL_BADGE` to 0. The default is the current behavior, i.e. to push the badge (1).