### PR TITLE
fix: Add icons and multiplicity to class diagrams

### DIFF
--- a/capellambse/aird/_edge_factories.py
+++ b/capellambse/aird/_edge_factories.py
@@ -388,6 +388,19 @@ def _construct_labels(
             int(layout.attrib.get("height", "0")),
         )
 
+        if melodyobj.tag == "ownedFeatures" and len(melodyobj) == 2:
+            start, end = melodyobj
+            if (start.get("value", "1") != "1") or (
+                end.get("value", "1") != "1"
+            ):
+                if start.tag != "ownedMinCard":
+                    max, min = start.get("value"), end.get("value")
+                else:
+                    min, max = start.get("value"), end.get("value")
+                mult = f"[{min}..{max}] "
+                labeltext = mult + labeltext
+                label_pos -= diagram.Vector2D(helpers.extent_func(mult)[0], 0)
+
         # Rotate the position vector into place
         label_pos = label_pos.rotatedby(travel_direction.angleto((1, 0)))
 

--- a/capellambse/diagram/_icons.py
+++ b/capellambse/diagram/_icons.py
@@ -955,6 +955,94 @@ def _class_symbol() -> container.Symbol:
 
 
 @_factory()
+def _class_feature_symbol() -> container.Symbol:
+    symb = container.Symbol(id="ClassFeatureSymbol", viewBox="0 0 27 21")
+    grad_id = "ClassFeatureSymbol-gradient"
+    symb.add(_make_lgradient(grad_id, stop_colors=("#cfa6a5", "#f1e2e3")))
+    grp = symb.add(container.Group())
+    grp.add(shapes.Rect(insert=(7, 4), fill="#913734", size=(17, 11.5)))
+    grp.add(
+        shapes.Rect(insert=(7, 5), size=(17, 9.5), fill=f"url(#{grad_id})")
+    )
+    grp.add(
+        shapes.Circle(
+            center=(20.7, 12.1),
+            r=4.1,
+            fill="#f1e2e3",
+            stroke="#913734",
+            stroke_width=1,
+        )
+    )
+    return symb
+
+
+@_factory()
+def _enumeration_symbol() -> container.Symbol:
+    symb = container.Symbol(id="EnumerationSymbol", viewBox="0 0 25 20")
+    grad_id = "EnumerationSymbol-gradient"
+    symb.add(_make_lgradient(grad_id, stop_colors=("#cfa6a5", "#f1e2e3")))
+    grp = symb.add(container.Group(stroke="#913734"))
+    grp.add(shapes.Rect(insert=(5, 13), size=(15, 3.5), fill="#eedcdd"))
+    grp.add(shapes.Rect(insert=(5, 4), size=(15, 9), fill=f"url(#{grad_id})"))
+    letters = container.Group(
+        transform="scale(0.3,0.3) translate(20, 16)",
+        stroke="#000",
+        stroke_width=1.5,
+    )
+    d1 = (
+        "M 4.25 17.4 L 0 17.6 L 0 15.6 L 3.375 15.475 L 3.375 2.65 "
+        "L 0.25 2.875 L 0.25 1 L 5.625 0 L 5.625 15.475 L 8.5 15.6 "
+        "L 8.5 17.6 L 4.25 17.4 Z"
+    )
+    letters.add(path.Path(d=d1))
+    d2 = (
+        "M 13.375 15.5 L 24.625 15.5 L 24.625 17.5 L 11.125 17.5 "
+        "L 11.125 8.7 L 22.375 7.45 L 22.375 2 L 11.375 2 L 11.375 0 "
+        "L 22.625 0 L 24.625 2 L 24.625 9.125 L 13.375 10.375 L 13.375 15.5 Z"
+    )
+    letters.add(path.Path(d=d2, transform="translate(1, 3)"))
+    d3 = (
+        "M 40.375 15.5 L 38.375 17.5 L 26.875 17.5 L 26.875 15.5 "
+        "L 38.125 15.5 L 38.125 9.5 L 28.375 9.5 L 28.375 7.5 L 37.625 7.5 "
+        "L 37.625 2 L 27.125 2 L 27.125 0 L 37.875 0 L 39.875 2 "
+        "L 39.875 7.275 L 38.45 8.35 L 40.375 9.85 L 40.375 15.5 Z"
+    )
+    letters.add(path.Path(d=d3, transform="translate(3, 6)"))
+    symb.add(letters)
+    return symb
+
+
+@_factory()
+def _enumeration_feature_symbol() -> container.Symbol:
+    symb = container.Symbol(id="EnumerationFeatureSymbol", viewBox="0 0 27 21")
+    grad_id = "EnumerationFeatureSymbol-gradient"
+    symb.add(_make_lgradient(grad_id, stop_colors=("#cfa6a5", "#f1e2e3")))
+    grp = symb.add(container.Group())
+    grp.add(shapes.Rect(insert=(7, 4), fill="#913734", size=(17, 11.5)))
+    grp.add(
+        shapes.Rect(insert=(7, 5), size=(17, 9.5), fill=f"url(#{grad_id})")
+    )
+    letters = container.Group(
+        transform="scale(0.4,0.4) translate(24, 15.5)",
+        stroke="#000",
+        stroke_width=1.5,
+    )
+    d1 = (
+        "M 12.25 17.5 L 0 17.5 L 0 0 L 12 0 L 12 2 L 2.25 2 L 2.25 7.5 "
+        "L 10.75 7.5 L 10.75 9.5 L 2.25 9.5 L 2.25 15.5 L 12.25 15.5 "
+        "L 12.25 17.5 Z"
+    )
+    letters.add(path.Path(d=d1))
+    d2 = (
+        "M 27.25 17.5 L 14.5 17.5 L 14.5 0 L 16.75 0 L 16.75 15.5 "
+        "L 27.25 15.5 Z"
+    )
+    letters.add(path.Path(d=d2, transform="translate(2, 0)"))
+    symb.add(letters)
+    return symb
+
+
+@_factory()
 def _representation_link_symbol() -> container.Symbol:
     symb = container.Symbol(id="RepresentationLinkSymbol", viewBox="0 0 16 16")
     grp = symb.add(container.Group(stroke_width=0.5))

