### PR TITLE
Cancel old Code QA workflows on new pushes

### DIFF
--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -10,6 +10,10 @@ on:
     tags: ["v*.*.*"]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref_type == 'tag' && github.sha || '0' }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test with Python ${{matrix.python_version}} on ${{matrix.os}}


### PR DESCRIPTION
This is especially useful when stacking PRs and pushing an entire stack at once, because each stacked PR will trigger multiple times per push (at least once each for the pushed base and head branch, possibly even more for larger stacks, depending on the processing order).