### PR TITLE
perf: Reduce fetch depth to 1 in Gitlab pipelines

### DIFF
--- a/ci-templates/gitlab/filter-derive.yml
+++ b/ci-templates/gitlab/filter-derive.yml
@@ -31,7 +31,7 @@ derive:
     # considered for the model badge generation.
     - |
       if [[ -n $CI_COMMIT_BRANCH ]]; then
-        git fetch;
+        git fetch --depth 1;
         git reset --hard origin/$CI_COMMIT_BRANCH;
       fi
     - python -m venv /tmp/.venv

--- a/ci-templates/gitlab/model-badge.yml
+++ b/ci-templates/gitlab/model-badge.yml
@@ -9,7 +9,7 @@ generate-model-badge:
     # Reset branch. This is helpful when chaining jobs
     # and a previous job pushes changes that should be
     # considered for the model badge generation.
-    - git fetch
+    - git fetch --depth 1
     - git reset --hard origin/$CI_COMMIT_BRANCH
     - pip install "git+https://github.com/DSD-DBS/py-capellambse.git@$CAPELLAMBSE_REVISION"
     - |


### PR DESCRIPTION
The fetch depth is sufficient and speeds up the pipelines.