### PR TITLE
Don't crash if there are no diagrams in the model

### DIFF
--- a/capellambse/aird/__init__.py
+++ b/capellambse/aird/__init__.py
@@ -58,13 +58,8 @@ def enumerate_diagrams(
     model
         The MelodyLoader instance
     """
-    raw_views = model.xpath2(C.XP_VIEWS)
     views: list[tuple[pathlib.PurePosixPath, etree._Element, str]] = []
-    if len(raw_views) == 0:
-        raise ValueError("Invalid XML: No viewpoints found")
-
-    # Extract the views' names
-    for i in raw_views:
+    for i in model.xpath2(C.XP_VIEWS):
         viewname = helpers.xpath_fetch_unique(
             "./viewpoint", i[1], "viewpoint description"
         )
@@ -75,16 +70,14 @@ def enumerate_diagrams(
         views.append((*i, urllib.parse.unquote(viewname or "")))
 
     if not views:
-        raise ValueError("No viewpoints found")
+        C.LOGGER.debug("No viewpoints found in the model")
+        return
 
     descriptors: list[tuple[pathlib.PurePosixPath, etree._Element, str]] = []
     for view in views:
         descriptors += [
             (view[0], d, view[2]) for d in C.XP_DESCRIPTORS(view[1])
         ]
-
-    if len(descriptors) == 0:
-        raise ValueError("Invalid XML: No diagrams found")
 
     for descriptor in descriptors:
         name = uid = None

--- a/capellambse/extensions/metrics/composer.py
+++ b/capellambse/extensions/metrics/composer.py
@@ -145,7 +145,10 @@ def draw_labeled_bar(
 ) -> str:
     """Construct a bar with label and icon (SVG string)."""
     total = sum(segments)
-    normalized_segments = [x / total for x in segments]
+    if total:
+        normalized_segments = [x / total for x in segments]
+    else:
+        normalized_segments = [0 for _ in segments]
     return (
         draw_icon(x, y)
         + draw_text(x + 5, y + 3, f"{total}")

--- a/tests/test_aird_parser.py
+++ b/tests/test_aird_parser.py
@@ -10,6 +10,10 @@ import pytest
 import capellambse
 from capellambse import aird, diagram, loader
 
+EMPTY_MODEL = pathlib.Path(__file__).parent.joinpath(
+    "data/decl/empty_project_52/empty_project_52.aird"
+)
+
 
 class TestAIRDBasicFunctionality:
     test_model = (
@@ -80,6 +84,11 @@ class TestAIRDBasicFunctionality:
         expected = self.test_repr.read_text().strip()
         actual = repr(diagram_under_test)
         assert actual == expected
+
+    def test_enumerate_diagrams_doesnt_crash_if_there_are_no_diagrams(self):
+        model = loader.MelodyLoader(EMPTY_MODEL)
+        for _ in aird.enumerate_diagrams(model):
+            pass
 
 
 def test_airdparser_msm_produces_valid_json_without_error(


### PR DESCRIPTION
Just because nobody bothered to draw pretty pictures, doesn't make the whole XML invalid. Apparently diagram-less models are a thing after all.
