### PR TITLE
Fix Property class

### DIFF
--- a/capellambse/diagram/_styleclass.py
+++ b/capellambse/diagram/_styleclass.py
@@ -116,6 +116,11 @@ def _region(obj: model.ModelObject) -> str:
     return f"{parent_xclass}{_default(obj)}"
 
 
+def _property(obj: model.ModelObject) -> str:
+    assert isinstance(obj, model.information.Property)
+    return obj.kind.name.capitalize()
+
+
 _STYLECLASSES: dict[str, cabc.Callable[[model.ModelObject], str]] = {
     "Association": _association,
     "CapellaIncomingRelation": lambda _: "RequirementRelation",
@@ -130,6 +135,7 @@ _STYLECLASSES: dict[str, cabc.Callable[[model.ModelObject], str]] = {
     "Part": _part,
     "PhysicalComponent": _physical_component,
     "PhysicalPort": lambda _: "PP",
+    "Property": _property,
     "PortAllocation": _port_allocation,
     "Region": _region,
     "SystemComponent": _generic_component,

--- a/capellambse/diagram/capstyle.py
+++ b/capellambse/diagram/capstyle.py
@@ -348,10 +348,12 @@ STYLES: dict[str, dict[str, dict[str, CSSdef]]] = {
         "Edge.Aggregation": {
             "stroke": COLORS["_CAP_Association_Color"],
             "marker-start": "DiamondMark",
+            "marker-end": "FineArrowMark",
         },
         "Edge.Composition": {
             "stroke": COLORS["_CAP_Association_Color"],
             "marker-start": "FilledDiamondMark",
+            "marker-end": "FineArrowMark",
         },
         "Edge.ExchangeItemElement": {  # DT_ExchangeItemElement
             "stroke": COLORS["black"],

--- a/capellambse/svg/symbols.py
+++ b/capellambse/svg/symbols.py
@@ -1149,7 +1149,7 @@ def fine_arrow_mark(
     id_: str = "FineArrow", *, style: style_.Styling, **kw
 ) -> container.Marker:
     return _make_marker(
-        (7, 3.5),
+        (7, 3.75),
         (7.5, 7.5),
         id_=id_,
         d=(


### PR DESCRIPTION
Styleclasses for `information.Property`s couldn't be resolved based on the `kind` attribute. Also end-markers were missing for composition and aggregation kinds of properties in a CDB diagram. The ref x coordinate for the FineArrowMarker was corrected to be exact centric.

**_These changes are needed in the Class-Tree feature for the [capellambse-context-diagrams #53](https://github.com/DSD-DBS/capellambse-context-diagrams/pull/53) extension._**