### PR TITLE
Lax ID duplication checking within `aird` fragments

### DIFF
--- a/capellambse/loader/core.py
+++ b/capellambse/loader/core.py
@@ -195,7 +195,9 @@ class ModelFile:
     ) -> None:
         self.filename = filename
         self.filehandler = handler
-        self.__ignore_uuid_dups = ignore_uuid_dups
+        self.__ignore_uuid_dups = (
+            ignore_uuid_dups or self.fragment_type is FragmentType.VISUAL
+        )
         _verify_extension(filename)
 
         with handler.open(filename) as f:


### PR DESCRIPTION
Being strict about UUID duplication within `.aird` fragments, while in theory probably a good idea, in practice just became a hassle. It's too common for the ID algorithm used there to accidentally produce duplicates, and they're much less harmful than ones in `.capella` fragments (worst case, some styling would be wrong on a diagram).

This commit therefore changes the duplication check to only warn about duplication within these visual-only fragments, instead of raising an exception about it.

Resolves #414.