### PR TITLE
Implement a "sync" operation for declarative YAML

### DIFF
--- a/capellambse/decl.py
+++ b/capellambse/decl.py
@@ -29,7 +29,6 @@ import dataclasses
 import os
 import sys
 import typing as t
-import warnings
 
 import yaml
 
@@ -139,7 +138,6 @@ def _operate_create(
     parent: capellambse.ModelObject,
     creations: dict[str, t.Any],
 ) -> cabc.Generator[_OperatorResult, t.Any, None]:
-    warnings.warn("Use 'extend' instead of 'create' in declarative YAML")
     yield from _operate_extend(promises, parent, creations)
 
 

--- a/capellambse/decl.py
+++ b/capellambse/decl.py
@@ -107,9 +107,23 @@ def apply(
 
     while instructions:
         instruction = instructions.popleft()
+
         parent = instruction.pop("parent")
         if isinstance(parent, UUIDReference):
             parent = model.by_uuid(parent.uuid)
+        elif isinstance(parent, Promise):
+            if parent in promises:
+                parent = promises[parent]
+            else:
+                deferred[parent].append({"parent": parent, **instruction})
+                continue
+
+        if not isinstance(parent, capellambse.model.GenericElement):
+            raise TypeError(
+                "Expected a model object as parent, found "
+                f"{type(parent).__name__}"
+            )
+
         for op_type, apply_op in _OPERATIONS.items():
             try:
                 op = instruction.pop(op_type)

--- a/capellambse/decl.py
+++ b/capellambse/decl.py
@@ -263,6 +263,8 @@ def _operate_sync(
             if candidate is not None:
                 if mods := obj.pop("set", None):
                     yield from _operate_modify(promises, candidate, mods)
+                if ext := obj.pop("extend", None):
+                    yield from _operate_extend(promises, candidate, ext)
                 promise: str | Promise | None = obj.get("promise_id")
                 if promise is not None:
                     if isinstance(promise, str):

--- a/capellambse/decl.py
+++ b/capellambse/decl.py
@@ -228,7 +228,7 @@ def _operate_modify(
                 continue
 
         if isinstance(value, list):
-            delattr(parent, attr)
+            getattr(parent, attr).clear()
             yield from _create_complex_objects(promises, parent, attr, value)
         elif isinstance(value, dict):
             obj = getattr(parent, attr)

--- a/capellambse/model/common/__init__.py
+++ b/capellambse/model/common/__init__.py
@@ -59,6 +59,23 @@ def build_xtype(class_: type[ModelObject]) -> str:
     return f"{package}{module}:{clsname}"
 
 
+def find_wrapper(typehint: str) -> tuple[type[ModelObject], ...]:
+    """Find the possible wrapper classes for the hinted type.
+
+    The typehint is either a single class name, or a namespace prefix
+    and class name separated by ``:``. This function searches for all
+    known wrapper classes that match the given namespace prefix (if any)
+    and which have the given name, and returns them as a tuple. If no
+    matching wrapper classes are found, an empty tuple is returned.
+    """
+    return tuple(
+        v
+        for i in XTYPE_HANDLERS.values()
+        for k, v in i.items()
+        if k.endswith(f":{typehint}") or k == typehint
+    )
+
+
 def enumliteral(
     generic_element: GenericElement, attr: str, default: str = "NOT_SET"
 ) -> AttributeProperty | str:

--- a/capellambse/model/crosslayer/information/__init__.py
+++ b/capellambse/model/crosslayer/information/__init__.py
@@ -13,6 +13,8 @@ Information object-relations map (ontology):
 
 from __future__ import annotations
 
+import typing as t
+
 from ... import common as c
 from ... import modeltypes
 from .. import capellacommon, capellacore, modellingcore
@@ -90,12 +92,15 @@ class Property(c.GenericElement):
     )
     type = c.AttrProxyAccessor(c.GenericElement, "abstractType")
     default_value = c.RoleTagAccessor("ownedDefaultValue")
-    min = c.RoleTagAccessor("ownedMinValue")
-    max = c.RoleTagAccessor("ownedMaxValue")
+    min_value = c.RoleTagAccessor("ownedMinValue")
+    max_value = c.RoleTagAccessor("ownedMaxValue")
     null_value = c.RoleTagAccessor("ownedNullValue")
     min_card = c.RoleTagAccessor("ownedMinCard")
     max_card = c.RoleTagAccessor("ownedMaxCard")
     association = c.ReferenceSearchingAccessor(Association, "roles")
+
+    min = c.DeprecatedAccessor[t.Any]("min_value")
+    max = c.DeprecatedAccessor[t.Any]("max_value")
 
 
 @c.xtype_handler(None)

--- a/capellambse/svg/drawing.py
+++ b/capellambse/svg/drawing.py
@@ -53,7 +53,7 @@ class Drawing:
         superparams = {
             "cursor": "pointer",
             "filename": f"{metadata.name}.svg",
-            "font-family": "Open Sans",
+            "font-family": "'Open Sans','Segoe UI',Arial,sans-serif",
             "font-size": "8px",
             "shape-rendering": "geometricPrecision",
             "size": metadata.size,

--- a/capellambse/svg/symbols.py
+++ b/capellambse/svg/symbols.py
@@ -511,7 +511,7 @@ def function_symbol(
             text=label,
             insert=(42.2, 38),
             text_anchor="middle",
-            font_family="Open Sans",
+            font_family="'Open Sans','Segoe UI',Arial,sans-serif",
             font_size="16px",
             font_weight="bold",
             fill="#000",

--- a/docs/source/start/declarative.rst
+++ b/docs/source/start/declarative.rst
@@ -73,7 +73,8 @@ object that already exists in the model) is selected, and one or more of three
 different operations is applied to it:
 
 - ``extend``-ing the object on list attributes,
-- ``modify``-ing the object itself, or
+- ``modify``-ing the object itself,
+- ``sync``-ing objects into the model, or
 - ``delete``-ing one or more children.
 
 Selecting a parent
@@ -279,6 +280,42 @@ e.g. numeric properties. This example changes the ``min_card`` property of an
      modify:
        min_card: 0
        max_card: .inf
+
+Synchronizing objects
+---------------------
+
+The ``sync:`` key is a combination of the above ``extend:`` and ``modify:``
+keys. Using it, it is possible to modify objects that already exist, or create
+new objects if they don't exist yet.
+
+Unlike the other keys however, ``sync:`` takes two sets of attributs: one that
+is used to find a matching object (using the ``find:`` key), and one that is
+only used to set values once the object of interest was found (using the
+``set:`` key).
+
+This operation also supports Promise IDs, which are resolved either using the
+found existing object or the newly created one.
+
+The following snippet ensures that the root LogicalFunction contains a
+subfunction "brew coffee" with the given description. A function named "brew
+coffee" will be used if it already exists, but if not, a new one will be
+created. In either case, the used function will resolve the "brew-coffee"
+promise, which can be used to reference it elsewhere:
+
+.. code-block:: yaml
+
+   - parent: !uuid f28ec0f8-f3b3-43a0-8af7-79f194b29a2d  # the root function
+     sync:
+       functions:
+         - find:
+             name: brew coffee
+           set:
+             description: This function brews coffee.
+           promise_id: brew-coffee
+   - parent: !uuid 0d2edb8f-fa34-4e73-89ec-fb9a63001440  # the root component
+     extend:
+       allocated_functions:
+         - !promise brew-coffee
 
 Deleting objects
 ----------------

--- a/docs/source/start/declarative.rst
+++ b/docs/source/start/declarative.rst
@@ -76,13 +76,44 @@ different operations is applied to it:
 - ``modify``-ing the object itself, or
 - ``delete``-ing one or more children.
 
-Parents can be selected by their universally unique ID (UUID), using the
-``!uuid`` YAML tag. The following query selects the root logical function in
-our test model:
+Selecting a parent
+------------------
+
+There are a few ways to select a parent object from the model.
+
+The most straight-forward way is to use the universally unique ID (UUID), using
+the ``!uuid`` YAML tag. The following query selects the root logical function
+in our test model:
 
 .. code-block:: yaml
 
    - parent: !uuid f28ec0f8-f3b3-43a0-8af7-79f194b29a2d
+
+A more versatile way involves the ``!find`` YAML tag, which allows specifying a
+set of attributes in order to filter down to a single model element. This tag
+simply takes a mapping of all the attributes to select for. This usually also
+involves the element's type (or class), which is selectable with the ``_type``
+attribute:
+
+.. code-block:: yaml
+
+   - parent: !find
+       _type: LogicalFunction
+     # ^-- note the leading underscore, to disambiguate from the "type"
+     # property that exists on some model elements
+       name: Root Logical Function
+     modify: [...]
+
+The ``!find`` tag also supports dot-notation for filtering on nested
+attributes.
+
+.. code-block:: yaml
+
+   - parent: !find
+       _type: FunctionOutputPort
+       name: FOP 1
+       owner.name: manage the school
+     modify: [...]
 
 Extending objects
 -----------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Global fixtures for pytest."""
 import collections.abc as cabc
+import importlib.metadata as imm
 import io
 import pathlib
 import sys
@@ -16,6 +17,15 @@ TEST_ROOT = pathlib.Path(__file__).parent / "data" / "melodymodel"
 TEST_MODEL = "Melody Model Test.aird"
 
 capellambse.load_model_extensions()
+
+if not any(
+    i.module.startswith("capellambse.extensions.")
+    for i in imm.entry_points(group="capellambse.model_extensions")
+):
+    raise RuntimeError(
+        "Built-in model extensions are not loaded,"
+        " is capellambse installed properly?"
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/data/melodymodel/5_0/Melody Model Test.aird
+++ b/tests/data/melodymodel/5_0/Melody Model Test.aird
@@ -5414,7 +5414,7 @@
       </ownedStyle>
       <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Function%20Breakdown']/@defaultLayer/@nodeMappings[name='LFB_LogicalFunction']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNode" uid="__dHVZtZLEeqiU8uzTY0Puw" name="teach  Potions" outgoingEdges="_QXRX0EhQEeyVkeSUJyVgbw" width="7" height="7" resizeKind="NSEW">
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="__dHVZtZLEeqiU8uzTY0Puw" name="teach Potions" outgoingEdges="_QXRX0EhQEeyVkeSUJyVgbw" width="7" height="7" resizeKind="NSEW">
       <target xmi:type="org.polarsys.capella.core.data.la:LogicalFunction" href="Melody%20Model%20Test.capella#a7acb298-d14b-4707-a419-fea272434541"/>
       <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalFunction" href="Melody%20Model%20Test.capella#a7acb298-d14b-4707-a419-fea272434541"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
@@ -9587,7 +9587,7 @@
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Data%20Flow%20Blank']/@defaultLayer/@containerMappings[name='LDFB_Function']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Y4_NcgATEeykFulkDFvkrg" name="teach  Potions">
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Y4_NcgATEeykFulkDFvkrg" name="teach Potions">
         <target xmi:type="org.polarsys.capella.core.data.la:LogicalFunction" href="Melody%20Model%20Test.capella#a7acb298-d14b-4707-a419-fea272434541"/>
         <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalFunction" href="Melody%20Model%20Test.capella#a7acb298-d14b-4707-a419-fea272434541"/>
         <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Y4_NdQATEeykFulkDFvkrg" name="FOP 1" width="1" height="1">
@@ -13699,7 +13699,7 @@
       </ownedStyle>
       <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNode" uid="_TmY_o3PIEeyW3OIB4qRWZA" name="teach  Potions" visible="false" width="10" height="5" resizeKind="NSEW">
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_TmY_o3PIEeyW3OIB4qRWZA" name="teach Potions" visible="false" width="10" height="5" resizeKind="NSEW">
       <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="Melody%20Model%20Test.capella#8d80bc57-be92-47db-8a53-0dd2b518f6f6"/>
       <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="Melody%20Model%20Test.capella#8d80bc57-be92-47db-8a53-0dd2b518f6f6"/>
       <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalFunction" href="Melody%20Model%20Test.capella#a7acb298-d14b-4707-a419-fea272434541"/>

--- a/tests/data/melodymodel/5_0/Melody Model Test.capella
+++ b/tests/data/melodymodel/5_0/Melody Model Test.capella
@@ -2340,7 +2340,7 @@ The predator is far away</bodies>
             <ownedFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
                 id="24d3e25a-5399-4374-aa85-8a4fd2b2a815" name="teach Care of Magical Creatures"/>
             <ownedFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
-                id="83ba0220-54f2-48f7-bca1-cd87e39639f2" name="teach  Potions">
+                id="83ba0220-54f2-48f7-bca1-cd87e39639f2" name="teach Potions">
               <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
                   id="a88ff724-b8af-4609-8142-550a9aaabc78" name="FOP 1"/>
             </ownedFunctions>

--- a/tests/data/melodymodel/5_2/Melody Model Test.aird
+++ b/tests/data/melodymodel/5_2/Melody Model Test.aird
@@ -3204,7 +3204,7 @@
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@conditionnalStyles.0/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
-      <ownedDiagramElements xmi:type="diagram:DNode" uid="_aDTsMrCBEeqLtsTDMgEHBw" name="teach  Potions" width="5" height="5" resizeKind="NSEW">
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_aDTsMrCBEeqLtsTDMgEHBw" name="teach Potions" width="5" height="5" resizeKind="NSEW">
         <target xmi:type="org.polarsys.capella.core.data.la:LogicalFunction" href="Melody%20Model%20Test.capella#a7acb298-d14b-4707-a419-fea272434541"/>
         <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalFunction" href="Melody%20Model%20Test.capella#a7acb298-d14b-4707-a419-fea272434541"/>
         <ownedBorderedNodes xmi:type="diagram:DNode" uid="_gQ9V8MEDEeqW8_YksX3uDg" name="FOP 1" outgoingEdges="_RmRSwMTrEeqlbN5fRfdrWQ" incomingEdges="_E2dxpUhREeyVkeSUJyVgbw" width="1" height="1">
@@ -5370,7 +5370,7 @@
       </ownedStyle>
       <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Function%20Breakdown']/@defaultLayer/@nodeMappings[name='LFB_LogicalFunction']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNode" uid="_fbhgxEybEeyns9TdzUL1Ow" name="teach  Potions" outgoingEdges="_CPCP_OMeEeyfMuvLtydCpg" width="7" height="7" resizeKind="NSEW">
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_fbhgxEybEeyns9TdzUL1Ow" name="teach Potions" outgoingEdges="_CPCP_OMeEeyfMuvLtydCpg" width="7" height="7" resizeKind="NSEW">
       <target xmi:type="org.polarsys.capella.core.data.la:LogicalFunction" href="Melody%20Model%20Test.capella#a7acb298-d14b-4707-a419-fea272434541"/>
       <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalFunction" href="Melody%20Model%20Test.capella#a7acb298-d14b-4707-a419-fea272434541"/>
       <ownedStyle xmi:type="diagram:Square" uid="_CPBB2-MeEeyfMuvLtydCpg" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" labelPosition="node" color="198,230,255">
@@ -5476,7 +5476,7 @@
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Function%20Breakdown']/@defaultLayer/@edgeMappings[name='LFB_LogicalFunction_subFunctions']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNode" uid="__dHVZtZLEeqiU8uzTY0Puw" name="teach  Potions" outgoingEdges="_QXRX0EhQEeyVkeSUJyVgbw" width="7" height="7" resizeKind="NSEW">
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="__dHVZtZLEeqiU8uzTY0Puw" name="teach Potions" outgoingEdges="_QXRX0EhQEeyVkeSUJyVgbw" width="7" height="7" resizeKind="NSEW">
       <target xmi:type="org.polarsys.capella.core.data.la:LogicalFunction" href="Melody%20Model%20Test.capella#a7acb298-d14b-4707-a419-fea272434541"/>
       <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalFunction" href="Melody%20Model%20Test.capella#a7acb298-d14b-4707-a419-fea272434541"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
@@ -8507,7 +8507,7 @@
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Data%20Flow%20Blank']/@defaultLayer/@containerMappings[name='LDFB_Function']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Y4_NcgATEeykFulkDFvkrg" name="teach  Potions">
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Y4_NcgATEeykFulkDFvkrg" name="teach Potions">
         <target xmi:type="org.polarsys.capella.core.data.la:LogicalFunction" href="Melody%20Model%20Test.capella#a7acb298-d14b-4707-a419-fea272434541"/>
         <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalFunction" href="Melody%20Model%20Test.capella#a7acb298-d14b-4707-a419-fea272434541"/>
         <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Y4_NdQATEeykFulkDFvkrg" name="FOP 1" width="1" height="1">
@@ -12429,7 +12429,7 @@
       </ownedStyle>
       <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNode" uid="_TmY_o3PIEeyW3OIB4qRWZA" name="teach  Potions" visible="false" width="10" height="5" resizeKind="NSEW">
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_TmY_o3PIEeyW3OIB4qRWZA" name="teach Potions" visible="false" width="10" height="5" resizeKind="NSEW">
       <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="Melody%20Model%20Test.capella#8d80bc57-be92-47db-8a53-0dd2b518f6f6"/>
       <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="Melody%20Model%20Test.capella#8d80bc57-be92-47db-8a53-0dd2b518f6f6"/>
       <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalFunction" href="Melody%20Model%20Test.capella#a7acb298-d14b-4707-a419-fea272434541"/>

--- a/tests/data/melodymodel/5_2/Melody Model Test.capella
+++ b/tests/data/melodymodel/5_2/Melody Model Test.capella
@@ -2189,7 +2189,7 @@ The predator is far away</bodies>
             <ownedFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
                 id="24d3e25a-5399-4374-aa85-8a4fd2b2a815" name="teach Care of Magical Creatures"/>
             <ownedFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
-                id="83ba0220-54f2-48f7-bca1-cd87e39639f2" name="teach  Potions">
+                id="83ba0220-54f2-48f7-bca1-cd87e39639f2" name="teach Potions">
               <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
                   id="a88ff724-b8af-4609-8142-550a9aaabc78" name="FOP 1"/>
             </ownedFunctions>

--- a/tests/data/melodymodel/6_0/Melody Model Test.aird
+++ b/tests/data/melodymodel/6_0/Melody Model Test.aird
@@ -5383,7 +5383,7 @@
       </ownedStyle>
       <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Function%20Breakdown']/@defaultLayer/@nodeMappings[name='LFB_LogicalFunction']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNode" uid="_24ZiJ2weEe6E1o-WT31uyg" name="teach  Potions" outgoingEdges="_24b-amweEe6E1o-WT31uyg" width="7" height="7" resizeKind="NSEW">
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_24ZiJ2weEe6E1o-WT31uyg" name="teach Potions" outgoingEdges="_24b-amweEe6E1o-WT31uyg" width="7" height="7" resizeKind="NSEW">
       <target xmi:type="org.polarsys.capella.core.data.la:LogicalFunction" href="Melody%20Model%20Test.capella#83ba0220-54f2-48f7-bca1-cd87e39639f2"/>
       <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalFunction" href="Melody%20Model%20Test.capella#83ba0220-54f2-48f7-bca1-cd87e39639f2"/>
       <ownedStyle xmi:type="diagram:Square" uid="_24ZiKGweEe6E1o-WT31uyg" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" color="197,255,166">
@@ -12532,7 +12532,7 @@
       </ownedStyle>
       <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNode" uid="_TmY_o3PIEeyW3OIB4qRWZA" name="teach  Potions" visible="false" width="10" height="5" resizeKind="NSEW">
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_TmY_o3PIEeyW3OIB4qRWZA" name="teach Potions" visible="false" width="10" height="5" resizeKind="NSEW">
       <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="Melody%20Model%20Test.capella#8d80bc57-be92-47db-8a53-0dd2b518f6f6"/>
       <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="Melody%20Model%20Test.capella#8d80bc57-be92-47db-8a53-0dd2b518f6f6"/>
       <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalFunction" href="Melody%20Model%20Test.capella#a7acb298-d14b-4707-a419-fea272434541"/>

--- a/tests/data/melodymodel/6_0/Melody Model Test.capella
+++ b/tests/data/melodymodel/6_0/Melody Model Test.capella
@@ -2187,7 +2187,7 @@ The predator is far away</bodies>
             <ownedFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
                 id="24d3e25a-5399-4374-aa85-8a4fd2b2a815" name="teach Care of Magical Creatures"/>
             <ownedFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
-                id="83ba0220-54f2-48f7-bca1-cd87e39639f2" name="teach  Potions">
+                id="83ba0220-54f2-48f7-bca1-cd87e39639f2" name="teach Potions">
               <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
                   id="a88ff724-b8af-4609-8142-550a9aaabc78" name="FOP 1"/>
             </ownedFunctions>

--- a/tests/test_decl.py
+++ b/tests/test_decl.py
@@ -427,6 +427,31 @@ class TestApplyPromises:
         with pytest.raises(decl.UnfulfilledPromisesError, match="^pass-test$"):
             decl.apply(model, io.StringIO(yml))
 
+    @staticmethod
+    def test_promises_are_resolved_for_parent_objects(
+        model: capellambse.MelodyModel,
+    ) -> None:
+        yml = f"""\
+            - parent: !promise pass-test
+              modify:
+                name: pass the unit test
+            - parent: !uuid {ROOT_FUNCTION}
+              extend:
+                functions:
+                  - promise_id: pass-test
+            - parent: !promise pass-test
+              modify:
+                description: Makes sure that the test passes.
+            """
+
+        resolved = decl.apply(model, io.StringIO(yml))
+
+        assert decl.Promise("pass-test") in resolved
+        func = resolved[decl.Promise("pass-test")]
+        assert isinstance(func, capellambse.model.la.LogicalFunction)
+        assert func.name == "pass the unit test"
+        assert func.description == "Makes sure that the test passes."
+
 
 class TestApplyModify:
     @staticmethod

--- a/tests/test_decl.py
+++ b/tests/test_decl.py
@@ -679,6 +679,30 @@ class TestApplySync:
         assert old_port in subfunc.inputs
 
     @staticmethod
+    def test_sync_operation_recursive(model: capellambse.MelodyModel) -> None:
+        root_package = model.la.data_package
+        package_name = "The new package"
+        subpackage_name = "The new subpackage"
+        assert package_name not in root_package.packages.by_name
+        yml = f"""\
+            - parent: !uuid {root_package.uuid}
+              sync:
+                packages:
+                  - find:
+                      name: "{package_name}"
+                    sync:
+                      packages:
+                        - find:
+                            name: {subpackage_name}
+
+            """
+
+        decl.apply(model, io.StringIO(yml))
+        assert package_name in root_package.packages.by_name
+        package = root_package.packages.by_name(package_name)
+        assert subpackage_name in package.packages.by_name
+
+    @staticmethod
     def test_sync_operation_creates_a_new_object_if_it_didnt_find_a_match(
         model: capellambse.MelodyModel,
     ) -> None:

--- a/tests/test_decl.py
+++ b/tests/test_decl.py
@@ -26,6 +26,7 @@ MODELPATH = pathlib.Path(TEST_ROOT / "5_0")
 
 ROOT_COMPONENT = helpers.UUIDString("0d2edb8f-fa34-4e73-89ec-fb9a63001440")
 ROOT_FUNCTION = helpers.UUIDString("f28ec0f8-f3b3-43a0-8af7-79f194b29a2d")
+TEACH_POTIONS_FUNC = helpers.UUIDString("83ba0220-54f2-48f7-bca1-cd87e39639f2")
 
 
 class TestDumpLoad:
@@ -85,18 +86,19 @@ class TestApplyExtend:
 
     @staticmethod
     @pytest.mark.parametrize(
-        ["parent_str", "parent_getter"],
+        ["parent_str"],
         [
+            pytest.param(f"!uuid {TEACH_POTIONS_FUNC}", id="!uuid"),
             pytest.param(
-                f"!uuid {ROOT_FUNCTION}",
-                lambda m: m.by_uuid(ROOT_FUNCTION),
-                id="!uuid",
+                "!find {_type: LogicalFunction, name: teach Potions}",
+                id="!find",
             ),
         ],
     )
     def test_decl_finds_parent_to_act_on(
-        model: capellambse.MelodyModel, parent_str, parent_getter
+        model: capellambse.MelodyModel, parent_str
     ) -> None:
+        parent = model.by_uuid(TEACH_POTIONS_FUNC)
         funcname = "pass the unit test"
         yml = f"""\
             - parent: {parent_str}
@@ -105,13 +107,13 @@ class TestApplyExtend:
                   - name: {funcname!r}
             """
         expected_len = len(model.search()) + 1
-        assert funcname not in parent_getter(model).functions.by_name
+        assert funcname not in parent.functions.by_name
 
         decl.apply(model, io.StringIO(yml))
 
         actual_len = len(model.search())
         assert actual_len == expected_len
-        assert funcname in parent_getter(model).functions.by_name
+        assert funcname in parent.functions.by_name
 
     @staticmethod
     def test_decl_creates_each_object_in_a_list(


### PR DESCRIPTION
This aims at making it easier to implement synchronization between a Capella model and other sources of information. With the currently possible operations (create/extend, modify and delete), a lot of manual logic is necessary to find objects that already exist and need to be updated with new content. `sync` aims to abstract that logic out into the common denominator that is `decl` itself.