### PR TITLE
Rename diagram_cache to diagram_image_cache

### DIFF
--- a/capellambse/_diagram_image_cache.py
+++ b/capellambse/_diagram_image_cache.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
 # SPDX-License-Identifier: Apache-2.0
-"""Module to populate the diagram cache with native Capella diagrams."""
+"""Module to populate the diagram image cache with native Capella diagrams."""
 
 from __future__ import annotations
 
@@ -67,10 +67,10 @@ def export(
     background: bool,
 ) -> None:
     if not isinstance(
-        getattr(model, "_diagram_cache", None), local.LocalFileHandler
+        getattr(model, "_diagram_image_cache", None), local.LocalFileHandler
     ):
         raise TypeError(
-            "Diagram cache updates are only supported for local paths"
+            "Diagram image cache updates are only supported for local paths"
         )
 
     format = format.lower()
@@ -80,12 +80,12 @@ def export(
             f"Invalid image format {format!r}, supported are {supported}"
         )
 
-    diag_cache_dir = pathlib.Path(model._diagram_cache.path)
+    diag_image_cache_dir = pathlib.Path(model._diagram_image_cache.path)
     try:
-        shutil.rmtree(diag_cache_dir)
+        shutil.rmtree(diag_image_cache_dir)
     except FileNotFoundError:
         pass
-    diag_cache_dir.mkdir(parents=True)
+    diag_image_cache_dir.mkdir(parents=True)
 
     native_args = _find_executor(model, capella, force)
     with _native.native_capella(model, **native_args) as cli:
