### PR TITLE
Declarative: Rename modify to set

### DIFF
--- a/capellambse/decl.py
+++ b/capellambse/decl.py
@@ -219,6 +219,17 @@ def _operate_modify(
     parent: capellambse.ModelObject,
     modifications: dict[str, t.Any],
 ) -> cabc.Generator[_OperatorResult, t.Any, None]:
+    import warnings
+
+    warnings.warn("The 'modify' key has been deprecated, use 'set' instead")
+    yield from _operate_set(promises, parent, modifications)
+
+
+def _operate_set(
+    promises: dict[Promise, capellambse.ModelObject],
+    parent: capellambse.ModelObject,
+    modifications: dict[str, t.Any],
+) -> cabc.Generator[_OperatorResult, t.Any, None]:
     for attr, value in modifications.items():
         if isinstance(value, (list, Promise, _ObjectFinder)):
             try:
@@ -264,7 +275,7 @@ def _operate_sync(
                 if sync := obj.pop("sync", None):
                     yield from _operate_sync(promises, candidate, sync)
                 if mods := obj.pop("set", None):
-                    yield from _operate_modify(promises, candidate, mods)
+                    yield from _operate_set(promises, candidate, mods)
                 if ext := obj.pop("extend", None):
                     yield from _operate_extend(promises, candidate, ext)
                 promise: str | Promise | None = obj.get("promise_id")
@@ -382,6 +393,7 @@ _OPERATIONS = collections.OrderedDict(
         ("create", _operate_create),
         ("extend", _operate_extend),
         ("modify", _operate_modify),
+        ("set", _operate_set),
         ("sync", _operate_sync),
         ("delete", _operate_delete),
     )

--- a/docs/source/start/declarative.rst
+++ b/docs/source/start/declarative.rst
@@ -73,7 +73,7 @@ object that already exists in the model) is selected, and one or more of three
 different operations is applied to it:
 
 - ``extend``-ing the object on list attributes,
-- ``modify``-ing the object itself,
+- ``set``-ting properties on the object itself,
 - ``sync``-ing objects into the model, or
 - ``delete``-ing one or more children.
 
@@ -103,7 +103,7 @@ attribute:
      # ^-- note the leading underscore, to disambiguate from the "type"
      # property that exists on some model elements
        name: Root Logical Function
-     modify: [...]
+     set: [...]
 
 The ``!find`` tag also supports dot-notation for filtering on nested
 attributes.
@@ -114,7 +114,7 @@ attributes.
        _type: FunctionOutputPort
        name: FOP 1
        owner.name: manage the school
-     modify: [...]
+     set: [...]
 
 Extending objects
 -----------------
@@ -250,12 +250,12 @@ since the ``functions`` attribute has a parent/children relationship (i.e. the
        functions:
          - !uuid 8833d2dc-b862-4a50-b26c-6f7e0f17faef
 
-Modifying objects
------------------
+Setting properties
+------------------
 
 After selecting a parent, it is also possible to directly change its properties
 without introducing new objects into the model. This happens by specifying the
-attributes in the ``modify:`` key.
+attributes in the ``set:`` key.
 
 The following example would change the ``name`` of the root
 :py:class:`~capellambse.model.layers.la.LogicalComponent` to "Coffee Machine"
@@ -265,7 +265,7 @@ The following example would change the ``name`` of the root
    :emphasize-lines: 2
 
    - parent: !uuid 0d2edb8f-fa34-4e73-89ec-fb9a63001440
-     modify:
+     set:
        name: Coffee Machine
 
 This is not limited to string attributes; it is just as well possible to change
@@ -277,16 +277,16 @@ e.g. numeric properties. This example changes the ``min_card`` property of an
    :emphasize-lines: 3-
 
    - parent: !uuid 81b87fcc-03cf-434b-ad5b-ef18266c5a3e
-     modify:
+     set:
        min_card: 0
        max_card: .inf
 
 Synchronizing objects
 ---------------------
 
-The ``sync:`` key is a combination of the above ``extend:`` and ``modify:``
-keys. Using it, it is possible to modify objects that already exist, or create
-new objects if they don't exist yet.
+The ``sync:`` key is a combination of the above ``extend:`` and ``set:`` keys.
+Using it, it is possible to modify objects that already exist, or create new
+objects if they don't exist yet.
 
 Unlike the other keys however, ``sync:`` takes two sets of attributs: one that
 is used to find a matching object (using the ``find:`` key), and one that is


### PR DESCRIPTION
~~sync set should be called sync modify~~ modify should be called set. it's weird that it has to be:
```
- parent: !uuid blahblah
  modify:
    description: "hey"
```
for parent, but for find it's:
```
- find:
    name: blah
  set:
    description: "hey"
```
even though they both do the same thing.

it should instead be:
```
- parent: !uuid blahblah
  set:
    description: "hey"
```