### PR TITLE
Improve the diagram cache index

### DIFF
--- a/src/capellambse/_diagram_cache.py
+++ b/src/capellambse/_diagram_cache.py
@@ -90,6 +90,7 @@ class IndexEntry(t.TypedDict):
     """An entry for the index JSON file."""
 
     uuid: str
+    format: str
     name: str
     type: m.DiagramType
     viewpoint: str
@@ -195,6 +196,7 @@ def _copy_images(
     for i in model.diagrams:
         entry: IndexEntry = {
             "uuid": i.uuid,
+            "format": extension,
             "name": i.name,
             "type": i.type,
             "viewpoint": i.viewpoint,

--- a/src/capellambse/model/_model.py
+++ b/src/capellambse/model/_model.py
@@ -113,6 +113,15 @@ class MelodyModel:
 
     diagram_cache: filehandler.FileHandler | None
 
+    _diagram_cache_index: (
+        dict[str, capellambse._diagram_cache.IndexEntry] | None
+    )
+    """An index describing the diagrams in the cache.
+
+    If the attribute does not exist, the index has not been loaded from
+    the file handler yet. If the attribute is None, it means that the
+    index file could not be found and all diagram files need to tried.
+    """
     __diagram_cache: t.Any
     """Stores proxy instances for Diagram.
 


### PR DESCRIPTION
- Add the export format to the index entries
- Use the index for reducing cache lookups if it exists