### PR TITLE
Fix definitions of PhysicalComponent nature and kind

### DIFF
--- a/capellambse/model/layers/pa.py
+++ b/capellambse/model/layers/pa.py
@@ -47,9 +47,11 @@ class PhysicalComponent(cs.Component):
 
     _xmltag = "ownedPhysicalComponents"
 
-    nature = c.EnumAttributeProperty("nature", modeltypes.Nature)
+    nature = c.EnumAttributeProperty(
+        "nature", modeltypes.PhysicalComponentNature, default="UNSET"
+    )
     kind = c.EnumAttributeProperty(
-        "kind", modeltypes.Kind, default=modeltypes.Kind.UNSET
+        "kind", modeltypes.PhysicalComponentKind, default="UNSET"
     )
 
     allocated_functions = c.LinkAccessor[PhysicalFunction](

--- a/capellambse/model/modeltypes.py
+++ b/capellambse/model/modeltypes.py
@@ -146,14 +146,15 @@ class ExchangeItemType(_StringyEnumMixin, _enum.Enum):
     SHARED_DATA = _enum.auto()
 
 
-class Nature(_StringyEnumMixin, _enum.Enum):
+class PhysicalComponentNature(_StringyEnumMixin, _enum.Enum):
     r"""The "NATURE" of ``PhysicalComponent``\ s."""
 
+    UNSET = _enum.auto()
     NODE = _enum.auto()
     BEHAVIOR = _enum.auto()
 
 
-class Kind(_StringyEnumMixin, _enum.Enum):
+class PhysicalComponentKind(_StringyEnumMixin, _enum.Enum):
     r"""The "KIND" of ``PhysicalComponent``\ s."""
 
     UNSET = _enum.auto()
@@ -250,3 +251,27 @@ class NumericTypeKind(_StringyEnumMixin, _enum.Enum):
 
     INTEGER = _enum.auto()
     FLOAT = _enum.auto()
+
+
+if not t.TYPE_CHECKING:
+
+    def __getattr__(name: str) -> t.Any:
+        if name == "Kind":
+            import warnings
+
+            warnings.warn(
+                "Kind is deprecated; use PhysicalComponentKind instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return PhysicalComponentKind
+        if name == "Nature":
+            import warnings
+
+            warnings.warn(
+                "Nature is deprecated; use PhysicalComponentNature instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return PhysicalComponentNature
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/test_model_layers.py
+++ b/tests/test_model_layers.py
@@ -903,7 +903,7 @@ class TestArchitectureLayers:
     @pytest.mark.parametrize(
         "nature,uuid",
         [
-            (None, "b9f9a83c-fb02-44f7-9123-9d86326de5f1"),
+            ("UNSET", "b9f9a83c-fb02-44f7-9123-9d86326de5f1"),
             ("NODE", "8a6d68c8-ac3d-4654-a07e-ada7adeed09f"),
             ("BEHAVIOR", "7b188ad0-0d82-4b2c-9913-45292e537871"),
         ],


### PR DESCRIPTION
Somehow `.nature` could return a `None` value. It should default to
`Node`.