### PR TITLE
Ignore Sphinx errors on master builds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Auto-generate APIDOC sources
         run: make -C docs apidoc
       - name: Create docs
+        env:
+          SPHINXOPTS: ${{ github.ref != 'refs/heads/master' && '-W' || '' }}
         run: make -C docs html
       - name: Upload built docs as artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Use `-W` to Sphinx only when building on pull requests, but not master. This allows to easily catch new warnings during PRs, while still allowing to ignore them for a while and keep up to date documentation built for master in most cases.