### PR TITLE
Use correct FunctionalExchange styleclass on OA

### DIFF
--- a/capellambse/aird/_edge_factories.py
+++ b/capellambse/aird/_edge_factories.py
@@ -544,6 +544,15 @@ def eie_factory(seb: C.SemanticElementBuilder) -> diagram.Edge:
     return edge
 
 
+def fex_factory(seb: C.SemanticElementBuilder) -> diagram.Edge:
+    """Create a functional exhcange."""
+    edge = generic_factory(seb)
+    assert edge.styleclass is not None and edge.target is not None
+    if edge.target.styleclass == "OperationalActivity":
+        edge.styleclass = "OperationalExchange"
+    return edge
+
+
 def _guard_condition(seb: C.SemanticElementBuilder, attr: str) -> str:
     """Extract the guard condition's text from the XML."""
     try:

--- a/capellambse/aird/_semantic.py
+++ b/capellambse/aird/_semantic.py
@@ -188,6 +188,7 @@ STYLECLASS_LOOKUP = {
             _box_factories.generic_factory, _edge_factories.labelless_factory
         ),
     ),
+    "FunctionalExchange": ("FunctionalExchange", _edge_factories.fex_factory),
     "FunctionInputPort": ("FIP", _GENERIC_FACTORIES),
     "FunctionOutputPort": ("FOP", _GENERIC_FACTORIES),
     "ForkPseudoState": (

--- a/capellambse/diagram/_styleclass.py
+++ b/capellambse/diagram/_styleclass.py
@@ -71,6 +71,14 @@ def _functional_chain_involvement(obj: model.ModelObject) -> str:
     return styleclass
 
 
+def _functional_exchange(obj: model.ModelObject) -> str:
+    assert isinstance(obj, model.fa.FunctionalExchange)
+    styleclass = _default(obj)
+    if get_styleclass(obj.target) == "OperationalActivity":
+        return styleclass.replace("Functional", "Operational")
+    return styleclass
+
+
 def _generic_component(obj: model.ModelObject) -> str:
     assert isinstance(obj, model.cs.Component)
     styleclass = _default(obj)
@@ -131,6 +139,7 @@ _STYLECLASSES: dict[str, cabc.Callable[[model.ModelObject], str]] = {
     "ControlNode": _control_node,
     "FunctionalChainInvolvementFunction": _functional_chain_involvement,
     "FunctionalChainInvolvementLink": _functional_chain_involvement,
+    "FunctionalExchange": _functional_exchange,
     "FunctionInputPort": lambda _: "FIP",
     "FunctionOutputPort": lambda _: "FOP",
     "LogicalComponent": _generic_component,

--- a/capellambse/diagram/capstyle.py
+++ b/capellambse/diagram/capstyle.py
@@ -699,7 +699,7 @@ STYLES: dict[str, dict[str, dict[str, CSSdef]]] = {
             "marker-end": "ArrowMark",
             "stroke": COLORS["dark_gray"],
         },
-        "Edge.FunctionalExchange": {
+        "Edge.OperationalExchange": {
             "marker-end": "ArrowMark",
             "stroke": COLORS["_CAP_Activity_Border_Orange"],
         },
@@ -717,6 +717,11 @@ STYLES: dict[str, dict[str, dict[str, CSSdef]]] = {
         "Edge.OperationalActor": {
             "marker-end": "FineArrowMark",
             "stroke": COLORS["gray"],
+        },
+        "Edge.OperationalExchange": {
+            "marker-end": "ArrowMark",
+            "stroke-width": 2,
+            "stroke": COLORS["_CAP_Activity_Border_Orange"],
         },
     },
     "Operational Process Description": {
@@ -746,7 +751,7 @@ STYLES: dict[str, dict[str, dict[str, CSSdef]]] = {
             "stroke": COLORS["black"],
             "text_fill": COLORS["black"],
         },
-        "Edge.FunctionalExchange": {
+        "Edge.OperationalExchange": {
             "marker-end": "ArrowMark",
             "stroke-width": 2,
             "stroke": COLORS["_CAP_Activity_Border_Orange"],


### PR DESCRIPTION
The `FunctionalExchange`s in OA diagrams are not styled correctly. This is caused by a faulty/missing styleclass factory and aird factory patching the style class to `OperationalExchange`.

Additionally missing default styles were added.