### PR TITLE
Fix the publishing workflow

### DIFF
--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -29,6 +29,28 @@ jobs:
       - name: Run Pre-Commit
         run: uv run pre-commit run --all-files
 
+  sdist: # {{{1
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
+          python-version: "3.13"
+      - name: Package the sources
+        run: |-
+          uv build --sdist --out-dir wheelhouse/
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: wheelhouse/
+          if-no-files-found: error
+
   build: # {{{1
     name: Build wheel for ${{matrix.os}} / ${{matrix.arch}}${{ matrix.manylinux && ' / ' || '' }}${{ matrix.manylinux || '' }}
     runs-on: ${{matrix.os}}
@@ -149,6 +171,11 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/
+          name: sdist
       - name: Download built wheels
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -107,6 +107,11 @@ jobs:
           python-version: "3.13"
       - name: Build the wheel
         run: |-
+          export SETUPTOOLS_SCM_PRETEND_VERSION="$(
+            uvx --with setuptools_scm python -c \
+              "import setuptools_scm as scm; print(scm.get_version())"
+          )"
+
           uvx --with tomli_w python <<EOF
           import tomllib, tomli_w
           with open("pyproject.toml", "rb") as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,13 +97,14 @@ test = [
 
 dev = [
   "capellambse-context-diagrams>=0.6.1",
-  "docformatter[tomli]>=1.7.5",
-  "jupyterlab>=4.3.3",
+  "docformatter[tomli]==1.7.5",
+  "jupyterlab==4.4.2",
+  "mypy==1.15.0",
   "pandas>=2.2.3",
-  "pre-commit>=4.0.1",
-  "pylsp-mypy>=0.6.9",
-  "python-lsp-server[rope]>=1.12.0",
-  "reuse>=5.0.2",
+  "pre-commit==4.2.0",
+  "pylsp-mypy==0.7.0",
+  "python-lsp-server[rope]==1.12.2",
+  "reuse==5.0.2",
   "ruff==0.9.3",
   "xlsxwriter>=3.2.0",
 ]


### PR DESCRIPTION
In this commit the publish to PyPI job is outsourced into its own workflow such that it is only executed when a new release tag is created. Since the publish job depends on build jobs which were only defined in the code-qa workflow, a reusable workflow was defined.
See the [docs](https://resources.github.com/learn/pathways/automation/intermediate/create-reusable-workflows-in-github-actions/) for reusable workflows.