### PR TITLE
Defer loading the filehandler until after `loadinfo`

### DIFF
--- a/src/capellambse/cli_helpers.py
+++ b/src/capellambse/cli_helpers.py
@@ -255,7 +255,7 @@ def _load_from_file(value: str) -> dict[str, t.Any]:
 
     proto, _ = filehandler.split_protocol(value)
     if proto != "file":
-        return {"path": capellambse.get_filehandler(value)}
+        return {"path": value}
 
     raise ValueError(
         "value is not a known model,"


### PR DESCRIPTION
See also 0b4ca00d0cdc91c1267d4bd7aea3f5d20707ce16.

This keeps the returned modelinfo dict to simple basic types, which makes analyzing and logging easier downstream.