### PR TITLE
Handle resources in write_tmp_project_dir

### DIFF
--- a/capellambse/_diagram_cache.py
+++ b/capellambse/_diagram_cache.py
@@ -90,8 +90,6 @@ def export(
 
     native_args = _find_executor(model, capella, force)
     with _native.native_capella(model, **native_args) as cli:
-        assert cli.project
-
         if refresh:
             cli(
                 *_native.ARGS_CMDLINE,
@@ -112,7 +110,7 @@ def export(
 
         diagrams = _copy_images(
             model,
-            cli.project / "main_model" / "output",
+            cli.workspace / "main_model" / "output",
             diag_cache_dir,
             format,
             background,

--- a/capellambse/extensions/filtering.py
+++ b/capellambse/extensions/filtering.py
@@ -206,7 +206,6 @@ else:
                 results, item_show_func=lambda i: getattr(i, "name", "")
             ) as progress,
         ):
-            assert cli.workspace
             for result in progress:
                 derived_name = name_pattern.format(model=model_, result=result)
                 output_sub = output / derived_name


### PR DESCRIPTION
The 'write_tmp_project_dir' method is now able to create a full workspace structure when more than one resource is involved in a model. Previously, calling this method on a model with loaded resources (i.e. library models) would result in an exception.