### PR TITLE
RiiR™

### DIFF
--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -15,37 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test with Python ${{matrix.python_version}} on ${{matrix.os}}
-    runs-on: ${{matrix.os}}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        python_version:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        include:
-          - os: windows-latest
-            python_version: "3.10"
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          cache-dependency-glob: "**/pyproject.toml"
-          python-version: ${{matrix.python_version}}
-      - name: Run unit tests
-        run: uv run coverage run
-      - name: Report coverage
-        if: always()
-        run: uv run coverage report
-
-  pre-commit:
+  pre-commit: # {{{1
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -59,8 +29,72 @@ jobs:
       - name: Run Pre-Commit
         run: uv run pre-commit run --all-files
 
-  build:
-    name: Build wheel
+  build: # {{{1
+    name: Build wheel for ${{matrix.os}} / ${{matrix.arch}}${{ matrix.manylinux && ' / ' || '' }}${{ matrix.manylinux || '' }}
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux manylinux {{{
+          - os: ubuntu-latest
+            arch: x86_64
+            manylinux: manylinux
+          - os: ubuntu-24.04-arm
+            arch: aarch64
+            manylinux: manylinux
+          # }}}
+          # Linux musllinux {{{
+          - os: ubuntu-latest
+            arch: x86_64
+            manylinux: musllinux
+          - os: ubuntu-24.04-arm
+            arch: aarch64
+            manylinux: musllinux
+          # }}}
+          # macOS {{{
+          - os: macos-13
+            arch: x86_64
+          - os: macos-14
+            arch: arm64
+          # }}}
+          # Windows {{{
+          - os: windows-latest
+            arch: x86
+          - os: windows-latest
+            arch: AMD64
+          # }}}
+    env:
+      CIBW_ARCHS: ${{matrix.arch}}
+      CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH"'
+      CIBW_ENVIRONMENT_WINDOWS: 'PATH="$UserProfile\.cargo\bin;$PATH"'
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Determine which Python versions to test against
+        shell: bash
+        env:
+          ENV_TAG: ${{runner.os}}-${{matrix.arch}}-${{matrix.manylinux}}
+          MANYLINUX: ${{matrix.manylinux}}
+        run: |-
+          if [[ "$ENV_TAG" == "Linux-x86_64-manylinux" || "$ENV_TAG" == "macOS-arm64-" ]]; then
+            echo "CIBW_BUILD=cp*-$MANYLINUX*" >> $GITHUB_ENV
+          else
+            echo "CIBW_BUILD=cp310-$MANYLINUX* cp313-$MANYLINUX*" >> $GITHUB_ENV
+          fi
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22.0
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{runner.os}}-${{matrix.arch}}${{ matrix.manylinux && '-' || '' }}${{ matrix.manylinux || '' }}
+          path: wheelhouse/
+          if-no-files-found: error
+
+  build-pure: # {{{1
+    name: Build pure-Python wheel
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -70,30 +104,39 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
-          python-version: "3.12"
-      - name: Build packages
-        run: uv build
-      - name: Verify packages
-        run: uvx twine check dist/*
+          python-version: "3.13"
+      - name: Build the wheel
+        run: |-
+          uvx --with tomli_w python <<EOF
+          import tomllib, tomli_w
+          with open("pyproject.toml", "rb") as f:
+            metadata = tomllib.load(f)
+          del metadata["tool"]["setuptools-rust"]
+          with open("pyproject.toml", "wb") as f:
+            tomli_w.dump(metadata, f)
+          EOF
+
+          uv build --wheel --out-dir wheelhouse/
+      - name: Run unittests
+        run: |-
+          echo "::group::Prepare test environment"
+          uv sync --group test --no-install-project
+          . .venv/bin/activate
+          uv pip install wheelhouse/*.whl
+          echo "::endgroup::"
+
+          coverage run
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: python-package-distributions
-          path: dist/
+          name: wheel-${{runner.os}}-pure
+          path: wheelhouse/
           if-no-files-found: error
-      - name: Push to release branch
-        if: startsWith(github.ref, 'refs/tags/v')
-        continue-on-error: true
-        env:
-          GITHUB_REF: ${{github.ref}}
-        run: |-
-          releasever="$(echo "$GITHUB_REF" | grep -Po '(?<=^refs/tags/v)(?:0\.)?[1-9][0-9]*').x"
-          if [[ "$releasever" = 0.5.x ]]; then releasever="${releasever%.x}"; fi
-          git push origin "HEAD:release-$releasever"
-  pypi:
-    name: Publish to PyPI
+
+  publish: # {{{1
+    name: Publish release
     runs-on: ubuntu-latest
-    needs: [build, test, example-notebooks]
+    needs: [build, build-pure, example-notebooks]
     if: startsWith(github.ref, 'refs/tags/v')
     environment:
       name: pypi
@@ -101,15 +144,24 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - name: Download built wheel
+      - name: Download built wheels
         uses: actions/download-artifact@v4
         with:
-          name: python-package-distributions
           path: dist/
+          pattern: wheel-*
+          merge-multiple: true
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Push to release branch
+        continue-on-error: true
+        env:
+          GITHUB_REF: ${{github.ref}}
+        run: |-
+          releasever="$(echo "$GITHUB_REF" | grep -Po '(?<=^refs/tags/v)(?:0\.)?[1-9][0-9]*').x"
+          if [[ "$releasever" = 0.5.x ]]; then releasever="${releasever%.x}"; fi
+          git push origin "HEAD:release-$releasever"
 
-  example-notebooks:
+  example-notebooks: # {{{1
     name: Run and verify the example notebooks
     runs-on: ubuntu-latest
     steps:
@@ -124,7 +176,7 @@ jobs:
       - name: Run example notebooks
         run: make -C docs verify-examples
 
-  docs:
+  docs: # {{{1
     name: Build documentation
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
@@ -153,3 +205,5 @@ jobs:
           force_orphan: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/build/html
+
+# vim:set fdm=marker:

--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,7 @@ cython_debug/
 
 # don't commit lock files for library projects
 uv.lock
+Cargo.lock
 
 # Mac garbage
 .DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     hooks:
       - id: insert-license
         name: Insert license headers (shell-style comments)
-        files: '(?:^|/)(?:.*\.(?:py|sh|toml|ya?ml)|Dockerfile|Makefile)$'
+        files: '(?:^|/)(?:.*\.(?:pyi?|sh|toml|ya?ml)|Dockerfile|Makefile)$'
         exclude: '(?:^|/)\..+|^docs/Makefile$'
         args:
           - --detect-license-in-X-top-lines=15
@@ -60,6 +60,16 @@ repos:
           - LICENSES/.license_header.txt
           - --comment-style
           - "/*| *| */"
+      - id: insert-license
+        name: Insert license headers (Rust-style comments)
+        files: '\.rs$'
+        exclude: '(?:^|/)\..+'
+        args:
+          - --detect-license-in-X-top-lines=15
+          - --license-filepath
+          - LICENSES/.license_header.txt
+          - --comment-style
+          - "//"
       - id: insert-license
         name: Insert license headers (reST comments)
         files: '\.rst$'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,7 +117,7 @@ repos:
       - id: mypy
         name: mypy
         language: system
-        entry: uv run --dev --group typecheck mypy src/capellambse tests
+        entry: uv run --dev --group test --group typecheck mypy src/capellambse tests
         types_or: [python, pyi, toml, yaml]
         require_serial: true
         pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ Developing
 ----------
 
 Use [uv](https://docs.astral.sh/uv/) to set up a local development environment.
+Additionally, a Rust compiler is required to build the native module.
 
 ```bash
 git clone https://github.com/DSD-DBS/py-capellambse
@@ -41,6 +42,13 @@ venv. For example, to run the unit tests, use:
 
 ```sh
 uv run pytest
+```
+
+To rebuild the native module after modifying the Rust source code, run the
+following command:
+
+```bash
+uv sync --reinstall-package capellambse
 ```
 
 The example notebooks (see above) are verified during CI, to ensure their

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "capellambse"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+pyo3 = { version = "0.24.0", features = ["abi3-py310", "extension-module"] }
+
+[lib]
+name = "_compiled"
+path = "src/lib.rs"
+crate-type = ["cdylib"]

--- a/README.md
+++ b/README.md
@@ -178,6 +178,11 @@ You can install the latest released version directly from PyPI.
 pip install capellambse
 ```
 
+On supported platforms, the downloaded wheel includes an optional native
+module, which provides faster implementations of some functions. Other
+platforms will fall back to a pure Python wheel without this speedup. To build
+the native module, a Rust compiler is required.
+
 Development
 -----------
 

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -17,6 +17,9 @@ build:
       - asdf plugin add uv
       - asdf install uv latest
       - asdf global uv latest
+      - asdf plugin add rust
+      - asdf install rust stable
+      - asdf global rust stable
     build:
       html:
         - make -C docs html BUILDDIR=$READTHEDOCS_OUTPUT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm[toml]>=3.4", "wheel"]
+requires = [
+  "setuptools>=64",
+  "setuptools-rust",
+  "setuptools-scm[toml]>=3.4",
+  "wheel",
+]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -134,6 +139,26 @@ docs = [
   "tomli>=2.2.1 ; python_full_version < '3.11'",
 ]
 
+[tool.cibuildwheel]
+enable = "pypy"
+build-frontend = "build"
+before-build = ["rustup default stable", "rustup show"]
+test-groups = ["dev"]
+test-command = ["cd {project}", "coverage run", "coverage report"]
+
+[tool.cibuildwheel.linux]
+before-build = [
+  "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=stable --profile=minimal -y",
+  "rustup show",
+]
+repair-wheel-command = [
+  "pipx run abi3audit {wheel}",
+  "auditwheel repair -w {dest_dir} {wheel}",
+]
+
+[tool.cibuildwheel.windows]
+test-command = ["cd /d {project}", "coverage run", "coverage report"]
+
 [tool.coverage.run]
 branch = true
 command_line = "-m pytest"
@@ -147,6 +172,9 @@ exclude_also = [
   '@t\.overload',
 ]
 skip_covered = true
+
+[tool.distutils.bdist_wheel]
+py_limited_api = "cp310"
 
 [tool.docformatter]
 wrap-descriptions = 72
@@ -279,6 +307,10 @@ zip-safe = false
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[[tool.setuptools-rust.ext-modules]]
+target = "capellambse._compiled"
+optional = true
 
 [tool.setuptools_scm]
 # This section must exist for setuptools_scm to work

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,20 +85,23 @@ reqif = "capellambse.extensions.reqif:init"
 validation = "capellambse.extensions.validation:init"
 
 [dependency-groups]
-dev = [
+test = [
   "cairosvg>=2.5.2",
-  "capellambse-context-diagrams>=0.6.1",
   "click>=8.1.7",
   "coverage>=7.6.9",
-  "docformatter[tomli]>=1.7.5",
   "jinja2>=3.1.3",
+  "pytest>=8.3.4",
+  "requests-mock>=1.12.1",
+]
+
+dev = [
+  "capellambse-context-diagrams>=0.6.1",
+  "docformatter[tomli]>=1.7.5",
   "jupyterlab>=4.3.3",
   "pandas>=2.2.3",
   "pre-commit>=4.0.1",
   "pylsp-mypy>=0.6.9",
-  "pytest>=8.3.4",
   "python-lsp-server[rope]>=1.12.0",
-  "requests-mock>=1.12.1",
   "reuse>=5.0.2",
   "ruff==0.9.3",
   "xlsxwriter>=3.2.0",
@@ -143,7 +146,7 @@ docs = [
 enable = "pypy"
 build-frontend = "build"
 before-build = ["rustup default stable", "rustup show"]
-test-groups = ["dev"]
+test-groups = ["test"]
 test-command = ["cd {project}", "coverage run", "coverage report"]
 
 [tool.cibuildwheel.linux]
@@ -316,4 +319,4 @@ optional = true
 # This section must exist for setuptools_scm to work
 
 [tool.uv]
-default-groups = ["dev", "typecheck"]
+default-groups = ["dev", "test", "typecheck"]

--- a/src/capellambse/_compiled.pyi
+++ b/src/capellambse/_compiled.pyi
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG
+# SPDX-License-Identifier: Apache-2.0

--- a/src/capellambse/_compiled.pyi
+++ b/src/capellambse/_compiled.pyi
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Protocol
+
 from lxml import etree
+
+class _HasWrite(Protocol):
+    def write(self, _: bytes, /) -> None: ...
 
 def serialize(
     tree: etree._Element,
@@ -9,4 +14,5 @@ def serialize(
     *,
     line_length: int,
     siblings: bool,
+    file: _HasWrite | None,
 ) -> bytes: ...

--- a/src/capellambse/_compiled.pyi
+++ b/src/capellambse/_compiled.pyi
@@ -1,2 +1,12 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG
 # SPDX-License-Identifier: Apache-2.0
+
+from lxml import etree
+
+def serialize(
+    tree: etree._Element,
+    /,
+    *,
+    line_length: int,
+    siblings: bool,
+) -> bytes: ...

--- a/src/exs.rs
+++ b/src/exs.rs
@@ -1,0 +1,504 @@
+// SPDX-FileCopyrightText: Copyright DB InfraGO AG
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    borrow::Cow,
+    cmp::Ordering,
+    collections::{HashMap, HashSet},
+    sync::LazyLock,
+};
+
+use pyo3::{
+    exceptions::{PyTypeError, PyValueError},
+    intern,
+    prelude::*,
+    types::{PyDict, PyString, PyType},
+};
+
+const DEFAULT_BUFFER_SIZE: usize = 2 * 1024 * 1024; // 2 MiB
+
+#[cfg(not(windows))]
+const LINESEP: &[u8; 1] = b"\n";
+#[cfg(windows)]
+const LINESEP: &[u8; 2] = b"\r\n";
+
+const INDENT_WIDTH: usize = 2;
+const INDENT_CHAR: u8 = ' ' as u8;
+
+static ALWAYS_EXPANDED_TAGS: LazyLock<HashSet<(Option<&Cow<'static, str>>, &'static str)>> =
+    LazyLock::new(|| [(None, "bodies"), (None, "semanticResources")].into());
+static EARLY_NAMESPACES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    [
+        "http://www.omg.org/XMI",
+        "http://www.w3.org/2001/XMLSchema-instance",
+    ]
+    .into()
+});
+
+#[pyfunction]
+#[pyo3(signature=(tree, /, *, line_length, siblings))]
+pub fn serialize<'py>(
+    py: Python<'py>,
+    tree: &'py Bound<PyAny>,
+    line_length: usize,
+    siblings: bool,
+) -> PyResult<Vec<u8>> {
+    Ok(Serializer::new(py, line_length)
+        .feed_tree(tree, siblings)?
+        .finish())
+}
+
+struct Serializer {
+    buf: Vec<u8>,
+    pos: usize,
+    line_length: usize,
+
+    etree_element: Py<PyType>,
+    etree_comment: Py<PyType>,
+}
+
+impl Serializer {
+    fn new(py: Python<'_>, line_length: usize) -> Self {
+        let etree = py.import("lxml.etree").expect("cannot import lxml.etree");
+        let etree_element = etree
+            .getattr("_Element")
+            .expect("lxml.etree does not have _Element")
+            .downcast::<PyType>()
+            .expect("lxml.etree._Element is not a type")
+            .clone()
+            .unbind();
+        let etree_comment = etree
+            .getattr("_Comment")
+            .expect("lxml.etree does not have _Comment")
+            .downcast::<PyType>()
+            .expect("lxml.etree._Comment is not a type")
+            .clone()
+            .unbind();
+
+        Self {
+            buf: Vec::with_capacity(DEFAULT_BUFFER_SIZE),
+            pos: 0,
+            line_length,
+
+            etree_element,
+            etree_comment,
+        }
+    }
+
+    fn feed_tree(mut self, tree: &Bound<PyAny>, siblings: bool) -> PyResult<Self> {
+        let py = tree.py();
+
+        if !tree.is_instance(&self.etree_element.bind(py))? {
+            Err(PyTypeError::new_err(format!(
+                "Unserializable object type {}, expected lxml.etree._Element",
+                tree.get_type()
+                    .name()
+                    .map(|n| n.extract::<String>().expect("__name__ is not valid UTF-8"))
+                    .unwrap_or_else(|_| "<unknown type>".into())
+            )))?;
+        }
+
+        fn check_has_no_tail(e: &Bound<PyAny>) -> PyResult<()> {
+            if e.getattr(intern!(e.py(), "tail"))
+                .expect("element/comment has no tail attribute")
+                .is_truthy()?
+            {
+                Err(PyValueError::new_err(
+                    "Text content outside of the main tree, try 'siblings=False'",
+                ))?
+            }
+            Ok(())
+        }
+
+        if siblings {
+            let kwargs = PyDict::new(py);
+            kwargs
+                .set_item(intern!(py, "preceding"), true)
+                .expect("cannot create method kwargs");
+            let preceding_siblings = tree
+                .call_method(intern!(py, "itersiblings"), (), Some(&kwargs))?
+                .try_iter()
+                .expect("itersiblings did not return an iterable")
+                .collect::<PyResult<Vec<_>>>()?;
+            drop(kwargs);
+
+            for i in preceding_siblings.iter().rev() {
+                if !i.is_instance(&self.etree_comment.bind(py))? {
+                    Err(PyValueError::new_err(
+                        "Non-comment before main tree, try 'siblings=False'",
+                    ))?
+                }
+
+                check_has_no_tail(i)?;
+                self.eat_comment(i, 0)?;
+                self.emit_linebreak(0);
+            }
+
+            check_has_no_tail(tree)?;
+        }
+
+        self.eat_element(tree, 0, &HashMap::default())?;
+
+        if siblings {
+            for i in tree
+                .call_method0(intern!(py, "itersiblings"))?
+                .try_iter()
+                .expect("itersiblings did not return an iterable")
+            {
+                let i = &i?;
+                if !i.is_instance(&self.etree_comment.bind(py))? {
+                    Err(PyValueError::new_err(
+                        "Non-comment after main tree, try 'siblings=False'",
+                    ))?
+                }
+
+                check_has_no_tail(i)?;
+                self.eat_comment(i, 0)?;
+                self.emit_linebreak(0);
+            }
+        }
+
+        Ok(self)
+    }
+
+    fn finish(mut self) -> Vec<u8> {
+        self.emit_linebreak(0);
+        self.buf
+    }
+}
+
+impl Serializer {
+    fn eat_comment(&mut self, element: &Bound<PyAny>, indent: usize) -> PyResult<()> {
+        let py = element.py();
+        let text = element
+            .getattr(intern!(py, "text"))
+            .expect("comment has no text");
+        let text = text
+            .downcast::<PyString>()
+            .expect("comment text is not a string or none")
+            .to_cow()
+            .expect("comment text is not valid UTF-8");
+
+        self.emit_linebreak(indent);
+        self.emit_raw_string(b"<!--");
+        self.digest_multiline_text(&text, EscapeCharset::Comment);
+        self.emit_raw_string(b"-->");
+        Ok(())
+    }
+
+    fn eat_element(
+        &mut self,
+        e: &Bound<PyAny>,
+        indent: usize,
+        parent_nsmap: &HashMap<Cow<'_, str>, Cow<'_, str>>,
+    ) -> PyResult<()> {
+        let py = e.py();
+        assert!(e.is_instance(self.etree_element.bind(py)).unwrap_or(false));
+
+        let mut nsmap_alias2uri = e
+            .getattr("nsmap")
+            .expect("element has no nsmap")
+            .downcast::<PyDict>()
+            .expect("nsmap is not a dict")
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.downcast().expect("nsmap alias is not a string").clone(),
+                    v.downcast().expect("nsmap uri is not a string").clone(),
+                )
+            })
+            .collect::<Vec<(Bound<PyString>, Bound<PyString>)>>();
+        nsmap_alias2uri.sort_unstable_by(namespaces_sort);
+        let nsmap_uri2alias = nsmap_alias2uri
+            .iter()
+            .map(|(k, v)| (v.to_string_lossy(), k.to_string_lossy()))
+            .collect::<HashMap<Cow<'_, str>, Cow<'_, str>>>();
+
+        self.emit_raw_string(b"<");
+        let unresolved_tag = self.unresolve_namespace(e, &nsmap_uri2alias);
+        let unresolved_tag = (unresolved_tag.0.as_ref(), unresolved_tag.1.as_str());
+        self.digest_namespaced_name(unresolved_tag);
+
+        let attribs = PyDict::new(py);
+        attribs
+            .call_method1(
+                intern!(py, "update"),
+                (e.getattr(intern!(py, "attrib"))
+                    .expect("cannot get attributes of element"),),
+            )
+            .expect("cannot copy element attributes");
+
+        for attr in [
+            intern!(py, "{http://www.omg.org/XMI}version"),
+            intern!(py, "{http://www.omg.org/XMI}type"),
+            intern!(py, "{http://www.omg.org/XMI}id"),
+            intern!(py, "{http://www.w3.org/2001/XMLSchema-instance}type"),
+        ] {
+            let value = attribs
+                .call_method1(intern!(py, "pop"), (attr, py.None()))
+                .expect("cannot pop from attrib dict");
+            if !value.is_none() {
+                let value = value
+                    .downcast::<PyString>()
+                    .expect("attrib value is not a string");
+                let (ns, ln) = self.unresolve_namespace(attr, &nsmap_uri2alias);
+                if self.pos > self.line_length {
+                    self.emit_linebreak(indent + 2);
+                } else {
+                    self.emit_raw_string(b" ");
+                }
+                self.digest_attr_pair(
+                    (ns.as_ref(), &ln),
+                    &value.to_cow().expect("attrib value is not valid UTF-8") as &str,
+                );
+            }
+        }
+
+        for (alias, uri) in nsmap_alias2uri.iter() {
+            if !parent_nsmap.contains_key(&uri.to_cow()? as &str) {
+                if self.pos > self.line_length {
+                    self.emit_linebreak(indent + 2);
+                } else {
+                    self.emit_raw_string(b" ");
+                }
+                self.digest_attr_pair(
+                    (Some(&Cow::Borrowed("xmlns")), &alias.to_cow()? as &str),
+                    &uri.to_cow()? as &str,
+                );
+            }
+        }
+
+        let has_parent = !e
+            .call_method0(intern!(py, "getparent"))
+            .map(|o| !o.is_none())
+            .unwrap_or(false);
+        let mut force_break = false;
+        for kv in attribs.items().iter() {
+            let (key, value) = kv
+                .extract::<(Bound<PyString>, Bound<PyString>)>()
+                .expect("attrib key/value is not a string 2-tuple");
+            let (ns, key) = self.unresolve_namespace(&key, &nsmap_uri2alias);
+            if force_break || self.pos > self.line_length {
+                self.emit_linebreak(indent + 2);
+            } else {
+                self.emit_raw_string(b" ");
+            }
+            self.digest_attr_pair(
+                (ns.as_ref(), &key),
+                &value.to_cow().expect("attrib value is not valid UTF-8"),
+            );
+
+            force_break = has_parent && ns.is_none() && key == "id";
+        }
+
+        let text = e.getattr(intern!(py, "text")).expect("element has no text");
+        let has_children = e.len().expect("cannot get len() of element") > 0;
+        if text.is_none() && !has_children && !ALWAYS_EXPANDED_TAGS.contains(&unresolved_tag) {
+            self.emit_raw_string(b"/>");
+            return Ok(());
+        }
+        self.emit_raw_string(b">");
+
+        let mut trailing_text = if !text.is_none() {
+            let text = text
+                .downcast::<PyString>()
+                .expect("element text is not a string");
+            self.digest_multiline_text(
+                &text.to_cow().expect("element text is not valid UTF-8"),
+                EscapeCharset::Text,
+            );
+            true
+        } else {
+            false
+        };
+        for child in e.try_iter().expect("cannot iterate over element") {
+            if !trailing_text {
+                self.emit_linebreak(indent + 1);
+            }
+
+            let child = child.expect("cannot iterate over element");
+            if child
+                .is_instance(self.etree_comment.bind(py))
+                .unwrap_or(false)
+            {
+                self.eat_comment(&child, indent + 1)?;
+            } else if child
+                .is_instance(self.etree_element.bind(py))
+                .unwrap_or(false)
+            {
+                self.eat_element(&child, indent + 1, &nsmap_uri2alias)?;
+            } else {
+                Err(PyTypeError::new_err(format!(
+                    "expected only _Element and _Comment in tree, found {}",
+                    child
+                        .get_type()
+                        .name()
+                        .and_then(|n| n.extract::<String>())
+                        .unwrap_or_else(|_| "<unknown type>".into())
+                )))?
+            }
+
+            let tail = child
+                .getattr(intern!(py, "tail"))
+                .expect("element has no tail attribute");
+            trailing_text = if !tail.is_none() {
+                let tail = tail
+                    .downcast::<PyString>()
+                    .expect("element tail is not a string");
+                self.digest_multiline_text(
+                    &tail.to_cow().expect("element tail is not valid UTF-8"),
+                    EscapeCharset::Text,
+                );
+                true
+            } else {
+                false
+            }
+        }
+
+        if has_children && !trailing_text {
+            self.emit_linebreak(indent);
+        }
+
+        self.emit_raw_string(b"</");
+        self.digest_namespaced_name(unresolved_tag);
+        self.emit_raw_string(b">");
+
+        py.check_signals()
+    }
+}
+
+impl Serializer {
+    fn unresolve_namespace<'n>(
+        &self,
+        e: &Bound<PyAny>,
+        nsmap: &'n HashMap<Cow<'n, str>, Cow<'n, str>>,
+    ) -> (Option<Cow<'n, str>>, String) {
+        let py = e.py();
+        let tag = if let Ok(tag) = e.downcast::<PyString>() {
+            tag.clone()
+        } else if e.is_instance(&self.etree_element.bind(py)).unwrap_or(false) {
+            e.getattr(intern!(py, "tag"))
+                .expect("element has no tag")
+                .downcast::<PyString>()
+                .expect("tag is not a string")
+                .clone()
+        } else {
+            panic!(
+                "cannot unresolve namespace on a {}",
+                e.get_type()
+                    .name()
+                    .and_then(|n| n.extract::<String>())
+                    .unwrap_or_else(|_| "<unknown type>".into())
+            );
+        };
+        let tag = tag.to_cow().expect("namespaced name is not valid UTF-8");
+        assert!(tag.len() > 0, "empty tag");
+
+        if tag.chars().nth(0) == Some('{') {
+            let closing = tag.find("}").expect("malformed tag (no '}')");
+            let uri = &tag[1..closing];
+            assert!(uri.len() > 0, "unnamed namespace is not supported");
+            let ns = nsmap.get(uri).expect("namespace not in nsmap").clone();
+            (Some(ns), tag[closing + 1..].to_string())
+        } else {
+            (None, tag.to_string())
+        }
+    }
+
+    fn digest_string(&mut self, string: &str, charset: EscapeCharset) {
+        let string = escape(string, charset);
+        self.emit_raw_string(string.as_bytes());
+    }
+
+    fn digest_multiline_text(&mut self, text: &str, charset: EscapeCharset) {
+        for (i, line) in text.split('\n').enumerate() {
+            if i > 0 {
+                self.emit_linebreak(0);
+            }
+            self.digest_string(line, charset);
+        }
+    }
+
+    fn digest_namespaced_name(&mut self, name: (Option<&Cow<'_, str>>, &str)) {
+        if let Some(ns) = name.0 {
+            self.emit_raw_string(ns.as_bytes());
+            self.emit_raw_string(b":");
+        }
+        self.emit_raw_string(name.1.as_bytes());
+    }
+
+    fn digest_attr_pair(&mut self, key: (Option<&Cow<'_, str>>, &str), value: &str) {
+        self.digest_namespaced_name(key);
+        self.emit_raw_string(b"=\"");
+        self.digest_string(&value, EscapeCharset::Attribute);
+        self.emit_raw_string(b"\"");
+    }
+}
+
+impl Serializer {
+    fn emit_linebreak(&mut self, indent: usize) {
+        self.buf.extend(LINESEP);
+        (0..INDENT_WIDTH * indent).for_each(|_| self.buf.push(INDENT_CHAR));
+        self.pos = INDENT_WIDTH * indent;
+    }
+
+    fn emit_raw_string(&mut self, string: &[u8]) {
+        self.buf.extend(string);
+        self.pos += string.len();
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum EscapeCharset {
+    Attribute,
+    Comment,
+    Text,
+}
+
+fn escape<'a>(string: &'a str, charset: EscapeCharset) -> Cow<'a, str> {
+    let mut output = None;
+    for (i, c) in string.char_indices() {
+        let escape = match (charset, c) {
+            (_, '\x00'..='\x08' | '\x0A'..='\x1F' | '\x7F') => true,
+            (EscapeCharset::Attribute, '\x09') => true,
+            (EscapeCharset::Attribute | EscapeCharset::Text, '"' | '&' | '<') => true,
+            (EscapeCharset::Comment, '>') => true,
+            _ => false,
+        };
+
+        if escape {
+            if output.is_none() {
+                output = Some(string[..i].to_owned());
+            }
+            let escaped = match c {
+                '&' => "&amp;",
+                '<' => "&lt;",
+                '>' => "&gt;",
+                '"' => "&quot;",
+                c => &format!("&#x{:X};", c as u64),
+            };
+            output.as_mut().unwrap().push_str(escaped);
+        } else if let Some(ref mut o) = output {
+            o.push(c);
+        }
+    }
+
+    match output {
+        Some(output) => Cow::Owned(output),
+        None => Cow::Borrowed(string),
+    }
+}
+
+fn namespaces_sort(
+    left: &(Bound<PyString>, Bound<PyString>),
+    right: &(Bound<PyString>, Bound<PyString>),
+) -> Ordering {
+    let left_early = EARLY_NAMESPACES.contains(&left.1.to_string_lossy() as &str);
+    let right_early = EARLY_NAMESPACES.contains(&right.1.to_string_lossy() as &str);
+
+    match (left_early, right_early) {
+        (true, false) => Ordering::Less,
+        (false, true) => Ordering::Greater,
+        _ => left.0.to_string_lossy().cmp(&right.0.to_string_lossy()),
+    }
+}

--- a/src/exs.rs
+++ b/src/exs.rs
@@ -15,7 +15,7 @@ use pyo3::{
     types::{PyDict, PyString, PyType},
 };
 
-const DEFAULT_BUFFER_SIZE: usize = 2 * 1024 * 1024; // 2 MiB
+const MEM_BUFFER_SIZE: usize = 2 * 1024 * 1024; // 2 MiB
 
 #[cfg(not(windows))]
 const LINESEP: &[u8; 1] = b"\n";
@@ -36,59 +36,69 @@ static EARLY_NAMESPACES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
 });
 
 #[pyfunction]
