### PR TITLE
feat: Align `Capability` and `CapabilityRealization`

### DIFF
--- a/src/capellambse/metamodel/capellacommon.py
+++ b/src/capellambse/metamodel/capellacommon.py
@@ -13,7 +13,10 @@ class AbstractStateRealization(m.ModelElement): ...
 class TransfoLink(m.ModelElement): ...
 
 
-class CapabilityRealizationInvolvement(m.ModelElement): ...
+class CapabilityRealizationInvolvement(m.ModelElement):
+    """An involvement in a capability realization."""
+
+    involved = m.Association(m.ModelElement, "involved")
 
 
 @m.xtype_handler(None)

--- a/src/capellambse/metamodel/cs.py
+++ b/src/capellambse/metamodel/cs.py
@@ -13,7 +13,41 @@ Composite Structure object-relations map (ontology):
 
 import capellambse.model as m
 
-from . import capellacommon, fa, information
+from . import capellacommon, capellacore, fa, information, interaction
+
+
+class CapabilityBase(m.ModelElement):
+    """Base class for capabilities."""
+
+    postcondition = m.Association(capellacore.Constraint, "postCondition")
+    precondition = m.Association(capellacore.Constraint, "preCondition")
+    scenarios = m.DirectProxyAccessor(
+        interaction.Scenario, aslist=m.ElementList
+    )
+    states = m.Association(
+        capellacommon.State, "availableInStates", aslist=m.ElementList
+    )
+
+    extends = m.DirectProxyAccessor(
+        interaction.AbstractCapabilityExtend, aslist=m.ElementList
+    )
+    extended_by = m.Backref(
+        interaction.AbstractCapabilityExtend, "target", aslist=m.ElementList
+    )
+    includes = m.DirectProxyAccessor(
+        interaction.AbstractCapabilityInclude, aslist=m.ElementList
+    )
+    included_by = m.Backref(
+        interaction.AbstractCapabilityInclude, "target", aslist=m.ElementList
+    )
+    generalizes = m.DirectProxyAccessor(
+        interaction.AbstractCapabilityGeneralization, aslist=m.ElementList
+    )
+    generalized_by = m.DirectProxyAccessor(
+        interaction.AbstractCapabilityGeneralization,
+        "target",
+        aslist=m.ElementList,
+    )
 
 
 @m.xtype_handler(None)

--- a/src/capellambse/metamodel/la.py
+++ b/src/capellambse/metamodel/la.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from capellambse import model as m
 
-from . import capellacommon, capellacore, cs, fa, interaction, sa
+from . import capellacommon, cs, fa, interaction, sa
 
 
 @m.xtype_handler(None)
@@ -80,23 +80,14 @@ class LogicalComponentPkg(m.ModelElement):
 
 
 @m.xtype_handler(None)
-class CapabilityRealization(m.ModelElement):
+class CapabilityRealization(cs.CapabilityBase):
     """A capability."""
 
     _xmltag = "ownedCapabilityRealizations"
 
-    owned_chains = m.DirectProxyAccessor(
-        fa.FunctionalChain, aslist=m.ElementList
-    )
     involved_functions = m.Allocation[LogicalFunction](
         "ownedAbstractFunctionAbstractCapabilityInvolvements",
         interaction.AbstractFunctionAbstractCapabilityInvolvement,
-        aslist=m.ElementList,
-        attr="involved",
-    )
-    involved_chains = m.Allocation[fa.FunctionalChain](
-        "ownedFunctionalChainAbstractCapabilityInvolvements",
-        interaction.FunctionalChainAbstractCapabilityInvolvement,
         aslist=m.ElementList,
         attr="involved",
     )
@@ -106,23 +97,24 @@ class CapabilityRealization(m.ModelElement):
         aslist=m.MixedElementList,
         attr="involved",
     )
+    component_involvements = m.DirectProxyAccessor(
+        capellacommon.CapabilityRealizationInvolvement, aslist=m.ElementList
+    )
+    involved_chains = m.Allocation[fa.FunctionalChain](
+        "ownedFunctionalChainAbstractCapabilityInvolvements",
+        interaction.FunctionalChainAbstractCapabilityInvolvement,
+        aslist=m.ElementList,
+        attr="involved",
+    )
+    owned_chains = m.DirectProxyAccessor(
+        fa.FunctionalChain, aslist=m.ElementList
+    )
     realized_capabilities = m.Allocation[sa.Capability](
         "ownedAbstractCapabilityRealizations",
         interaction.AbstractCapabilityRealization,
         aslist=m.ElementList,
         attr="targetElement",
     )
-
-    postcondition = m.Association(capellacore.Constraint, "postCondition")
-    precondition = m.Association(capellacore.Constraint, "preCondition")
-    scenarios = m.DirectProxyAccessor(
-        interaction.Scenario, aslist=m.ElementList
-    )
-    states = m.Association(
-        capellacommon.State, "availableInStates", aslist=m.ElementList
-    )
-
-    packages: m.Accessor
 
 
 @m.xtype_handler(None)

--- a/src/capellambse/metamodel/oa.py
+++ b/src/capellambse/metamodel/oa.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from capellambse import model as m
 
-from . import capellacommon, capellacore, cs, fa, information, interaction
+from . import capellacommon, cs, fa, information, interaction
 
 
 @m.xtype_handler(None)
@@ -49,31 +49,11 @@ class EntityOperationalCapabilityInvolvement(interaction.AbstractInvolvement):
 
 
 @m.xtype_handler(None)
