### PR TITLE
ci: Enforce `pre-commit` version >= 3.2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@
 
 default_install_hook_types: [commit-msg, pre-commit]
 default_stages: [commit, merge-commit]
+minimum_pre_commit_version: 3.2.0
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0


### PR DESCRIPTION
Older pre-commit versions are not compatible with the used pre-commit configuration since the `commit` stage was renamed to `pre-commit`.

This can lead to error messages like:
> Expected one of commit, commit-msg, manual, merge-commit, post-checkout, post-commit, post-merge, post-rewrite, prepare-commit-msg, push but got: 'pre-commit'

With a minimum required version the error messages is clearer.