@@ -104,12 +104,12 @@ def export(
         diagrams = _copy_images(
             model,
             cli.project / "main_model" / "output",
-            diag_cache_dir,
+            diag_image_cache_dir,
             format,
             background,
         )
         if index:
-            _write_index(model, format, diag_cache_dir, diagrams)
+            _write_index(model, format, diag_image_cache_dir, diagrams)
 
 
 def _find_executor(
@@ -249,7 +249,7 @@ def _write_index(
     index: list[IndexEntry],
 ) -> None:
     now = datetime.datetime.now().strftime("%A, %Y-%m-%d %H:%M:%S")
-    title = f"Capella diagram cache for {model.name!r}"
+    title = f"Capella diagram image cache for {model.name!r}"
     html = E.html(
         E.head(
             E.style(

--- a/capellambse/cli_helpers.py
+++ b/capellambse/cli_helpers.py
@@ -67,7 +67,7 @@ try:
            @click.open("-m", "modelinfo", type=capellambse.ModelInfoCLI())
            def main(modelinfo: dict[str, t.Any]) -> None:
                # change any options, for example:
-               modelinfo["diagram_cache"] = "/tmp/diagrams"
+               modelinfo["diagram_image_cache"] = "/tmp/diagrams"
                # load the model:
                model = capellambse.MelodyModel(**modelinfo)
                ...

--- a/capellambse/diagram_image_cache.py
+++ b/capellambse/diagram_image_cache.py
@@ -1,16 +1,16 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
 # SPDX-License-Identifier: Apache-2.0
-"""CLI for the diagram cache updating feature."""
+"""CLI for the diagram image cache updating feature."""
 from __future__ import annotations
 
 import pathlib
 import sys
 
 import capellambse
-from capellambse import _diagram_cache, cli_helpers
+from capellambse import _diagram_image_cache, cli_helpers
 
 # pylint: disable=unused-import
-from capellambse._diagram_cache import IndexEntry
+from capellambse._diagram_image_cache import IndexEntry
 
 try:
     import click
@@ -45,7 +45,7 @@ else:
     @click.option(
         "-f",
         "--format",
-        type=click.Choice(sorted(_diagram_cache.VALID_FORMATS)),
+        type=click.Choice(sorted(_diagram_image_cache.VALID_FORMATS)),
         default="svg",
         help="Image output format",
         show_default=True,
@@ -73,11 +73,11 @@ else:
         docker: str | None,
         background: bool,
     ) -> None:
-        model_._diagram_cache = capellambse.get_filehandler(output)
-        model_._diagram_cache_subdir = pathlib.PurePosixPath(".")
+        model_._diagram_image_cache = capellambse.get_filehandler(output)
+        model_._diagram_image_cache_subdir = pathlib.PurePosixPath(".")
 
         if docker:
-            _diagram_cache.export(
+            _diagram_image_cache.export(
                 docker,
                 model_,
                 format=format,
@@ -87,7 +87,7 @@ else:
             )
         else:
             exe = exe or "capella{VERSION}"
-            _diagram_cache.export(
+            _diagram_image_cache.export(
                 exe,
                 model_,
                 format=format,

--- a/capellambse/model/diagram.py
+++ b/capellambse/model/diagram.py
@@ -244,7 +244,7 @@ class AbstractDiagram(metaclass=abc.ABCMeta):
             def conv(i: diagram.Diagram) -> diagram.Diagram:
                 return i
 
-        cache_handler = getattr(self._model, "_diagram_cache", None)
+        cache_handler = getattr(self._model, "_diagram_image_cache", None)
         if fmt is not None and cache_handler is not None:
             try:
                 return self.__load_cache(conv)
@@ -325,8 +325,8 @@ class AbstractDiagram(metaclass=abc.ABCMeta):
         return diag
 
     def __load_cache(self, converter: DiagramConverter):
-        cache_handler = getattr(self._model, "_diagram_cache", None)
-        cachedir = getattr(self._model, "_diagram_cache_subdir", None)
+        cache_handler = getattr(self._model, "_diagram_image_cache", None)
+        cachedir = getattr(self._model, "_diagram_image_cache_subdir", None)
         if cache_handler is None or cachedir is None:
             raise KeyError(self.uuid)
 

--- a/capellambse/model/layers/ctx.py
+++ b/capellambse/model/layers/ctx.py
@@ -272,7 +272,7 @@ class SystemAnalysis(crosslayer.BaseArchitectureLayer):
     )
 
     diagrams = diagram.DiagramAccessor(
-        "System Analysis", cacheattr="_MelodyModel__diagram_cache"
+        "System Analysis", cacheattr="_MelodyModel__diagram_image_cache"
     )
 
 

--- a/capellambse/model/layers/la.py
+++ b/capellambse/model/layers/la.py
@@ -192,7 +192,7 @@ class LogicalArchitecture(crosslayer.BaseArchitectureLayer):
     )
 
     diagrams = diagram.DiagramAccessor(
-        "Logical Architecture", cacheattr="_MelodyModel__diagram_cache"
+        "Logical Architecture", cacheattr="_MelodyModel__diagram_image_cache"
     )
 
 

--- a/capellambse/model/layers/oa.py
+++ b/capellambse/model/layers/oa.py
@@ -267,7 +267,7 @@ class OperationalAnalysis(crosslayer.BaseArchitectureLayer):
     )
 
     diagrams = diagram.DiagramAccessor(
-        "Operational Analysis", cacheattr="_MelodyModel__diagram_cache"
+        "Operational Analysis", cacheattr="_MelodyModel__diagram_image_cache"
     )
 
 

--- a/capellambse/model/layers/pa.py
+++ b/capellambse/model/layers/pa.py
@@ -162,7 +162,7 @@ class PhysicalArchitecture(crosslayer.BaseArchitectureLayer):
     )
 
     diagrams = diagram.DiagramAccessor(
-        "Physical Architecture", cacheattr="_MelodyModel__diagram_cache"
+        "Physical Architecture", cacheattr="_MelodyModel__diagram_image_cache"
     )
 
 

--- a/capellambse/repl.py
+++ b/capellambse/repl.py
@@ -152,8 +152,11 @@ def _parse_args(args: list[str] | None = None) -> dict[str, t.Any]:
     if pargs.wipe:
         modelinfo["disable_cache"] = True
 
-    if pargs.disable_diagram_cache and "diagram_cache" in modelinfo:
-        del modelinfo["diagram_cache"]
+    if (
+        pargs.disable_diagram_image_cache
+        and "diagram_image_cache" in modelinfo
+    ):
+        del modelinfo["diagram_image_cache"]
 
     if pargs.dump:
         print(json.dumps(modelinfo, indent=2))

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -601,7 +601,9 @@ def test_model_info_contains_viewpoints_and_capella_version() -> None:
 def test_model_loads_diagrams_from_cache_by_uuid(
     tmp_path: pathlib.Path, format: str, content: bytes
 ):
-    model = capellambse.MelodyModel(TEST_MODEL_5_0, diagram_cache=tmp_path)
+    model = capellambse.MelodyModel(
+        TEST_MODEL_5_0, diagram_image_cache=tmp_path
+    )
     dg = model.diagrams[0]
     tmp_path.joinpath(f"{dg.uuid}.{format}").write_bytes(content)
 
@@ -612,10 +614,12 @@ def test_model_loads_diagrams_from_cache_by_uuid(
     assert rendered == content
 
 
-def test_model_will_refuse_to_render_diagrams_if_diagram_cache_was_given(
+def test_model_will_refuse_to_render_diagrams_if_diagram_image_cache_was_given(
     tmp_path: pathlib.Path,
 ):
-    model = capellambse.MelodyModel(TEST_MODEL_5_0, diagram_cache=tmp_path)
+    model = capellambse.MelodyModel(
+        TEST_MODEL_5_0, diagram_image_cache=tmp_path
+    )
 
     with pytest.raises(RuntimeError, match="not in cache"):
         model.diagrams[0].render("svg")
@@ -626,7 +630,7 @@ def test_model_will_fall_back_to_rendering_internally_despite_the_cache_if_told_
 ):
     model = capellambse.MelodyModel(
         TEST_MODEL_5_0,
-        diagram_cache=tmp_path,
+        diagram_image_cache=tmp_path,
         fallback_render_aird=True,
     )
 
@@ -636,6 +640,8 @@ def test_model_will_fall_back_to_rendering_internally_despite_the_cache_if_told_
 def test_model_diagram_visible_nodes_can_be_accessed_when_a_cache_was_specified(
     tmp_path: pathlib.Path,
 ):
-    model = capellambse.MelodyModel(TEST_MODEL_5_0, diagram_cache=tmp_path)
+    model = capellambse.MelodyModel(
+        TEST_MODEL_5_0, diagram_image_cache=tmp_path
+    )
 
     assert model.diagrams[0].nodes


### PR DESCRIPTION
Closes #247

Added a deprecation warning for `diagram_cache` and `diagram_cache_subdir` in the MelodyLoader and for the `update_diagram_cache` function.