### PR TITLE
Enhance *State/Mode classes with incoming and outgoing StateTransition accessors

### DIFF
--- a/capellambse/metamodel/capellacommon.py
+++ b/capellambse/metamodel/capellacommon.py
@@ -49,6 +49,9 @@ class State(AbstractStateMode):
         m.ModelElement, "exit", aslist=m.MixedElementList
     )
 
+    incoming_transitions = m.Accessor
+    outgoing_transitions = m.Accessor
+
     functions: m.Accessor
 
 
@@ -158,6 +161,40 @@ for cls in [
         "realizing_states",
         m.ReferenceSearchingAccessor(
             cls, "realized_states", aslist=m.ElementList
+        ),
+    )
+
+for cls in [
+    State,
+    Mode,
+    DeepHistoryPseudoState,
+    FinalState,
+    ForkPseudoState,
+    JoinPseudoState,
+    ShallowHistoryPseudoState,
+    TerminatePseudoState,
+]:
+    m.set_accessor(
+        cls,
+        "incoming_transitions",
+        m.ReferenceSearchingAccessor(
+            StateTransition, "destination", aslist=m.ElementList
+        ),
+    )
+for cls in [
+    State,
+    Mode,
+    DeepHistoryPseudoState,
+    ForkPseudoState,
+    InitialPseudoState,
+    JoinPseudoState,
+    ShallowHistoryPseudoState,
+]:
+    m.set_accessor(
+        cls,
+        "outgoing_transitions",
+        m.ReferenceSearchingAccessor(
+            StateTransition, "source", aslist=m.ElementList
         ),
     )
 

--- a/tests/test_metamodel_common.py
+++ b/tests/test_metamodel_common.py
@@ -48,3 +48,26 @@ def test_state_attributes(
     functions = getattr(state, attr)
 
     assert functions == expected_functions
+
+
+def test_state_outgoing_transitions(model: capellambse.MelodyModel) -> None:
+    state = model.by_uuid("1d03b3f0-f65b-451a-b9c7-b5df12b7bf4c")
+    expected_outgoing = [model.by_uuid("8f868115-f5fe-412c-b2a2-4adf92806fc6")]
+
+    assert state.outgoing_transitions == expected_outgoing
+
+
+def test_initial_state_outgoing_transitions(
+    model: capellambse.MelodyModel,
+) -> None:
+    initial_state = model.by_uuid("43932114-8ad4-4074-b2a9-b0d55b8d027b")
+    expected_outgoing = [model.by_uuid("4764929e-92b5-4400-a57c-432477275f48")]
+
+    assert initial_state.outgoing_transitions == expected_outgoing
+
+
+def test_state_incoming_transitions(model: capellambse.MelodyModel) -> None:
+    state = model.by_uuid("1d03b3f0-f65b-451a-b9c7-b5df12b7bf4c")
+    expected_incoming = [model.by_uuid("8770f95c-ac4e-4d37-a690-0920aa22d3f9")]
+
+    assert state.incoming_transitions == expected_incoming


### PR DESCRIPTION
Hello py-capellambse team, and thank you very much for this great project and especially for the amazing contributor experience!

I'm interested in working with `StateMachine`s and the relations within and around them, so I noticed #426 which I'll now stop spamming with mentions. To start from the related `StateTransition`s, this PR adds:
- `incoming_transitions`
- `outgoing_transitions`

Please check the commits for the detailed lists of classes impacted, which can also be rolled back to just `State`.

The PR also adds test cases for both of these new accessors on `State`, and for `InitialPseudoState.outgoing_transitions`; I couldn't find a `StateMachine` with a `FinalState` to write the test case for `FinalState.incoming_transitions` but it should be easy to add with the right UUIDs.

Thanks in advance!