### PR TITLE
fix: Replace references to deprecated `capella/cli` image

### DIFF
--- a/capellambse/model/__init__.py
+++ b/capellambse/model/__init__.py
@@ -593,10 +593,11 @@ class MelodyModel:
         ...     "/Applications/Capella_{VERSION}.app/Contents/MacOS/capella"
         ... )
 
-        **Running a Capella CLI container**
+        **Running a Capella container**
 
         >>> model.update_diagram_cache(
-        ...     "capella/cli:{VERSION}-latest"
+        ...     "ghcr.io/dsd-dbs/capella-dockerimages/capella/base"
+        ...     ":{VERSION}-selected-dropins-main"
         ... )
         """
         if self.diagram_cache is None:

--- a/ci-templates/gitlab/filter-derive.yml
+++ b/ci-templates/gitlab/filter-derive.yml
@@ -4,7 +4,7 @@
 
 derive:
   image:
-    name: $DOCKER_REGISTRY/capella/cli:${CAPELLA_DOCKER_IMAGES_TAG}
+    name: $DOCKER_REGISTRY/capella/base:${CAPELLA_DOCKER_IMAGES_TAG}
     entrypoint: [""]
 
   script:


### PR DESCRIPTION
The `capella/cli` image in the [capella-dockerimages repository](https://github.com/DSD-DBS/capella-dockerimages) was deprecated in https://github.com/DSD-DBS/capella-dockerimages/pull/152. More information is available in the release notes: https://github.com/DSD-DBS/capella-dockerimages/releases/tag/v1.12.2.

While the old image is still functual, it is no longer built and therefore doesn't receive any new updates.

The `capella/cli` image was replaced with the `capella/base`. The interface is the same.

In addition, I changed one example in the documentation to point to the prebuilt Capella image from the capella-dockerimages repository.