### PR TITLE
wip: Add modifier for xmltags of OperationalActivities

### DIFF
--- a/src/capellambse/metamodel/oa.py
+++ b/src/capellambse/metamodel/oa.py
@@ -27,6 +27,15 @@ class OperationalActivity(fa.AbstractFunction):
 
     owner: m.Accessor[Entity]
 
+    def _switch_xmltag(self) -> None:
+        if self == self._model.oa.root_activity:
+            return
+
+        new_tag = "ownedFunctions"
+        if self._element.tag != new_tag:
+            self._xmltag = new_tag
+            self._element.tag = new_tag
+
     @property
     def related_exchanges(self) -> m.ElementList[fa.FunctionalExchange]:
         seen: set[str] = set()

--- a/src/capellambse/model/_obj.py
+++ b/src/capellambse/model/_obj.py
@@ -255,6 +255,8 @@ class ModelElement:
         self._model = model
         self._element: etree._Element = etree.Element(xmltag)
         parent.append(self._element)
+        self._model.by_uuid(parent.get("id", ""))._reevaluate()
+        self._reevaluate()
         try:
             self.uuid = uuid
             for key, val in kw.items():
@@ -524,6 +526,17 @@ class ModelElement:
             )
         _ICON_CACHE[sc, format, size] = data
         return data
+
+    def _reevaluate(self) -> None:
+        """Re-evaluate the element.
+
+        This is called when the element is modified, and should be
+        overridden by subclasses to update any cached values.
+        """
+        element_modification_triggers = ("_switch_xmltag",)
+        for trigger in element_modification_triggers:
+            if hasattr(self, trigger):
+                getattr(self, trigger)()
 
     if t.TYPE_CHECKING:
 


### PR DESCRIPTION
In order to not corrupt the model, created OperationalActivities other than the root activity need to have the `ownedFunctions` tag.