### PR TITLE
Add missing Capella nature in test project

### DIFF
--- a/tests/data/melodymodel/6_0/.project
+++ b/tests/data/melodymodel/6_0/.project
@@ -7,5 +7,6 @@
 	<buildSpec>
 	</buildSpec>
 	<natures>
+		<nature>org.polarsys.capella.project.nature</nature>
 	</natures>
 </projectDescription>


### PR DESCRIPTION
All test projects must at least list the Capella project nature to serve as Capella test project. If this nature is missing, it is just a general (generic) Eclipse project.
This is especially of relevance, when using the Java API of Capella since many basic Capella API calls cannot be used. The nature is also needed to work with the Capella perspective in Eclipse.