### PR TITLE
Make SVG viewbox cropping more resilient

### DIFF
--- a/src/capellambse/_diagram_cache.py
+++ b/src/capellambse/_diagram_cache.py
@@ -392,6 +392,9 @@ def _crop_svg_viewbox(src: pathlib.Path, root: etree._Element):
     except _NoBoundingBoxFound:
         LOGGER.warning("Cannot determine bounding box in file: %s", src)
         return
+    except Exception:
+        LOGGER.exception("Cannot determine bounding box in file: %s", src)
+        return
 
     old_width = float(root.get("width", 0))
     old_height = float(root.get("height", 0))

--- a/src/capellambse/_diagram_cache.py
+++ b/src/capellambse/_diagram_cache.py
@@ -359,7 +359,7 @@ def _calculate_svg_viewbox(root: etree._Element) -> ViewBox:
     x_max = y_max = float("-inf")
     for element in root.iter():
         if (
-            isinstance(element, etree._Comment)
+            isinstance(element, etree._Comment | etree._ProcessingInstruction)
             or not hasattr(element, "tag")
             or element.get("transform")
         ):


### PR DESCRIPTION
Do not consider the XML declaration as a potential graphical element for which the bounding box should be calculated.