### PR TITLE
Fix unraisable exception during Git worktree cleanup on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,6 +215,7 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 addopts = """
+  -W error::pytest.PytestUnraisableExceptionWarning
   --import-mode=importlib
   --strict-config
   --strict-markers

--- a/src/capellambse/filehandler/git.py
+++ b/src/capellambse/filehandler/git.py
@@ -752,13 +752,13 @@ class GitFileHandler(abc.FileHandler):
             os.rmdir(worktree)
             raise
         self.cache_dir = worktree
-        gitdir = self.__git_nolock("rev-parse", "--git-dir", encoding="utf-8")
-        assert isinstance(gitdir, str)
-        self.__repo = pathlib.Path(self.cache_dir, gitdir.strip()).resolve()
-
         self.__fnz = weakref.finalize(
             self, self.__cleanup_worktree, self.__repo, worktree
         )
+
+        gitdir = self.__git_nolock("rev-parse", "--git-dir", encoding="utf-8")
+        assert isinstance(gitdir, str)
+        self.__repo = pathlib.Path(self.cache_dir, gitdir.strip()).resolve()
 
         if not self.__is_local_repo():
             try:


### PR DESCRIPTION
Resolves #490 