### PR TITLE
Drop Python 3.10

### DIFF
--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -105,7 +105,7 @@ jobs:
             echo "CIBW_BUILD=cp*-$MANYLINUX*" >> "$GITHUB_ENV"
             echo "CIBW_SKIP=cp*t-*" >> "$GITHUB_ENV"
           else
-            echo "CIBW_BUILD=cp310-$MANYLINUX* cp314-$MANYLINUX*" >> "$GITHUB_ENV"
+            echo "CIBW_BUILD=cp311-$MANYLINUX* cp314-$MANYLINUX*" >> "$GITHUB_ENV"
           fi
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,6 +10,7 @@
 #
 import os
 import sys
+import tomllib
 
 sys.path.insert(0, os.path.abspath("../.."))
 
@@ -17,10 +18,6 @@ import capellambse
 
 # -- Project information -----------------------------------------------------
 
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
 with open("../../pyproject.toml", "rb") as f:
     _metadata = tomllib.load(f)["project"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dynamic = ["version"]
 name = "capellambse"
 description = "Provides access to Capella MBSE projects in Python"
 readme = "README.md"
-requires-python = ">=3.10, <3.15"
+requires-python = ">=3.11, <3.15"
 license = "Apache-2.0 AND OFL-1.1"
 license-files = ["LICENSES/*.txt"]
 authors = [{ name = "DB InfraGO AG" }]
@@ -27,7 +27,6 @@ classifiers = [
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
@@ -160,7 +159,6 @@ typecheck = [
   "platformdirs==4.5.1",
   "requests-mock==1.12.1",
   "sphinx==8.1.3",
-  "tomli>=2.2.1 ; python_full_version < '3.11'",
   "types-colorama==0.4.15.20250801",
   "types-docutils==0.22.3.20251115",
   "types-lxml==2026.1.1",
@@ -180,7 +178,6 @@ docs = [
   "sphinx==8.1.3",
   "sphinx-autodoc-typehints==3.0.1",
   "sphinx-click==6.2.0",
-  "tomli==2.2.1 ; python_full_version < '3.11'",
 ]
 
 [tool.cibuildwheel]
@@ -218,7 +215,7 @@ exclude_also = [
 skip_covered = true
 
 [tool.distutils.bdist_wheel]
-py_limited_api = "cp310"
+py_limited_api = "cp311"
 
 [tool.docformatter]
 wrap-descriptions = 72
@@ -234,7 +231,7 @@ warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_ignores = true
 plugins = ["mypypp.deprecated"]
-python_version = "3.10"
+python_version = "3.11"
 
 [[tool.mypy.overrides]]
 # Untyped third party libraries

--- a/scripts/ecore2py.py
+++ b/scripts/ecore2py.py
@@ -10,7 +10,6 @@ import enum
 import logging
 import operator
 import re
-import sys
 import textwrap
 import typing as t
 
@@ -19,11 +18,6 @@ from lxml import etree
 
 from capellambse import model
 from capellambse.helpers import qtype_of
-
-if sys.version_info >= (3, 11):
-    from typing import assert_never
-else:
-    from typing_extensions import assert_never
 
 LOGGER = logging.getLogger(__name__)
 
@@ -283,7 +277,7 @@ def write_relationship(
         case RelationshipType.Association:
             f.write(f"{clsname}, {member.xmlname!r}")
         case _:
-            assert_never(f"Unhandled relationship type: {member.type.name}")
+            t.assert_never(f"Unhandled relationship type: {member.type.name}")
 
     if member.single:
         f.write(")")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -15,17 +15,13 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import tomllib
 import typing as t
 
 import awesomeversion
 import click
 
 from capellambse import helpers
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
 
 CONCOM = re.compile(
     r"^(?P<type>\w+)(?:\((?P<scope>[A-Za-z0-9_-]+)\))?(?P<breaking>\!)?: (?P<subject>.*)$"

--- a/src/capellambse/__init__.py
+++ b/src/capellambse/__init__.py
@@ -48,7 +48,7 @@ def load_model_extensions() -> None:
         try:
             initfunc = entrypoint.load()
             initfunc()
-        except Exception:  # noqa: PERF203
+        except Exception:
             logging.getLogger(__name__).exception(
                 "Cannot load model extension %r from %r",
                 entrypoint.name,

--- a/src/capellambse/aird/__init__.py
+++ b/src/capellambse/aird/__init__.py
@@ -121,7 +121,7 @@ def parse_diagrams(
     for descriptor in enumerate_descriptors(model):
         try:
             d = parse_diagram(model, descriptor, **params)
-        except Exception as err:  # noqa: BLE001, PERF203
+        except Exception as err:  # noqa: BLE001
             C.LOGGER.warning(
                 "Ignoring invalid diagram %r: %s", descriptor, err
             )

--- a/src/capellambse/aird/_filters/__init__.py
+++ b/src/capellambse/aird/_filters/__init__.py
@@ -359,7 +359,7 @@ class ActiveFilters(t.MutableSet[str]):
 for module in ("composite", "global"):
     try:
         importlib.import_module(f"{__name__}.{module}")
-    except Exception as _err:  # noqa: BLE001, PERF203
+    except Exception as _err:  # noqa: BLE001
         c.LOGGER.error(
             "Cannot load filters from %s: %s: %s",
             module,

--- a/src/capellambse/extensions/reqif/exporter.py
+++ b/src/capellambse/extensions/reqif/exporter.py
@@ -105,7 +105,7 @@ def _build_header(
     title = metadata.get("title", module.long_name)
     creation_time = (
         metadata.get("creation_time", datetime.datetime.now())
-        .astimezone(datetime.timezone.utc)
+        .astimezone(datetime.UTC)
         .strftime(REQIF_UTC_DATEFORMAT)
     )
     header = etree.Element("REQ-IF-HEADER")
@@ -466,7 +466,7 @@ def _build_attribute_value_simple(attr: rq.Attribute) -> etree._Element:
         if value is None:
             obj.set("THE-VALUE", "1990-01-01T00:00:00Z")
         elif isinstance(value, datetime.datetime):
-            utcval = value.astimezone(datetime.timezone.utc)
+            utcval = value.astimezone(datetime.UTC)
             obj.set("THE-VALUE", utcval.strftime(REQIF_UTC_DATEFORMAT))
         else:
             raise TypeError(f"Expected datetime, got {type(value).__name__}")

--- a/src/capellambse/filehandler/abc.py
+++ b/src/capellambse/filehandler/abc.py
@@ -16,20 +16,14 @@ import abc
 import collections.abc as cabc
 import dataclasses
 import fnmatch
+import importlib.resources.abc as ira
 import os
 import pathlib
-import sys
 import typing as t
 
 import typing_extensions as te
 
 from capellambse import helpers
-
-if sys.version_info >= (3, 11):
-    import importlib.resources.abc as ira
-else:
-    import importlib.abc as ira
-
 
 _F = t.TypeVar("_F", bound="FileHandler")
 
@@ -282,7 +276,8 @@ class FilePath(os.PathLike[str], ira.Traversable, t.Generic[_F]):
     def __fspath__(self) -> str:
         return str(self._path)
 
-    def joinpath(self, path: str | pathlib.PurePosixPath) -> te.Self:
+    def joinpath(self, *descendants: str | pathlib.PurePosixPath) -> te.Self:
+        path = pathlib.PurePosixPath(*descendants)
         newpath = helpers.normalize_pure_path(path, base=self._path)
         return type(self)(self._parent, newpath)
 

--- a/src/capellambse/helpers.py
+++ b/src/capellambse/helpers.py
@@ -268,7 +268,7 @@ if sys.platform.startswith("win"):
             while True:
                 try:
                     msvcrt.locking(lock.fileno(), msvcrt.LK_LOCK, 1)
-                except OSError as err:  # noqa: PERF203
+                except OSError as err:
                     if err.errno == errno.EDEADLOCK:
                         if not logged:
                             LOGGER.debug("Waiting for lock file %s", file)

--- a/src/capellambse/loader/core.py
+++ b/src/capellambse/loader/core.py
@@ -1288,7 +1288,7 @@ class MelodyLoader:
         for part in helpers.split_links(links):
             try:
                 targets.append(self.follow_link(from_element, part))
-            except (KeyError, ValueError):  # noqa: PERF203
+            except (KeyError, ValueError):
                 if not ignore_broken:
                     raise
         return targets

--- a/src/capellambse/model/_descriptors.py
+++ b/src/capellambse/model/_descriptors.py
@@ -2333,7 +2333,7 @@ class AttributeMatcherAccessor(DirectProxyAccessor[T_co]):
                     getattr(elm, k) == v for k, v in self.attributes.items()
                 ):
                     matches.append(elm._element)
-            except AttributeError:  # noqa: PERF203
+            except AttributeError:
                 pass
 
         if self.__aslist is None:

--- a/src/capellambse/model/diagram.py
+++ b/src/capellambse/model/diagram.py
@@ -347,7 +347,7 @@ class AbstractDiagram(metaclass=abc.ABCMeta):
             try:
                 chain = list(_walk_converters(conv))
                 bundle[mime] = _run_converter_chain(chain, render)
-            except Exception:  # noqa: PERF203
+            except Exception:
                 LOGGER.exception("Failed converting diagram with %r", conv)
         if not bundle:
             LOGGER.error("Failed converting diagram for MIME bundle")
@@ -1063,7 +1063,7 @@ def _iter_format_converters() -> t.Iterator[tuple[str, DiagramConverter]]:
     for ep in imm.entry_points(group="capellambse.diagram.formats"):
         try:
             conv = ep.load()
-        except ImportError:  # noqa: PERF203
+        except ImportError:
             pass
         else:
             yield (ep.name, conv)

--- a/tests/test_reqif.py
+++ b/tests/test_reqif.py
@@ -584,7 +584,7 @@ class TestReqIFModification:
             ),
             pytest.param(
                 "Date",
-                datetime.datetime(1987, 7, 27, tzinfo=datetime.timezone.utc),
+                datetime.datetime(1987, 7, 27, tzinfo=datetime.UTC),
                 "1987-07-27T00:00:00.000+0000",
             ),
             pytest.param("Bool", False, None),
@@ -704,9 +704,7 @@ class TestReqIFModification:
             pytest.param(False, id="Boolean Attribute"),
             pytest.param(1, id="Integer Attribute"),
             pytest.param(
-                datetime.datetime(
-                    2021, 7, 23, 13, 0, 0, tzinfo=datetime.timezone.utc
-                ),
+                datetime.datetime(2021, 7, 23, 13, 0, 0, tzinfo=datetime.UTC),
                 id="DateValue Attribute",
             ),
             pytest.param(1.9, id="Float/Real Attribute"),


### PR DESCRIPTION
This is mainly done for the sake of uv, which requires that all dependencies (even development-only ones) have to be resolvable for all allowed Python versions, even if those Python versions are not actually used. After capellambse-context-diagrams has dropped 3.10 support a while ago already, keeping support in capellambse doesn't make much sense anymore either.