### PR TITLE
style: Fix HTML repr styling

### DIFF
--- a/capellambse/model/_obj.py
+++ b/capellambse/model/_obj.py
@@ -387,7 +387,10 @@ class ModelElement:
         except Exception:
             icon = None
 
-        fragments.append("<h1>")
+        fragments.append(
+            '<h1 style="display: flex; align-items: baseline; '
+            'gap: 5px; font-size: 150%;">'
+        )
         if icon:
             fragments.append(
                 f'<img src="{icon}" alt="" width="20" height="20"> '


### PR DESCRIPTION
- Puts the icon and name of an element in the HTML repr title on one line
- Also makes title larger