### PR TITLE
Exit 3 on partial diagram cache export failure

### DIFF
--- a/src/capellambse/_diagram_cache.py
+++ b/src/capellambse/_diagram_cache.py
@@ -105,7 +105,7 @@ def export(
     force: t.Literal["exe", "docker", None],
     background: bool,
     refresh: bool = False,
-) -> None:
+) -> list[IndexEntry]:
     if model.diagram_cache is None:
         raise TypeError("No diagram cache configured for the model")
     if not isinstance(model.diagram_cache, local.LocalFileHandler):
@@ -154,6 +154,7 @@ def export(
         )
         if index:
             _write_index(model, format, diag_cache_dir, diagrams)
+        return diagrams
 
 
 def _find_executor(

--- a/src/capellambse/diagram_cache.py
+++ b/src/capellambse/diagram_cache.py
@@ -100,6 +100,18 @@ else:
         with `capellambse.MelodyModel`.
 
         \b
+        Exit codes
+        ----------
+
+        The CLI will indicate the success status via exit codes:
+
+        \b
+        - 0 in case of success
+        - 1 for general errors
+        - 2 for CLI usage errors
+        - 3 if some diagrams failed to export, but others were successful
+
+        \b
         Refreshing representations
         --------------------------
 
@@ -137,7 +149,7 @@ else:
             capella = exe or "capella{VERSION}"
             force = "exe"
 
-        _diagram_cache.export(
+        diagrams = _diagram_cache.export(
             capella,
             model_,
             format=format,
@@ -146,6 +158,11 @@ else:
             background=background,
             refresh=refresh,
         )
+        ok = sum(1 for i in diagrams if i["success"])
+        if ok == 0:
+            raise SystemExit(1)
+        if ok < len(diagrams):
+            raise SystemExit(3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signal to the caller that some diagrams failed to export by exiting with code 3. This allows automated scripts to more easily distinguish this case from other errors.