### PR TITLE
Add an envvar to generate deterministic UUIDs

### DIFF
--- a/capellambse/loader/core.py
+++ b/capellambse/loader/core.py
@@ -20,6 +20,7 @@ import logging
 import operator
 import os
 import pathlib
+import random
 import re
 import shutil
 import sys
@@ -74,6 +75,8 @@ ROOT_XT = (
     "org.polarsys.capella.core.data.capellamodeller:Project",
     "org.polarsys.capella.core.data.capellamodeller:Library",
 )
+
+UUID_GENERATOR = random.Random(os.getenv("CAPELLAMBSE_UUID_SEED") or None)
 
 
 def _derive_entrypoint(
@@ -689,7 +692,8 @@ class MelodyLoader:
                 raise ValueError(f"UUID {want!r} is already in use")
 
         while True:
-            new_id = str(uuid.uuid4())
+            rb = UUID_GENERATOR.randbytes(16)
+            new_id = str(uuid.UUID(bytes=rb, version=4))
             try:
                 self[new_id]
             except KeyError:

--- a/docs/source/start/envvars.rst
+++ b/docs/source/start/envvars.rst
@@ -36,6 +36,21 @@ understands, and how they affect regular operation.
 - ``TERM`` is used to determine whether the terminal supports PNG display, in
   order to preview diagrams in the REPL.
 
+- ``CAPELLAMBSE_UUID_SEED`` sets a seed for the internal pseudo-random number
+  generator for UUIDs. This is used when inserting new elements into a model,
+  either directly or indirectly by adding elements to ``Allocation`` relations.
+  If unset or empty, a randomized seed will be used.
+
+  This may be helpful when debugging CI runs or other automations. Note however
+  that the code creating the objects must then also be deterministic (i.e.
+  create and insert  the same objects in the same order every time), which
+  usually rules out any potentially multi-threaded applications.
+
+  Be aware that the generated UUIDs will still be checked against the model
+  that they will be used in, and if duplications are detected, the PRNG is
+  queried again. This may lead to different UUIDs than expected if the same
+  seed has been used before in a model.
+
 Debugging helpers
 -----------------
 

--- a/tests/data/pvmt/expected-output/apply.capella
+++ b/tests/data/pvmt/expected-output/apply.capella
@@ -444,7 +444,7 @@
               id="fb9456b9-72fe-40b1-add2-ef131e675652" targetElement="#af388362-bb6f-43bf-805f-a360f0a1bd81"
               sourceElement="#81ea3e64-9412-4775-86d4-3230dfebe6c3"/>
           <ownedPhysicalLinks xsi:type="org.polarsys.capella.core.data.cs:PhysicalLink"
-              id="d32caffc-b9a1-448e-8e96-65a36ba06292" name="DP-1" appliedPropertyValueGroups="#65db4b2e-4e14-47e8-af67-e5fc59fdd01a #5b1390f5-f7ac-4afd-bef0-8567f19f34a3 #00000000-0000-0000-0000-000000000001"
+              id="d32caffc-b9a1-448e-8e96-65a36ba06292" name="DP-1" appliedPropertyValueGroups="#65db4b2e-4e14-47e8-af67-e5fc59fdd01a #5b1390f5-f7ac-4afd-bef0-8567f19f34a3 #cd072cd8-be6f-4f62-ac4c-09c28206e7e3"
               linkEnds="#d7737b9b-02da-4c7d-af45-d5274c89ffe6 #8c8e9fdd-ace7-4322-9c6d-b6ec2ed2c0b3">
             <ownedPropertyValueGroups xsi:type="org.polarsys.capella.core.data.capellacore:PropertyValueGroup"
                 id="65db4b2e-4e14-47e8-af67-e5fc59fdd01a" name="Computer.Cables" appliedPropertyValueGroups="#0fb1fbfb-43a6-4f96-9ec3-2cb83d80c702">
@@ -469,10 +469,10 @@
                   appliedPropertyValues="#8ef4a68a-a50f-453d-b63a-351546488782" value="1"/>
             </ownedPropertyValueGroups>
             <ownedPropertyValueGroups xsi:type="org.polarsys.capella.core.data.capellacore:PropertyValueGroup"
-                id="00000000-0000-0000-0000-000000000001" name="External Data.Object IDs"
+                id="cd072cd8-be6f-4f62-ac4c-09c28206e7e3" name="External Data.Object IDs"
                 appliedPropertyValueGroups="#00fd06dd-cedc-403a-9742-261510c70b76">
               <ownedPropertyValues xsi:type="org.polarsys.capella.core.data.capellacore:StringPropertyValue"
-                  id="00000000-0000-0000-0000-000000000002" name="Object ID" appliedPropertyValues="#4ae427b8-af5d-4d42-b454-a656ddce9b1d"
+                  id="5594aa6b-342f-4d0a-ba5e-4842fab428f7" name="Object ID" appliedPropertyValues="#4ae427b8-af5d-4d42-b454-a656ddce9b1d"
                   value="CABLE-0001"/>
             </ownedPropertyValueGroups>
           </ownedPhysicalLinks>

--- a/tests/test_model_pvmt.py
+++ b/tests/test_model_pvmt.py
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pathlib
+import random
 import shutil
 
 import pytest
 
 import capellambse
+from capellambse import loader
 from capellambse.extensions import pvmt
 
 TEST_ROOT = pathlib.Path(__file__).parent / "data" / "pvmt"
@@ -136,21 +138,9 @@ class TestAppliedPropertyValueGroupXML:
         assert actual == expected
 
     def test_apply(self, model, monkeypatch):
-        call_count = 0
-
-        def mock_generate_uuid(*__, **_):
-            nonlocal call_count
-            call_count += 1
-            return f"00000000-0000-0000-0000-{call_count:012x}"
-
-        monkeypatch.setattr(
-            "capellambse.loader.MelodyLoader.generate_uuid",
-            mock_generate_uuid,
-        )
-
+        monkeypatch.setattr(loader.core, "UUID_GENERATOR", random.Random(0))
         elem = model.by_uuid(self.elem_uuid)
 
         elem.pvmt["External Data.Object IDs.Object ID"] = "CABLE-0001"
 
-        assert call_count == 2
         self.compare_xml(model, "apply.capella")


### PR DESCRIPTION
This commit changes the UUID generation logic to use its own `random.Random` object, which may be seeded using the newly introduced `CAPELLAMBSE_UUID_SEED` environment variable. This may be used to create reproducible results across multiple runs of an automation.

This also changes the PVMT tests to patch the used Random generator with a static seed instead of overriding the `generate_uuid` method, which greatly simplifies the test setup code.

***Stacked on #485***