--- a/capellambse/svg/drawing.py
+++ b/capellambse/svg/drawing.py
@@ -258,29 +258,30 @@ class Drawing:
         x = obj.attribs["x"]
         y = y or obj.attribs["y"] + decorations.feature_space
         w, h = obj.attribs["width"], obj.attribs["height"]
-        label: LabelDict = {
-            "x": x + decorations.feature_space / 2,
-            "y": y,
-            "width": w - decorations.feature_space / 2,
-            "height": h - decorations.feature_space,
-            "class": "Features",
-            "text": "\n".join(
-                chelpers.flatten_html_string(feat) for feat in features
-            ),
-        }
-        self._draw_label(
-            LabelBuilder(
-                w,
-                h,
-                [label],
-                group,
-                class_=class_,
-                labelstyle=labelstyle,
-                y_margin=5,
-                icon=False,
-                alignment="left",
+        for feat in features:
+            label: LabelDict = {
+                "x": x + decorations.feature_space / 2,
+                "y": y,
+                "width": w - decorations.feature_space / 2,
+                "height": h - decorations.feature_space,
+                "class": "Features",
+                "text": chelpers.flatten_html_string(feat),
+            }
+            lines = self._draw_label(
+                LabelBuilder(
+                    w,
+                    h,
+                    [label],
+                    group,
+                    class_=f"{class_}Feature",
+                    labelstyle=labelstyle,
+                    y_margin=5,
+                    icon=True,
+                    alignment="left",
+                )
             )
-        )
+            if lines:
+                y += lines.text_height
 
     def _draw_label(self, builder: LabelBuilder) -> LinesData | None:
         """Draw label text on given object and return the label's group."""
@@ -974,7 +975,7 @@ def get_label_position(
         label_height = chelpers.extent_func(label["text"])[1]
         dominant_baseline_adjust = label_height / 2
         if builder.text_anchor == "start":
-            label["x"] += lines.margin + icon_size
+            label["x"] += lines.margin + icon_size / 2
         else:
             label["x"] += (label["width"] + icon_size) / 2
 
@@ -988,7 +989,8 @@ def get_label_position(
                 fill="red",
             ),
         )
-    return diagram.Vector2D(builder.labels[0]["x"], builder.labels[0]["y"])
+    min_x = min(label["x"] for label in builder.labels)
+    return diagram.Vector2D(min_x, builder.labels[0]["y"])
 
 
 def get_label_icon_position(


### PR DESCRIPTION
Partially solves #78

solved:
- Added class property, enum and enum literal icons
- Added multiplicity to class diagram edges

not solved:
- didn't add icons for Box.NumericType and Box.StringType because why would you need that
- aggregation kind of associations still don't have the Diamond-Marker when kind attribute isn't in the XML. not possible to implement atp