### PR TITLE
fix(model): Fix `Interface` `exchange_item_allocations`

### DIFF
--- a/capellambse/model/crosslayer/cs.py
+++ b/capellambse/model/crosslayer/cs.py
@@ -44,7 +44,9 @@ class ExchangeItemAllocation(c.GenericElement):
 class Interface(c.GenericElement):
     """An interface."""
 
-    exchange_item_allocations = c.DirectProxyAccessor(ExchangeItemAllocation)
+    exchange_item_allocations = c.DirectProxyAccessor(
+        ExchangeItemAllocation, aslist=c.ElementList
+    )
 
 
 @c.xtype_handler(None)


### PR DESCRIPTION
There can be multiple `exchange_item_allocations` as the name suggests.