### PR TITLE
Fix README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -247,29 +247,11 @@ Render diagrams in untrusted jupyter notebooks
 
 The SVG format relies on a stylesheet, however in untrusted notebooks any
 stylesheets are stripped. As a workaround we support the PNG format. For this
-the `cairosvg`__ library is needed which depends on additional binaries. They
-can be installed with the following commands based on your OS:
+the `cairosvg`__ library is needed which depends on additional libraries. See
+the official `CairoSVG documentation`__ for detailed instructions.
 
 __ https://pypi.org/project/CairoSVG/
-
-On linux
-""""""""
-
-Make sure to use the right package manager. For debian/ubuntu:
-
-.. code::
-
-    sudo apt-get install libcairo2
-
-For windows
-"""""""""""
-
-- Download and execute the `latest GTK installer`__.
-
-  __ https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer/releases/tag/2022-01-04
-
-- Reboot to add the path to the installed compiled libraries into your system
-  environment PATH
+__ https://cairosvg.org/documentation/#installation
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,29 @@ notebook.
   __ https://docs.ros.org/en/rolling/Concepts/About-ROS-Interfaces.html
   __ https://developers.google.com/protocol-buffers
 
+- `08 Property Values.ipynb`__ shows how to access property values and property
+  value groups, as well as the `Property Value Management (PVMT)`__ extension.
+
+  __ https://dsd-dbs.github.io/py-capellambse/examples/08%20Property%20Values.html
+  __ https://eclipse.dev/capella/addons.html
+
+- `09 Context Diagrams.ipynb`__ shows the `capellambse-context-diagrams extension`__ that visualizes
+  contexts of Capella objects. The extension is external to the capellambse library
+  and needs to be installed separately.
+
+  __ https://dsd-dbs.github.io/py-capellambse/examples/09%20Context%20Diagrams.html
+  __ https://dsd-dbs.github.io/capellambse-context-diagrams/
+
+- `10 Declarative Modeling.ipynb`__ demonstrates a basic application of the
+  declarative approach to modeling on a coffee machine example.
+
+  __ https://dsd-dbs.github.io/py-capellambse/examples/10%20Declarative%20Modeling.html
+
+- `11 Complexity Assessment.ipynb`__ quickly demonstrates how to use and view the
+  model complexity badge for a Capella model.
+
+  __ https://dsd-dbs.github.io/py-capellambse/examples/11%20Complexity%20Assessment.html
+
 We are constantly working on improving everything shown here, as well as adding
 even more useful functionality and helpful demos. If you have any new ideas
 that were not mentioned yet, `don't hesitate to contribute`__!

--- a/README.rst
+++ b/README.rst
@@ -224,10 +224,22 @@ Render diagrams in untrusted jupyter notebooks
 
 The SVG format relies on a stylesheet, however in untrusted notebooks any
 stylesheets are stripped. As a workaround we support the PNG format. For this
-the `cairosvg`__ library is needed which requires the following additional
-setup steps on windows:
+the `cairosvg`__ library is needed which depends on additional binaries. They
+can be installed with the following commands based on your OS:
 
 __ https://pypi.org/project/CairoSVG/
+
+On linux
+""""""""
+
+Make sure to use the right package manager. For debian/ubuntu:
+
+.. code::
+
+    sudo apt-get install libcairo2
+
+For windows
+"""""""""""
 
 - Download and execute the `latest GTK installer`__.
 


### PR DESCRIPTION
Somehow it isn't enough to just `pip install capellambse[png]`. On linux you endup with a missing binary like on a windows machine. This commit informs the user about this flaw.