### PR TITLE
Ignore labels with transforms from bounds calculation

### DIFF
--- a/capellambse/diagram/_diagram.py
+++ b/capellambse/diagram/_diagram.py
@@ -456,15 +456,25 @@ class Box:
 
     @property
     def bounds(self) -> Box:
-        """Calculate the bounding box of this Box."""
+        """Calculate the bounding box of this Box.
+
+        Notes
+        -----
+        Labels with a `text_transform` in its `styleoverrides` are
+        ignored during bounds calculation.
+        """
         minx, miny = self.pos
         maxx, maxy = self.pos + self.size
+        if self.styleoverrides.get("text_transform") is not None:
+            return Box((minx, miny), (maxx - minx, maxy - miny))
+
         for label in self.floating_labels:
             if isinstance(label, Box) and not self.hidelabel:
                 minx = min(minx, label.pos.x)
                 miny = min(miny, label.pos.y)
                 maxx = max(maxx, label.pos.x + label.size.x)
                 maxy = max(maxy, label.pos.y + label.size.y)
+
         return Box((minx, miny), (maxx - minx, maxy - miny))
 
     @property


### PR DESCRIPTION
Text transforms are used for translations and rotations. Right now we only use rotations, such that positions can be very large since they are transformed anyways. I propose to trust the user with the calculated points instead of checking them during our calculations.

**_This is needed to fix unnecessary whitespace in realization view diagrams in the [context-diagrams extension #90](https://github.com/DSD-DBS/capellambse-context-diagrams/pull/90)._**