-#[pyo3(signature=(tree, /, *, line_length, siblings))]
+#[pyo3(signature=(tree, /, *, line_length, siblings, file))]
 pub fn serialize<'py>(
     py: Python<'py>,
     tree: &'py Bound<PyAny>,
     line_length: usize,
     siblings: bool,
-) -> PyResult<Vec<u8>> {
-    Ok(Serializer::new(py, line_length)
+    file: Option<Bound<PyAny>>,
+) -> PyResult<Option<Vec<u8>>> {
+    Ok(Serializer::new(py, line_length, file)?
         .feed_tree(tree, siblings)?
-        .finish())
+        .finish()?)
 }
 
-struct Serializer {
+struct Serializer<'py> {
     buf: Vec<u8>,
     pos: usize,
     line_length: usize,
+    write: Option<Bound<'py, PyAny>>,
 
-    etree_element: Py<PyType>,
-    etree_comment: Py<PyType>,
+    etree_element: Bound<'py, PyType>,
+    etree_comment: Bound<'py, PyType>,
 }
 
-impl Serializer {
-    fn new(py: Python<'_>, line_length: usize) -> Self {
+impl<'py> Serializer<'py> {
+    fn new(
+        py: Python<'py>,
+        line_length: usize,
+        output: Option<Bound<'py, PyAny>>,
+    ) -> PyResult<Self> {
         let etree = py.import("lxml.etree").expect("cannot import lxml.etree");
         let etree_element = etree
             .getattr("_Element")
             .expect("lxml.etree does not have _Element")
             .downcast::<PyType>()
             .expect("lxml.etree._Element is not a type")
-            .clone()
-            .unbind();
+            .clone();
         let etree_comment = etree
             .getattr("_Comment")
             .expect("lxml.etree does not have _Comment")
             .downcast::<PyType>()
             .expect("lxml.etree._Comment is not a type")
-            .clone()
-            .unbind();
+            .clone();
 
-        Self {
-            buf: Vec::with_capacity(DEFAULT_BUFFER_SIZE),
+        let write = match output {
+            Some(output) => Some(output.getattr(intern!(py, "write"))?),
+            None => None,
+        };
+
+        Ok(Self {
+            buf: Vec::with_capacity(MEM_BUFFER_SIZE),
             pos: 0,
             line_length,
+            write,
 
             etree_element,
             etree_comment,
-        }
+        })
     }
 
     fn feed_tree(mut self, tree: &Bound<PyAny>, siblings: bool) -> PyResult<Self> {
         let py = tree.py();
 
-        if !tree.is_instance(&self.etree_element.bind(py))? {
+        if !tree.is_instance(&self.etree_element)? {
             Err(PyTypeError::new_err(format!(
                 "Unserializable object type {}, expected lxml.etree._Element",
                 tree.get_type()
@@ -123,7 +133,7 @@ impl Serializer {
             drop(kwargs);
 
             for i in preceding_siblings.iter().rev() {
-                if !i.is_instance(&self.etree_comment.bind(py))? {
+                if !i.is_instance(&self.etree_comment)? {
                     Err(PyValueError::new_err(
                         "Non-comment before main tree, try 'siblings=False'",
                     ))?
@@ -131,7 +141,7 @@ impl Serializer {
 
                 check_has_no_tail(i)?;
                 self.eat_comment(i, 0)?;
-                self.emit_linebreak(0);
+                self.emit_linebreak(0)?;
             }
 
             check_has_no_tail(tree)?;
@@ -146,7 +156,7 @@ impl Serializer {
                 .expect("itersiblings did not return an iterable")
             {
                 let i = &i?;
-                if !i.is_instance(&self.etree_comment.bind(py))? {
+                if !i.is_instance(&self.etree_comment)? {
                     Err(PyValueError::new_err(
                         "Non-comment after main tree, try 'siblings=False'",
                     ))?
@@ -154,20 +164,25 @@ impl Serializer {
 
                 check_has_no_tail(i)?;
                 self.eat_comment(i, 0)?;
-                self.emit_linebreak(0);
+                self.emit_linebreak(0)?;
             }
         }
 
         Ok(self)
     }
 
-    fn finish(mut self) -> Vec<u8> {
-        self.emit_linebreak(0);
-        self.buf
+    fn finish(mut self) -> PyResult<Option<Vec<u8>>> {
+        self.emit_linebreak(0)?;
+        if let Some(write) = self.write {
+            write.call1((self.buf,))?;
+            Ok(None)
+        } else {
+            Ok(Some(self.buf))
+        }
     }
 }
 
-impl Serializer {
+impl<'py> Serializer<'py> {
     fn eat_comment(&mut self, element: &Bound<PyAny>, indent: usize) -> PyResult<()> {
         let py = element.py();
         let text = element
@@ -179,10 +194,10 @@ impl Serializer {
             .to_cow()
             .expect("comment text is not valid UTF-8");
 
-        self.emit_linebreak(indent);
-        self.emit_raw_string(b"<!--");
-        self.digest_multiline_text(&text, EscapeCharset::Comment);
-        self.emit_raw_string(b"-->");
+        self.emit_linebreak(indent)?;
+        self.emit_raw_string(b"<!--")?;
+        self.digest_multiline_text(&text, EscapeCharset::Comment)?;
+        self.emit_raw_string(b"-->")?;
         Ok(())
     }
 
@@ -193,7 +208,7 @@ impl Serializer {
         parent_nsmap: &HashMap<Cow<'_, str>, Cow<'_, str>>,
     ) -> PyResult<()> {
         let py = e.py();
-        assert!(e.is_instance(self.etree_element.bind(py)).unwrap_or(false));
+        assert!(e.is_instance(&self.etree_element).unwrap_or(false));
 
         let mut nsmap_alias2uri = e
             .getattr("nsmap")
@@ -214,10 +229,10 @@ impl Serializer {
             .map(|(k, v)| (v.to_string_lossy(), k.to_string_lossy()))
             .collect::<HashMap<Cow<'_, str>, Cow<'_, str>>>();
 
-        self.emit_raw_string(b"<");
+        self.emit_raw_string(b"<")?;
         let unresolved_tag = self.unresolve_namespace(e, &nsmap_uri2alias);
         let unresolved_tag = (unresolved_tag.0.as_ref(), unresolved_tag.1.as_str());
-        self.digest_namespaced_name(unresolved_tag);
+        self.digest_namespaced_name(unresolved_tag)?;
 
         let attribs = PyDict::new(py);
         attribs
@@ -243,28 +258,28 @@ impl Serializer {
                     .expect("attrib value is not a string");
                 let (ns, ln) = self.unresolve_namespace(attr, &nsmap_uri2alias);
                 if self.pos > self.line_length {
-                    self.emit_linebreak(indent + 2);
+                    self.emit_linebreak(indent + 2)?;
                 } else {
-                    self.emit_raw_string(b" ");
+                    self.emit_raw_string(b" ")?;
                 }
                 self.digest_attr_pair(
                     (ns.as_ref(), &ln),
                     &value.to_cow().expect("attrib value is not valid UTF-8") as &str,
-                );
+                )?;
             }
         }
 
         for (alias, uri) in nsmap_alias2uri.iter() {
             if !parent_nsmap.contains_key(&uri.to_cow()? as &str) {
                 if self.pos > self.line_length {
-                    self.emit_linebreak(indent + 2);
+                    self.emit_linebreak(indent + 2)?;
                 } else {
-                    self.emit_raw_string(b" ");
+                    self.emit_raw_string(b" ")?;
                 }
                 self.digest_attr_pair(
                     (Some(&Cow::Borrowed("xmlns")), &alias.to_cow()? as &str),
                     &uri.to_cow()? as &str,
-                );
+                )?;
             }
         }
 
@@ -279,14 +294,14 @@ impl Serializer {
                 .expect("attrib key/value is not a string 2-tuple");
             let (ns, key) = self.unresolve_namespace(&key, &nsmap_uri2alias);
             if force_break || self.pos > self.line_length {
-                self.emit_linebreak(indent + 2);
+                self.emit_linebreak(indent + 2)?;
             } else {
-                self.emit_raw_string(b" ");
+                self.emit_raw_string(b" ")?;
             }
             self.digest_attr_pair(
                 (ns.as_ref(), &key),
                 &value.to_cow().expect("attrib value is not valid UTF-8"),
-            );
+            )?;
 
             force_break = has_parent && ns.is_none() && key == "id";
         }
@@ -294,10 +309,10 @@ impl Serializer {
         let text = e.getattr(intern!(py, "text")).expect("element has no text");
         let has_children = e.len().expect("cannot get len() of element") > 0;
         if text.is_none() && !has_children && !ALWAYS_EXPANDED_TAGS.contains(&unresolved_tag) {
-            self.emit_raw_string(b"/>");
+            self.emit_raw_string(b"/>")?;
             return Ok(());
         }
-        self.emit_raw_string(b">");
+        self.emit_raw_string(b">")?;
 
         let mut trailing_text = if !text.is_none() {
             let text = text
@@ -306,26 +321,20 @@ impl Serializer {
             self.digest_multiline_text(
                 &text.to_cow().expect("element text is not valid UTF-8"),
                 EscapeCharset::Text,
-            );
+            )?;
             true
         } else {
             false
         };
         for child in e.try_iter().expect("cannot iterate over element") {
             if !trailing_text {
-                self.emit_linebreak(indent + 1);
+                self.emit_linebreak(indent + 1)?;
             }
 
             let child = child.expect("cannot iterate over element");
-            if child
-                .is_instance(self.etree_comment.bind(py))
-                .unwrap_or(false)
-            {
+            if child.is_instance(&self.etree_comment).unwrap_or(false) {
                 self.eat_comment(&child, indent + 1)?;
-            } else if child
-                .is_instance(self.etree_element.bind(py))
-                .unwrap_or(false)
-            {
+            } else if child.is_instance(&self.etree_element).unwrap_or(false) {
                 self.eat_element(&child, indent + 1, &nsmap_uri2alias)?;
             } else {
                 Err(PyTypeError::new_err(format!(
@@ -348,7 +357,7 @@ impl Serializer {
                 self.digest_multiline_text(
                     &tail.to_cow().expect("element tail is not valid UTF-8"),
                     EscapeCharset::Text,
-                );
+                )?;
                 true
             } else {
                 false
@@ -356,18 +365,18 @@ impl Serializer {
         }
 
         if has_children && !trailing_text {
-            self.emit_linebreak(indent);
+            self.emit_linebreak(indent)?;
         }
 
-        self.emit_raw_string(b"</");
-        self.digest_namespaced_name(unresolved_tag);
-        self.emit_raw_string(b">");
+        self.emit_raw_string(b"</")?;
+        self.digest_namespaced_name(unresolved_tag)?;
+        self.emit_raw_string(b">")?;
 
         py.check_signals()
     }
 }
 
-impl Serializer {
+impl<'py> Serializer<'py> {
     fn unresolve_namespace<'n>(
         &self,
         e: &Bound<PyAny>,
@@ -376,7 +385,7 @@ impl Serializer {
         let py = e.py();
         let tag = if let Ok(tag) = e.downcast::<PyString>() {
             tag.clone()
-        } else if e.is_instance(&self.etree_element.bind(py)).unwrap_or(false) {
+        } else if e.is_instance(&self.etree_element).unwrap_or(false) {
             e.getattr(intern!(py, "tag"))
                 .expect("element has no tag")
                 .downcast::<PyString>()
@@ -405,46 +414,81 @@ impl Serializer {
         }
     }
 
-    fn digest_string(&mut self, string: &str, charset: EscapeCharset) {
+    fn digest_string(&mut self, string: &str, charset: EscapeCharset) -> PyResult<()> {
         let string = escape(string, charset);
-        self.emit_raw_string(string.as_bytes());
+        self.emit_raw_string(string.as_bytes())
     }
 
-    fn digest_multiline_text(&mut self, text: &str, charset: EscapeCharset) {
+    fn digest_multiline_text(&mut self, text: &str, charset: EscapeCharset) -> PyResult<()> {
         for (i, line) in text.split('\n').enumerate() {
             if i > 0 {
-                self.emit_linebreak(0);
+                self.emit_linebreak(0)?;
             }
-            self.digest_string(line, charset);
+            self.digest_string(line, charset)?;
         }
+
+        Ok(())
     }
 
-    fn digest_namespaced_name(&mut self, name: (Option<&Cow<'_, str>>, &str)) {
+    fn digest_namespaced_name(&mut self, name: (Option<&Cow<'_, str>>, &str)) -> PyResult<()> {
         if let Some(ns) = name.0 {
-            self.emit_raw_string(ns.as_bytes());
-            self.emit_raw_string(b":");
+            self.emit_raw_string(ns.as_bytes())?;
+            self.emit_raw_string(b":")?;
         }
-        self.emit_raw_string(name.1.as_bytes());
+        self.emit_raw_string(name.1.as_bytes())
     }
 
-    fn digest_attr_pair(&mut self, key: (Option<&Cow<'_, str>>, &str), value: &str) {
-        self.digest_namespaced_name(key);
-        self.emit_raw_string(b"=\"");
-        self.digest_string(&value, EscapeCharset::Attribute);
-        self.emit_raw_string(b"\"");
+    fn digest_attr_pair(
+        &mut self,
+        key: (Option<&Cow<'_, str>>, &str),
+        value: &str,
+    ) -> PyResult<()> {
+        self.digest_namespaced_name(key)?;
+        self.emit_raw_string(b"=\"")?;
+        self.digest_string(&value, EscapeCharset::Attribute)?;
+        self.emit_raw_string(b"\"")
     }
 }
 
-impl Serializer {
-    fn emit_linebreak(&mut self, indent: usize) {
+impl<'py> Serializer<'py> {
+    fn emit_linebreak(&mut self, indent: usize) -> PyResult<()> {
+        if let Some(ref write) = self.write {
+            let needed_space = LINESEP.len() + INDENT_WIDTH * indent;
+            assert!(needed_space < MEM_BUFFER_SIZE);
+            if self.buf.len() + needed_space > MEM_BUFFER_SIZE {
+                write.call1((&self.buf,))?;
+                self.buf.clear();
+            }
+        }
+
         self.buf.extend(LINESEP);
         (0..INDENT_WIDTH * indent).for_each(|_| self.buf.push(INDENT_CHAR));
         self.pos = INDENT_WIDTH * indent;
+
+        Ok(())
     }
 
-    fn emit_raw_string(&mut self, string: &[u8]) {
-        self.buf.extend(string);
+    fn emit_raw_string(&mut self, string: &[u8]) -> PyResult<()> {
+        if let Some(ref write) = self.write {
+            let mut idx = 0;
+            loop {
+                let space = MEM_BUFFER_SIZE - self.buf.len();
+                self.buf.extend(string.iter().skip(idx).take(space));
+                idx += space;
+                if MEM_BUFFER_SIZE - self.buf.len() == 0 {
+                    write.call1((&self.buf,))?;
+                    self.buf.clear();
+                }
+                if idx >= string.len() {
+                    break;
+                }
+            }
+        } else {
+            self.buf.extend(string);
+        }
         self.pos += string.len();
+
+        Ok(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,11 @@
 
 use pyo3::prelude::*;
 
+mod exs;
+
 #[pymodule(name = "_compiled")]
 fn setup_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(exs::serialize, m)?)?;
+
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Copyright DB InfraGO AG
+// SPDX-License-Identifier: Apache-2.0
+
+use pyo3::prelude::*;
+
+#[pymodule(name = "_compiled")]
+fn setup_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    Ok(())
+}

--- a/tests/test_exs.py
+++ b/tests/test_exs.py
@@ -19,6 +19,7 @@ SERIALIZERS = [
             exs._native_serialize,
             line_length=sys.maxsize,
             siblings=True,
+            file=None,
         ),
         id="native",
         marks=pytest.mark.skipif(
@@ -32,6 +33,7 @@ SERIALIZERS = [
             errors="strict",
             line_length=sys.maxsize,
             siblings=True,
+            file=None,
         ),
         id="python",
     ),

--- a/tests/test_exs.py
+++ b/tests/test_exs.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import functools
+import os
+import sys
+
+import pytest
+from lxml import etree
+
+from capellambse.loader import exs
+
+LF = os.linesep
+
+SERIALIZERS = [
+    pytest.param(
+        functools.partial(
+            exs._native_serialize,
+            line_length=sys.maxsize,
+            siblings=True,
+        ),
+        id="native",
+        marks=pytest.mark.skipif(
+            not exs.HAS_NATIVE, reason="native module not available"
+        ),
+    ),
+    pytest.param(
+        functools.partial(
+            exs._python_serialize,
+            encoding="utf-8",
+            errors="strict",
+            line_length=sys.maxsize,
+            siblings=True,
+        ),
+        id="python",
+    ),
+]
+
+
+@pytest.mark.parametrize("serializer", SERIALIZERS)
+@pytest.mark.parametrize(
+    "string",
+    [
+        pytest.param(
+            f"""<p title="&#x9;&amp;Hello, &lt;&quot;World&quot;>!"/>{LF}""",
+            id="attribute",
+        ),
+        pytest.param(
+            f"""<p>\t&amp;Hello, &lt;&quot;World&quot;>!</p>{LF}""",
+            id="text",
+        ),
+        pytest.param(
+            f"""{LF}<!--\t&Hello, <"World"&gt;!-->{LF}<p/>{LF}""",
+            id="comment",
+        ),
+    ],
+)
+def test_escaping(serializer, string):
+    tree = etree.fromstring(string)
+    expected = string.encode("utf-8")
+
+    actual = serializer(tree)
+
+    assert actual == expected


### PR DESCRIPTION
Rewriting it in Rust makes saving the model about 2.5 times as fast. Writing out a medium-sized production model goes down from ~6 seconds to ~2.4 seconds on my machine.

Unfortunately we don't really have a chance to release the GIL during the process, as all the data we're writing out lives on the Python heap. (Well, technically that's not quite true, but we need the LXML bindings to access it, which does.)

I've been profiling this with cargo-flamegraph, and it shows only a very small fraction of time left that's spent in the Python interpreter itself, the vast majority goes into the Rust code, and a little bit into some underlying libxml2 code. We might be able to reduce the overhead even further by directly using the libxml2 bindings ourselves, but that is significantly more work to set up and compile, and I don't want to spend time doing that 🙃

Open issues:

- [x] CI wheel builds don't work yet. I was trying to set up cibuildwheel, but it might be less effort to port to Maturin.
- [x] Port the string escaping tests to pytest, so we don't need two test frameworks.
- [x] Revisit compiler optimizations. Currently we're always compiling in release mode - we should use debug mode at least when running pytest.