-class OperationalCapability(m.ModelElement):
+class OperationalCapability(cs.CapabilityBase):
     """A capability in the OperationalAnalysis layer."""
 
     _xmltag = "ownedOperationalCapabilities"
 
-    extends = m.DirectProxyAccessor(
-        interaction.AbstractCapabilityExtend, aslist=m.ElementList
-    )
-    extended_by = m.Backref(
-        interaction.AbstractCapabilityExtend, "target", aslist=m.ElementList
-    )
-    includes = m.DirectProxyAccessor(
-        interaction.AbstractCapabilityInclude, aslist=m.ElementList
-    )
-    included_by = m.Backref(
-        interaction.AbstractCapabilityInclude, "target", aslist=m.ElementList
-    )
-    generalizes = m.DirectProxyAccessor(
-        interaction.AbstractCapabilityGeneralization, aslist=m.ElementList
-    )
-    generalized_by = m.DirectProxyAccessor(
-        interaction.AbstractCapabilityGeneralization,
-        "target",
-        aslist=m.ElementList,
-    )
     involved_activities = m.Allocation[OperationalActivity](
         "ownedAbstractFunctionAbstractCapabilityInvolvements",
         interaction.AbstractFunctionAbstractCapabilityInvolvement,
@@ -98,17 +78,6 @@ class OperationalCapability(m.ModelElement):
     owned_processes = m.DirectProxyAccessor(
         OperationalProcess, aslist=m.ElementList
     )
-
-    postcondition = m.Association(capellacore.Constraint, "postCondition")
-    precondition = m.Association(capellacore.Constraint, "preCondition")
-    scenarios = m.DirectProxyAccessor(
-        interaction.Scenario, aslist=m.ElementList
-    )
-    states = m.Association(
-        capellacommon.State, "availableInStates", aslist=m.ElementList
-    )
-
-    packages: m.Accessor
 
 
 @m.xtype_handler(None)

--- a/src/capellambse/metamodel/sa.py
+++ b/src/capellambse/metamodel/sa.py
@@ -10,7 +10,7 @@ functions, actors etc. which is best presented in a glossary document.
 
 import capellambse.model as m
 
-from . import capellacommon, capellacore, cs, fa, interaction, oa
+from . import capellacommon, cs, fa, interaction, oa
 
 
 @m.xtype_handler(None)
@@ -85,43 +85,14 @@ class CapabilityInvolvement(interaction.AbstractInvolvement):
 
 
 @m.xtype_handler(None)
-class Capability(m.ModelElement):
+class Capability(cs.CapabilityBase):
     """A capability."""
 
     _xmltag = "ownedCapabilities"
 
-    extends = m.DirectProxyAccessor(
-        interaction.AbstractCapabilityExtend, aslist=m.ElementList
-    )
-    extended_by = m.Backref(
-        interaction.AbstractCapabilityExtend, "target", aslist=m.ElementList
-    )
-    includes = m.DirectProxyAccessor(
-        interaction.AbstractCapabilityInclude, aslist=m.ElementList
-    )
-    included_by = m.Backref(
-        interaction.AbstractCapabilityInclude, "target", aslist=m.ElementList
-    )
-    generalizes = m.DirectProxyAccessor(
-        interaction.AbstractCapabilityGeneralization, aslist=m.ElementList
-    )
-    generalized_by = m.Backref(
-        interaction.AbstractCapabilityGeneralization,
-        "target",
-        aslist=m.ElementList,
-    )
-    owned_chains = m.DirectProxyAccessor(
-        fa.FunctionalChain, aslist=m.ElementList
-    )
     involved_functions = m.Allocation[SystemFunction](
         "ownedAbstractFunctionAbstractCapabilityInvolvements",
         interaction.AbstractFunctionAbstractCapabilityInvolvement,
-        aslist=m.ElementList,
-        attr="involved",
-    )
-    involved_chains = m.Allocation[fa.FunctionalChain](
-        "ownedFunctionalChainAbstractCapabilityInvolvements",
-        interaction.FunctionalChainAbstractCapabilityInvolvement,
         aslist=m.ElementList,
         attr="involved",
     )
@@ -134,23 +105,21 @@ class Capability(m.ModelElement):
     component_involvements = m.DirectProxyAccessor(
         CapabilityInvolvement, aslist=m.ElementList
     )
+    involved_chains = m.Allocation[fa.FunctionalChain](
+        "ownedFunctionalChainAbstractCapabilityInvolvements",
+        interaction.FunctionalChainAbstractCapabilityInvolvement,
+        aslist=m.ElementList,
+        attr="involved",
+    )
+    owned_chains = m.DirectProxyAccessor(
+        fa.FunctionalChain, aslist=m.ElementList
+    )
     realized_capabilities = m.Allocation[oa.OperationalCapability](
         None,  # FIXME fill in tag
         interaction.AbstractCapabilityRealization,
         aslist=m.ElementList,
         attr="targetElement",
     )
-
-    postcondition = m.Association(capellacore.Constraint, "postCondition")
-    precondition = m.Association(capellacore.Constraint, "preCondition")
-    scenarios = m.DirectProxyAccessor(
-        interaction.Scenario, aslist=m.ElementList
-    )
-    states = m.Association(
-        capellacommon.State, "availableInStates", aslist=m.ElementList
-    )
-
-    packages: m.Accessor
 
 
 @m.xtype_handler(None)


### PR DESCRIPTION
In order to enable `context_diagram` for `CapabilityRealization` in the end, we'll need the following exchanges:
- extends
- includes
- generalizes and their reverse

This PR aligns all Capability classes with each other, introducing a `CapabilityBase` class to stay dry.