### PR TITLE
Evaluate `_NoObjectFoundError` description lazily

### DIFF
--- a/src/capellambse/decl.py
+++ b/src/capellambse/decl.py
@@ -582,9 +582,7 @@ def _resolve_findby(
             + candidates._short_repr_()
         )
     if not candidates:
-        raise _NoObjectFoundError(
-            f"No object found for !find {value.attributes!r}"
-        )
+        raise _NoObjectFoundError(value.attributes)
     return candidates[0]
 
 
@@ -593,7 +591,10 @@ class _UnresolvablePromise(BaseException):
 
 
 class _NoObjectFoundError(ValueError):
-    pass
+    def __str__(self) -> str:
+        if len(self.args) == 1:
+            return f"No object found for !find {self.args[0]!r}"
+        return super().__str__()
 
 
 _OPERATIONS = collections.OrderedDict(


### PR DESCRIPTION
The description text is never actually needed in a production environment, and only exists for convenience during debugging. Evaluate it lazily via a `__str__` method instead of passing already rendered text into the constructor.

This slightly improves performance by avoiding unneeded work, and more importantly, it avoids an accidental dependence on the 'termgraphics' converter (read: PNG support) when connected to a compatible TTY while applying decl YAML.