### PR TITLE
feat: Add support for embedded images

### DIFF
--- a/capellambse/extensions/pvmt/_config.py
+++ b/capellambse/extensions/pvmt/_config.py
@@ -157,7 +157,10 @@ class PVMTDescriptionProperty(m.BasePOD[SelectorRules]):
         super().__init__(attribute, default=SelectorRules(""), writable=True)
         self.__doc__ = "The element selector rules for this group."
 
-    def _from_xml(self, data: str, /) -> SelectorRules:
+    def _from_xml(
+        self, data: str, model: capellambse.MelodyModel, /
+    ) -> SelectorRules:
+        del model
         return SelectorRules(data)
 
     def _to_xml(self, value: SelectorRules | str, /) -> str:


### PR DESCRIPTION
Currently, embedded images are not handled properly. An embedded image link contains the name of the Capella project as first element of the path in the `src` attribute, but the path doesn't exist on the file system.

To resolve the issue, we remove the project name as prefix.

Open issues: 
- If the description is not modified but written back, there is an unintended diff. We have to make sure that the project name is added again in the `_to_xml` method. However, I don't have a stable solution how to identify embedded image links yet.
- Tests should be added to cover embedded images.
- It doesn't work if the image is referenced from another project.

Alternative solution could be to provide a description postprocessing helper function, which is used for the HTML rendering. This would solve the issue with broken image references in Jupyter. 