### PR TITLE
ci: Only trigger pypi push on release tag

### DIFF
--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -85,7 +85,7 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: [build, test]
-    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
+    if: startsWith(github.ref, 'refs/tags/v')
     environment:
       name: pypi
       url: https://pypi.org/project/capellambse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -269,4 +269,3 @@ include = ["capellambse", "capellambse.*"]
 
 [tool.setuptools_scm]
 # This section must exist for setuptools_scm to work
-local_scheme = "no-local-version"


### PR DESCRIPTION
The pipeline on master is unsuccessful because only non-dev versions can be uploaded to PyPI. This fixes the situation by only triggering the pypi stage when a release tag was created.