### PR TITLE
Fix feature text alignment

### DIFF
--- a/capellambse/svg/drawing.py
+++ b/capellambse/svg/drawing.py
@@ -239,9 +239,9 @@ class Drawing:
         x, y = obj.attribs["x"], obj.attribs["y"]
         w, h = obj.attribs["width"], obj.attribs["height"]
         label: LabelDict = {
-            "x": x,
+            "x": x + decorations.feature_space / 2,
             "y": y + decorations.feature_space,
-            "width": w,
+            "width": w - decorations.feature_space / 2,
             "height": h - decorations.feature_space,
             "class": "Features",
             "text": "\n".join(
@@ -256,6 +256,7 @@ class Drawing:
                 labelstyle=labelstyle,
                 y_margin=7,
                 icon=False,
+                alignment="left",
             )
         )
 
@@ -841,6 +842,7 @@ class LabelBuilder:
     text_anchor: str = "start"
     icon: bool = True
     icon_size: float | int = decorations.icon_size
+    alignment: helpers.AlignmentLiteral = "center"
 
 
 class LinesData(t.NamedTuple):
@@ -865,6 +867,7 @@ def render_hbounded_lines(
         builder.label["width"],
         decorations.icon_padding if render_icon else 0,
         builder.icon_size if render_icon else 0,
+        builder.alignment,
     )
     lines_to_render = helpers.check_for_vertical_overflow(
         lines, builder.label["height"], max_text_width

--- a/capellambse/svg/helpers.py
+++ b/capellambse/svg/helpers.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 
 import collections.abc as cabc
 import math
+import typing as t
 
 from capellambse import helpers
+
+AlignmentLiteral = t.Literal["center", "left", "right"]
 
 
 def check_for_horizontal_overflow(
@@ -14,6 +17,7 @@ def check_for_horizontal_overflow(
     width: int | float,
     icon_padding: int | float,
     icon_size: int | float,
+    alignment: AlignmentLiteral = "center",
 ) -> tuple[cabc.Sequence[str], float, float]:
     max_text_width = width - (icon_size + 2 * icon_padding)
     assert max_text_width >= 0
@@ -22,7 +26,12 @@ def check_for_horizontal_overflow(
     label_width = text_width + icon_size + 2 * icon_padding
     assert text_width <= max_text_width
     assert label_width <= width
-    label_margin = (width - label_width) / 2
+    if alignment == "center":
+        label_margin = (width - label_width) / 2
+    elif alignment == "left":
+        label_margin = 0
+    else:
+        label_margin = width - label_margin
     return (lines, label_margin, max_text_width)
 
 


### PR DESCRIPTION
The feature text span x coordinate was always calculated for a centric rendering. This commit fixes it by opening the door