### PR TITLE
reqif: Ignore one-sided relations

### DIFF
--- a/capellambse/extensions/reqif/_capellareq.py
+++ b/capellambse/extensions/reqif/_capellareq.py
@@ -346,6 +346,8 @@ class ElementRelationAccessor(
             rq.InternalRelation,
             CapellaOutgoingRelation,
         ):
+            if None in (relation.source, relation.target):
+                continue
             if obj in (relation.source, relation.target):
                 relations.append(relation._element)
         rv = self._make_list(obj, relations)

--- a/capellambse/model/common/element.py
+++ b/capellambse/model/common/element.py
@@ -556,6 +556,7 @@ class ElementList(cabc.MutableSequence, t.Generic[T]):
         mapkey: str | None = None,
         mapvalue: str | None = None,
     ) -> None:
+        assert None not in elements
         self._model = model
         self._elements = elements
         if elemclass is not None:


### PR DESCRIPTION
This fixes an issue where relations that have only a source or only a target would insert unexpected Nones when enumerating related elements. When enumerating relation objects themselves, they show up as usual.