### PR TITLE
Run tests in parallel with pytest-xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ test = [
   "coverage>=7.6.9",
   "jinja2>=3.1.3",
   "pytest>=8.3.4",
+  "pytest-xdist>=3.7.0",
   "requests-mock>=1.12.1",
 ]
 
@@ -185,7 +186,7 @@ enable = "pypy"
 build-frontend = "build"
 before-build = ["rustup default stable", "rustup show"]
 test-groups = ["test"]
-test-command = ["cd {project}", "coverage run", "coverage report"]
+test-command = ["cd {project}", "pytest -n auto"]
 
 [tool.cibuildwheel.linux]
 before-build = [
@@ -198,7 +199,7 @@ repair-wheel-command = [
 ]
 
 [tool.cibuildwheel.windows]
-test-command = ["cd /d {project}", "coverage run", "coverage report"]
+test-command = ["cd /d {project}", "pytest -n auto"]
 
 [tool.coverage.run]
 branch = true

--- a/tests/test_aird_filters.py
+++ b/tests/test_aird_filters.py
@@ -39,7 +39,7 @@ def test_add_activated_filter_to_diagram(
     assert EX_ITEMS_FILTER in diag.filters
 
 
-@pytest.mark.parametrize("filter_name", DEFAULT_ACTIVATED_FILTERS)
+@pytest.mark.parametrize("filter_name", sorted(DEFAULT_ACTIVATED_FILTERS))
 def test_remove_activated_filter_on_diagram(
     model_5_2: capellambse.MelodyModel, filter_name: str
 ) -> None:


### PR DESCRIPTION
This obviously makes running tests much faster.

To avoid problems with local IDE-/editor-integrated test runners, parallelization is only active by default in CI. However, local runs can easily be parallelized using `pytest -n auto` instead of plain `pytest`.

CI times are cut almost exactly in half, from ~70 minutes cumulative on current master to ~36 minutes.