### PR TITLE
Allow falling back to internal rendering on any cache error

### DIFF
--- a/src/capellambse/model/_model.py
+++ b/src/capellambse/model/_model.py
@@ -254,10 +254,14 @@ class MelodyModel:
 
             *This argument is **not** passed to the file handler.*
         fallback_render_aird: bool
-            If set to True, enable the internal engine to render
-            diagrams that were not found in the pre-rendered cache.
-            Defaults to False, which means an exception is raised
-            instead. Ignored if no ``diagram_cache`` was specified.
+            If set to True, always fall back to rendering diagrams
+            internally if the configured ``diagram_cache`` is not
+            available.
+
+            By default, the internal renderer is entirely disabled for
+            AIRD diagrams, and only used during cache misses
+            (``FileNotFoundError`` from the underlying file handler) for
+            all other types of diagrams.
         **kwargs
             Additional arguments are passed on to the underlying
             :class:`~capellambse.loader.core.MelodyLoader`, which in


### PR DESCRIPTION
Previously, passing `fallback_render_aird` would only cause a fallback to the internal rendering engine on cache misses. With this commit, diagrams are also rendered internally for any other cache error, for example if a remote cache server is unreachable or the cached artifacts have expired.