### PR TITLE
Treat str indices to ElementList as the special case

### DIFF
--- a/capellambse/model/common/element.py
+++ b/capellambse/model/common/element.py
@@ -666,11 +666,10 @@ class ElementList(cabc.MutableSequence, t.Generic[T]):
     def __getitem__(self, idx: int | slice | str) -> t.Any:
         if isinstance(idx, slice):
             return self._newlist(self._elements[idx])
-        if isinstance(idx, int):
-            return self._elemclass.from_model(self._model, self._elements[idx])
-
-        obj = self._map_find(idx)
-        return self._map_getvalue(obj)
+        if isinstance(idx, str):
+            obj = self._map_find(idx)
+            return self._map_getvalue(obj)
+        return self._elemclass.from_model(self._model, self._elements[idx])
 
     @t.overload
     def __setitem__(self, index: int, value: T) -> None:


### PR DESCRIPTION
When determining which type of indexing is requested for an ElementList (slice, mapping-like or list-like), treat str indices (i.e. mapping-like) as the special case and integer indices as the regular case. This improves compatibility with libraries that provide their own specialized integer classes, which are not subclasses of Python's standard `int`, such as numpy's fixed-size int8/16/32/64.